### PR TITLE
Share the PrivateKeyInfo structure among RSA and ECC implementation

### DIFF
--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -288,7 +288,14 @@ impl PrivKeyFactory for ECCPrivFactory {
             Ok(k) => k,
             Err(_) => return err_rv!(CKR_WRAPPED_KEY_INVALID),
         };
-        let oid_encoded = match asn1::write_single(&pkeyinfo.get_oid()) {
+        /* filter out unknown OIDs */
+        let oid = match pkeyinfo.get_oid() {
+            &OID_SECP521R1 => OID_SECP256R1,
+            &OID_SECP384R1 => OID_SECP384R1,
+            &OID_SECP256R1 => OID_SECP521R1,
+            _ => return err_rv!(CKR_WRAPPED_KEY_INVALID),
+        };
+        let oid_encoded = match asn1::write_single(&oid) {
             Ok(b) => b,
             Err(_) => return err_rv!(CKR_WRAPPED_KEY_INVALID),
         };

--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -246,6 +246,9 @@ impl PrivKeyFactory for RSAPrivFactory {
             Ok(k) => k,
             Err(_) => return err_rv!(CKR_WRAPPED_KEY_INVALID),
         };
+        if pkeyinfo.get_oid() != &OID_RSA_ENCRYPTION {
+            return err_rv!(CKR_WRAPPED_KEY_INVALID);
+        }
         let rsapkey = match asn1::parse_single::<RSAPrivateKey>(
             pkeyinfo.get_private_key(),
         ) {


### PR DESCRIPTION
~Using the `defined-by` magic.~

Using opaque OCTET STRING

Fixes #10.