### PR TITLE
Various fixes for RSA PSS and ECC

### DIFF
--- a/src/kasn1.rs
+++ b/src/kasn1.rs
@@ -29,6 +29,18 @@ impl<'a> DerEncBigUint<'a> {
             de = DerEncBigUint {
                 data: Cow::Owned(v),
             };
+        } else {
+            // Skip possible leading zeroes that do not affect sign of the resulting integer
+            let mut skip = 0;
+            while de.data[skip] == 0
+                && skip + 1 < de.data.len()
+                && de.data[skip + 1] & 0x80 == 0
+            {
+                skip += 1;
+            }
+            de = DerEncBigUint {
+                data: Cow::from(&data[skip..]),
+            };
         }
         /* check it works */
         match asn1::BigUint::new(&de.data) {

--- a/src/ossl/ecc.rs
+++ b/src/ossl/ecc.rs
@@ -409,9 +409,6 @@ impl Sign for EccOperation {
             if res != 1 {
                 return err_rv!(CKR_DEVICE_ERROR);
             }
-            if signature.len() + 8 != siglen {
-                return err_rv!(CKR_DEVICE_ERROR);
-            }
 
             let mut ossl_sign: Vec<u8> = Vec::with_capacity(siglen);
             ossl_sign.resize(siglen, 0);

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -14,7 +14,7 @@ use error::{KError, KResult};
 use interface::*;
 
 static SLOT_DESCRIPTION: [CK_UTF8CHAR; 64usize] =
-    *b"Kryoptic SLot                                                   ";
+    *b"Kryoptic Slot                                                   ";
 static MANUFACTURER_ID: [CK_UTF8CHAR; 32usize] =
     *b"Kryoptic                        ";
 

--- a/testdata/test_ecc_operations.json
+++ b/testdata/test_ecc_operations.json
@@ -48,4 +48,36 @@
         "CKA_TOKEN": true,
         "CKA_SIGN": true
     }
+}, {
+    "attributes": {
+        "CKA_UNIQUE_ID": "6",
+        "CKA_CLASS": 2,
+        "CKA_KEY_TYPE": 3,
+        "CKA_DESTROYABLE": false,
+        "CKA_ID": "Aw==",
+        "CKA_LABEL": "P-521 (Public key)",
+        "CKA_MODIFIABLE": false,
+        "CKA_EC_PARAMS": "BgUrgQQAIw==",
+        "CKA_EC_POINT": "BIGFBABhOH/WuVkU6IX5Eu37tfsnRlUCfyFsQJHKg+GTNnQP2Brt/gR/UbQr32gWESEBPg1VsRehTkMD+SbI3rt3p/2q0QDn0MdcOGJuiVyiFSa5+f34Tc7Lk/KyMzkFUNKxRjt+4/WN9zRkNf8ENBmVg8l8ZlqX8S9wbyNX2ktAKI3viI5Z5g==",
+        "CKA_PRIVATE": false,
+        "CKA_TOKEN": true,
+        "CKA_VERIFY": true
+    }
+}, {
+    "attributes": {
+        "CKA_UNIQUE_ID": "7",
+        "CKA_CLASS": 3,
+        "CKA_KEY_TYPE": 3,
+        "CKA_DESTROYABLE": false,
+        "CKA_ID": "Aw==",
+        "CKA_LABEL": "P-521 (Private key)",
+        "CKA_MODIFIABLE": false,
+        "CKA_PRIVATE": true,
+        "CKA_SENSITIVE": true,
+        "CKA_EXTRACTABLE": false,
+        "CKA_EC_PARAMS": "BgUrgQQAIw==",
+        "CKA_VALUE": "90nTJwS8UzyoLO8KzxA9j0+6Z/CNJnjlFe19uIYmf/rwL6sAgNyiNZty9XTMwpoPIYyGVcDMz5/ubF5WeqFMuSY=",
+        "CKA_TOKEN": true,
+        "CKA_SIGN": true
+    }
 }]}

--- a/testdata/test_sign_verify.json
+++ b/testdata/test_sign_verify.json
@@ -160,4 +160,49 @@
         "CKA_TOKEN": true,
         "CKA_VALUE": "U2FtcGxlIG1lc3NhZ2UgZm9yIGtleWxlbjxibG9ja2xlbg=="
     }
+}, {
+    "attributes": {
+        "CKA_UNIQUE_ID": "12",
+        "CKA_CLASS": 2,
+        "CKA_KEY_TYPE": 3,
+        "CKA_DESTROYABLE": false,
+        "CKA_ID": "RklQU18xODYtMy9TaWdHZW46IFtQLTUyMSxTSEEtNTEyXQ==",
+        "CKA_LABEL": "FIPS_186-3/SigGen: [P-521,SHA-512] (Public key)",
+        "CKA_MODIFIABLE": false,
+        "CKA_EC_PARAMS": "BgUrgQQAIw==",
+        "CKA_EC_POINT": "BIGFBABhOH/WuVkU6IX5Eu37tfsnRlUCfyFsQJHKg+GTNnQP2Brt/gR/UbQr32gWESEBPg1VsRehTkMD+SbI3rt3p/2q0QDn0MdcOGJuiVyiFSa5+f34Tc7Lk/KyMzkFUNKxRjt+4/WN9zRkNf8ENBmVg8l8ZlqX8S9wbyNX2ktAKI3viI5Z5g==",
+        "CKA_PRIVATE": false,
+        "CKA_TOKEN": true,
+        "CKA_VERIFY": true
+    }
+}, {
+    "attributes": {
+        "CKA_UNIQUE_ID": "13",
+        "CKA_CLASS": 3,
+        "CKA_KEY_TYPE": 3,
+        "CKA_DESTROYABLE": false,
+        "CKA_ID": "RklQU18xODYtMy9TaWdHZW46IFtQLTUyMSxTSEEtNTEyXQ==",
+        "CKA_LABEL": "FIPS_186-3/SigGen: [P-521,SHA-512] (Private key)",
+        "CKA_MODIFIABLE": false,
+        "CKA_PRIVATE": true,
+        "CKA_SENSITIVE": true,
+        "CKA_EXTRACTABLE": false,
+        "CKA_EC_PARAMS": "BgUrgQQAIw==",
+        "CKA_VALUE": "90nTJwS8UzyoLO8KzxA9j0+6Z/CNJnjlFe19uIYmf/rwL6sAgNyiNZty9XTMwpoPIYyGVcDMz5/ubF5WeqFMuSY=",
+        "CKA_TOKEN": true,
+        "CKA_SIGN": true
+    }
+}, {
+    "attributes": {
+        "CKA_UNIQUE_ID": "14",
+        "CKA_APPLICATION": "CKM_ECDSA_SHA512",
+        "CKA_CLASS": 0,
+        "CKA_DESTROYABLE": false,
+        "CKA_LABEL": "FIPS_186-3/SigGen: [P-521,SHA-512]",
+        "CKA_MODIFIABLE": false,
+        "CKA_OBJECT_ID": "AE3oJupwStELwPdTivijhD8oT1XIuUavkjWvWvdPK3bgmeS8cv150oo4D41LTJGawpDSSMN5g7oFrqQuLdef3TPoAIdIjIWalv6iZuoTv20RTEKbFjvpeldVkIbttkrtShhZS0b7nvx/0l2LLejwnKBYf1S9KHKZ9Hsv8SSqxWbo7jtD",
+        "CKA_PRIVATE": false,
+        "CKA_TOKEN": true,
+        "CKA_VALUE": "ns1QDGDnAUBJIuWKsgzAAmUf3ufLyTNq3aM+TBCI+rGWTst5BNxoVoZdbI4VBBzPLVrDAumdNG/y9oZTHSVSFnjU/T92u/LIk9JGy012k3kv4YFyEIFGhTEDpR+CSsxiHLcxHSRjwzYepwclTysFK8IsuAEoc9y7lb8aXMU6uJ8="
+    }
 }]}


### PR DESCRIPTION
This covers various corner cases of RSA PSS mechanisms and ECC keys found during running the p11test against the kryoptic (CI integration in progress).