### PR TITLE
Fix AES `C_Encrypt` with NULL result to query result size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -855,7 +855,7 @@ extern "C" fn fn_encrypt(
         return CKR_OPERATION_NOT_INITIALIZED;
     }
     if encrypted_data.is_null() {
-        let encryption_len = res_or_ret!(operation.encryption_len());
+        let encryption_len = res_or_ret!(operation.encryption_len(data_len));
         unsafe {
             *pul_encrypted_data_len = encryption_len as CK_ULONG;
         }
@@ -885,7 +885,7 @@ extern "C" fn fn_encrypt_update(
         return CKR_OPERATION_NOT_INITIALIZED;
     }
     if encrypted_part.is_null() {
-        let encryption_len = res_or_ret!(operation.encryption_len());
+        let encryption_len = res_or_ret!(operation.encryption_len(part_len));
         unsafe {
             *pul_encrypted_part_len = encryption_len as CK_ULONG;
         }
@@ -917,7 +917,7 @@ extern "C" fn fn_encrypt_final(
         return CKR_OPERATION_NOT_INITIALIZED;
     }
     if last_encrypted_part.is_null() {
-        let encryption_len = res_or_ret!(operation.encryption_len());
+        let encryption_len = res_or_ret!(operation.encryption_len(0));
         unsafe {
             *pul_last_encrypted_part_len = encryption_len as CK_ULONG;
         }

--- a/src/mechanism.rs
+++ b/src/mechanism.rs
@@ -164,7 +164,7 @@ pub trait Encryption: MechOperation {
     ) -> KResult<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn encryption_len(&self) -> KResult<usize> {
+    fn encryption_len(&self, _data_len: CK_ULONG) -> KResult<usize> {
         err_rv!(CKR_GENERAL_ERROR)
     }
 }

--- a/src/ossl/rsa.rs
+++ b/src/ossl/rsa.rs
@@ -888,7 +888,7 @@ impl Encryption for RsaPKCSOperation {
         return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
     }
 
-    fn encryption_len(&self) -> KResult<usize> {
+    fn encryption_len(&self, _data_len: CK_ULONG) -> KResult<usize> {
         match self.mech {
             CKM_RSA_PKCS | CKM_RSA_PKCS_OAEP => Ok(self.output_len),
             _ => err_rv!(CKR_GENERAL_ERROR),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1409,8 +1409,18 @@ fn test_aes_operations() {
 
         /* Data need to be exactly one block in size */
         let data = "0123456789ABCDEF";
+        let mut enc_len: CK_ULONG = 0;
+        ret = fn_encrypt(
+            session,
+            CString::new(data).unwrap().into_raw() as *mut u8,
+            data.len() as CK_ULONG,
+            std::ptr::null_mut(),
+            &mut enc_len,
+        );
+        assert_eq!(ret, CKR_OK);
+        assert_eq!(enc_len, 16);
+
         let enc: [u8; 16] = [0; 16];
-        let mut enc_len: CK_ULONG = 16;
         ret = fn_encrypt(
             session,
             CString::new(data).unwrap().into_raw() as *mut u8,


### PR DESCRIPTION
The `aes` module did not implement the `encryption_len()` which caused every operation with NULL result querying for the result size to fail.

There are some attempts to implement this inside of the encrypt() function, which became pointless and could be deleted (all within `if cipher.is_null` block:

https://github.com/latchset/kryoptic/blob/1c13e98edc766584281ac3dff7664b40a0afda35/src/ossl/aes.rs#L841-L851

But these are now used by wrapping, which does not have this handling separately and which I properly did not review yet so feel free to wait before merging this to figure out wrapping.