### PR TITLE
Support configuration through environment variable

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,6 +3,7 @@
 
 use super::*;
 use hex;
+use std::env;
 use std::ffi::CString;
 use std::sync::Once;
 
@@ -106,8 +107,12 @@ impl TestData<'_> {
         self.slot
     }
 
+    fn make_init_string(&self) -> String {
+        format!("{}:{}", self.filename, self.slot)
+    }
+
     fn make_init_args(&self) -> CK_C_INITIALIZE_ARGS {
-        let reserved: String = format!("{}:{}", self.filename, self.slot);
+        let reserved: String = self.make_init_string();
 
         CK_C_INITIALIZE_ARGS {
             CreateMutex: None,
@@ -117,6 +122,17 @@ impl TestData<'_> {
             flags: 0,
             pReserved: CString::new(reserved).unwrap().into_raw()
                 as *mut std::ffi::c_void,
+        }
+    }
+
+    fn make_empty_init_args(&self) -> CK_C_INITIALIZE_ARGS {
+        CK_C_INITIALIZE_ARGS {
+            CreateMutex: None,
+            DestroyMutex: None,
+            LockMutex: None,
+            UnlockMutex: None,
+            flags: 0,
+            pReserved: std::ptr::null_mut(),
         }
     }
 
@@ -162,14 +178,66 @@ fn test_token(name: &str) {
     testdata.finalize();
 }
 
+fn test_token_env(name: &str) {
+    let mut testdata = TestData::new(name);
+    testdata.setup_db(None);
+
+    let mut plist: *mut CK_FUNCTION_LIST = std::ptr::null_mut();
+    let pplist = &mut plist;
+    let result = C_GetFunctionList(&mut *pplist);
+    assert_eq!(result, 0);
+    unsafe {
+        let list: CK_FUNCTION_LIST = *plist;
+        match list.C_Initialize {
+            Some(init_fn) => {
+                let mut args = testdata.make_empty_init_args();
+                let args_ptr = &mut args as *mut CK_C_INITIALIZE_ARGS;
+                env::set_var("KRYOPTIC_CONF", testdata.make_init_string());
+                let ret = init_fn(args_ptr as *mut std::ffi::c_void);
+                assert_eq!(ret, CKR_OK)
+            }
+            None => todo!(),
+        }
+    }
+
+    testdata.finalize();
+}
+
+fn test_token_null_args(name: &str) {
+    let mut testdata = TestData::new(name);
+    testdata.setup_db(None);
+
+    let mut plist: *mut CK_FUNCTION_LIST = std::ptr::null_mut();
+    let pplist = &mut plist;
+    let result = C_GetFunctionList(&mut *pplist);
+    assert_eq!(result, 0);
+    unsafe {
+        let list: CK_FUNCTION_LIST = *plist;
+        match list.C_Initialize {
+            Some(init_fn) => {
+                env::set_var("KRYOPTIC_CONF", testdata.make_init_string());
+                let ret = init_fn(std::ptr::null_mut());
+                assert_eq!(ret, CKR_OK)
+            }
+            None => todo!(),
+        }
+    }
+
+    testdata.finalize();
+}
+
 #[test]
 fn test_token_json() {
     test_token("test_token.json");
+    test_token_env("test_token.json");
+    test_token_null_args("test_token.json");
 }
 
 #[test]
 fn test_token_sql() {
     test_token("test_token.sql");
+    test_token_env("test_token.sql");
+    test_token_null_args("test_token.sql");
 }
 
 #[test]


### PR DESCRIPTION
This is rough PoC of allowing the kryoptic to work without the pReserved pointer and without the init args altogether (as they are not mandatory). The code can probably be simplified, but this worked for me and allowed me to run the general pkcs11 applications against kryoptic without issues.