### PR TITLE
Support for wrapping EC keys + RSA wrapping fixes/comments/questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@ This is an experimental pkcs11 token written in rust
 
 First after cloning, we need to pull and update openssl submodule:
 
-$ git submodule init
-$ git submodule update
+    $ git submodule init
+    $ git submodule update
 
 Build the rust project:
 
-$ cargo build
+    $ cargo build
 
 For FIPS module, you need to generate hmac checksum:
 
-$ ./hmacify.sh target/release/libkryoptic_pkcs11.so
+    $ ./hmacify.sh target/release/libkryoptic_pkcs11.so
 
 # Tests
 
 To run test, run the check command:
 
-$ cargo test
+    $ cargo test

--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -23,10 +23,10 @@ pub const MIN_EC_SIZE_BITS: usize = 256;
 pub const MAX_EC_SIZE_BITS: usize = 521;
 
 // ASN.1 encoding of the OID
-const OID_SECP256R1: &[u8] =
-    &[0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07];
-const OID_SECP384R1: &[u8] = &[0x06, 0x05, 0x2B, 0x81, 0x04, 0x00, 0x22];
-const OID_SECP521R1: &[u8] = &[0x06, 0x05, 0x2B, 0x81, 0x04, 0x00, 0x23];
+const OID_SECP256R1: asn1::ObjectIdentifier =
+    asn1::oid!(1, 2, 840, 10045, 3, 1, 7);
+const OID_SECP384R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 34);
+const OID_SECP521R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 35);
 
 // ASN.1 encoding of the curve name
 const STRING_SECP256R1: &[u8] = &[
@@ -48,11 +48,7 @@ const BITS_SECP384R1: usize = 384;
 const BITS_SECP521R1: usize = 521;
 
 fn oid_to_curve_name(oid: asn1::ObjectIdentifier) -> KResult<&'static str> {
-    let asn1_oid = match asn1::write_single(&oid) {
-        Ok(r) => r,
-        Err(_) => return err_rv!(CKR_GENERAL_ERROR),
-    };
-    match asn1_oid.as_slice() {
+    match oid {
         OID_SECP256R1 => Ok(NAME_SECP256R1),
         OID_SECP384R1 => Ok(NAME_SECP384R1),
         OID_SECP521R1 => Ok(NAME_SECP521R1),
@@ -61,11 +57,7 @@ fn oid_to_curve_name(oid: asn1::ObjectIdentifier) -> KResult<&'static str> {
 }
 
 fn oid_to_bits(oid: asn1::ObjectIdentifier) -> KResult<usize> {
-    let asn1_oid = match asn1::write_single(&oid) {
-        Ok(r) => r,
-        Err(_) => return err_rv!(CKR_GENERAL_ERROR),
-    };
-    match asn1_oid.as_slice() {
+    match oid {
         OID_SECP256R1 => Ok(BITS_SECP256R1),
         OID_SECP384R1 => Ok(BITS_SECP384R1),
         OID_SECP521R1 => Ok(BITS_SECP521R1),
@@ -93,16 +85,12 @@ fn curve_name_to_oid(
         Ok(r) => r,
         Err(_) => return err_rv!(CKR_GENERAL_ERROR),
     };
-    let asn1_oid = match asn1_name.as_slice() {
+    Ok(match asn1_name.as_slice() {
         STRING_SECP256R1 => OID_SECP256R1,
         STRING_SECP384R1 => OID_SECP384R1,
         STRING_SECP521R1 => OID_SECP521R1,
         _ => return err_rv!(CKR_GENERAL_ERROR),
-    };
-    match asn1::parse_single::<asn1::ObjectIdentifier>(asn1_oid) {
-        Ok(r) => Ok(r),
-        Err(_) => err_rv!(CKR_GENERAL_ERROR),
-    }
+    })
 }
 
 #[derive(Debug)]

--- a/src/kasn1.rs
+++ b/src/kasn1.rs
@@ -40,6 +40,18 @@ impl<'a> DerEncBigUint<'a> {
     pub fn as_bytes(&self) -> &[u8] {
         &self.data
     }
+
+    /// Get the BN bytes without possible leading NULL bytes.
+    pub fn as_nopad_bytes(&self) -> &[u8] {
+        let mut skip = 0;
+        for val in self.data.as_ref() {
+            if *val != 0 {
+                break;
+            }
+            skip += 1;
+        }
+        &self.data[skip..]
+    }
 }
 
 impl Drop for DerEncBigUint<'_> {

--- a/src/kasn1.rs
+++ b/src/kasn1.rs
@@ -63,7 +63,7 @@ impl<'a> asn1::SimpleAsn1Readable<'a> for DerEncBigUint<'a> {
     }
 }
 impl<'a> asn1::SimpleAsn1Writable for DerEncBigUint<'a> {
-    const TAG: asn1::Tag = asn1::Tag::primitive(0x02);
+    const TAG: asn1::Tag = asn1::BigUint::TAG;
     fn write_data(&self, dest: &mut asn1::WriteBuf) -> asn1::WriteResult {
         dest.push_slice(self.as_bytes())
     }

--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -240,35 +240,35 @@ impl PrivKeyFactory for RSAPrivFactory {
         };
         attrs.push(CK_ATTRIBUTE::from_slice(
             CKA_MODULUS,
-            rsapkey.modulus.as_bytes(),
+            rsapkey.modulus.as_nopad_bytes(),
         ));
         attrs.push(CK_ATTRIBUTE::from_slice(
             CKA_PUBLIC_EXPONENT,
-            rsapkey.public_exponent.as_bytes(),
+            rsapkey.public_exponent.as_nopad_bytes(),
         ));
         attrs.push(CK_ATTRIBUTE::from_slice(
             CKA_PRIVATE_EXPONENT,
-            rsapkey.private_exponent.as_bytes(),
+            rsapkey.private_exponent.as_nopad_bytes(),
         ));
         attrs.push(CK_ATTRIBUTE::from_slice(
             CKA_PRIME_1,
-            rsapkey.prime1.as_bytes(),
+            rsapkey.prime1.as_nopad_bytes(),
         ));
         attrs.push(CK_ATTRIBUTE::from_slice(
             CKA_PRIME_2,
-            rsapkey.prime2.as_bytes(),
+            rsapkey.prime2.as_nopad_bytes(),
         ));
         attrs.push(CK_ATTRIBUTE::from_slice(
             CKA_EXPONENT_1,
-            rsapkey.exponent1.as_bytes(),
+            rsapkey.exponent1.as_nopad_bytes(),
         ));
         attrs.push(CK_ATTRIBUTE::from_slice(
             CKA_EXPONENT_2,
-            rsapkey.exponent2.as_bytes(),
+            rsapkey.exponent2.as_nopad_bytes(),
         ));
         attrs.push(CK_ATTRIBUTE::from_slice(
             CKA_COEFFICIENT,
-            rsapkey.coefficient.as_bytes(),
+            rsapkey.coefficient.as_nopad_bytes(),
         ));
 
         if match attrs.iter().position(|x| x.type_ == CKA_CLASS) {


### PR DESCRIPTION
Fixes also unwrapping for RSA keys, but we might need better solution.

I think the `DerEncBigUint` ensures the BN is unsigned and starts with zero byte, which is something we do not want when we import the BN as a modulus as you are using the modulus size to enforce the buffer size. Without stripping the null byte from the modulus, the operation requires 257 B buffer for signature and verification of this signature does not work.

The RSA wrapping is also using the `RSAPrivateKey` ASN1 directly, but from my reading of the PKCS#11 specification, we should use `PrivateKeyInfo`. This not obvious for RSA keys as everything needed is in the inner object, but EC keys needs the `privateKeyAlgorithm` field to learn what curve is used, if I read it right. 

Keeping it as a draft as there is more quesitons to resolve before merging.