### PR TITLE
Fixes various corner cases of AES and RSA operations

### DIFF
--- a/src/ossl/aes.rs
+++ b/src/ossl/aes.rs
@@ -1145,8 +1145,13 @@ impl Encryption for AesOperation {
             CKM_AES_CCM => self.params.datalen + self.params.taglen,
             CKM_AES_GCM => data_len as usize + self.params.taglen,
             CKM_AES_CTR | CKM_AES_CTS => data_len as usize,
-            CKM_AES_CBC | CKM_AES_CBC_PAD | CKM_AES_ECB => {
+            CKM_AES_CBC | CKM_AES_ECB => {
                 ((data_len as usize + AES_BLOCK_SIZE - 1) / AES_BLOCK_SIZE)
+                    * AES_BLOCK_SIZE
+            }
+            CKM_AES_CBC_PAD => {
+                // The PKCS#7 padding adds always at least 1 byte
+                ((data_len as usize + AES_BLOCK_SIZE) / AES_BLOCK_SIZE)
                     * AES_BLOCK_SIZE
             }
             #[cfg(not(feature = "fips"))]

--- a/src/ossl/common.rs
+++ b/src/ossl/common.rs
@@ -5,6 +5,8 @@ use super::object;
 
 use interface::*;
 
+use std::os::raw::c_uint;
+
 macro_rules! ptr_wrapper {
     ($name:ident; $ossl:ident; $free:expr) => {
         #[derive(Debug)]
@@ -256,6 +258,24 @@ impl OsslParam {
         let container = val.to_ne_bytes().to_vec();
         let param = unsafe {
             OSSL_PARAM_construct_size_t(key, container.as_ptr() as *mut usize)
+        };
+        self.v.push(container);
+        self.p.push(param);
+        Ok(self)
+    }
+
+    pub fn add_uint(
+        mut self,
+        key: *const c_char,
+        val: c_uint,
+    ) -> KResult<OsslParam> {
+        if self.finalized {
+            return err_rv!(CKR_GENERAL_ERROR);
+        }
+
+        let container = val.to_ne_bytes().to_vec();
+        let param = unsafe {
+            OSSL_PARAM_construct_uint(key, container.as_ptr() as *mut c_uint)
         };
         self.v.push(container);
         self.p.push(param);

--- a/src/ossl/common.rs
+++ b/src/ossl/common.rs
@@ -254,10 +254,11 @@ impl OsslParam {
         }
 
         let container = val.to_ne_bytes().to_vec();
-        unsafe {
-            OSSL_PARAM_construct_size_t(key, container.as_ptr() as *mut usize);
-        }
+        let param = unsafe {
+            OSSL_PARAM_construct_size_t(key, container.as_ptr() as *mut usize)
+        };
         self.v.push(container);
+        self.p.push(param);
         Ok(self)
     }
 

--- a/src/ossl/rsa.rs
+++ b/src/ossl/rsa.rs
@@ -21,6 +21,7 @@ use ossl::*;
 use std::mem::size_of;
 use std::os::raw::c_char;
 use std::os::raw::c_int;
+use std::os::raw::c_uint;
 use zeroize::Zeroize;
 
 #[cfg(not(feature = "fips"))]
@@ -552,7 +553,7 @@ impl RsaPKCSOperation {
         }
         let params = OsslParam::with_capacity(3)
             .add_bn(name_as_char(OSSL_PKEY_PARAM_RSA_E), &exponent)?
-            .add_size_t(name_as_char(OSSL_PKEY_PARAM_BITS), bits)?
+            .add_uint(name_as_char(OSSL_PKEY_PARAM_RSA_BITS), bits as c_uint)?
             .finalize();
         let res = unsafe {
             EVP_PKEY_CTX_set_params(ctx.as_mut_ptr(), params.as_ptr())

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1564,10 +1564,21 @@ fn test_aes_operations() {
         ret = fn_encrypt_init(session, &mut mechanism, handle);
         assert_eq!(ret, CKR_OK);
 
-        /* Data of exactly one block in size will cause two blocks output */
+        /* Data of exactly one block in size will cause two block output
+         * The PKCS#11 specs are wrong here! */
         let data = "0123456789ABCDEF";
+        let mut enc_len: CK_ULONG = 0;
+        ret = fn_encrypt(
+            session,
+            CString::new(data).unwrap().into_raw() as *mut u8,
+            data.len() as CK_ULONG,
+            std::ptr::null_mut(),
+            &mut enc_len,
+        );
+        assert_eq!(ret, CKR_OK);
+        assert_eq!(enc_len, 32);
+
         let enc: [u8; 32] = [0; 32];
-        let mut enc_len: CK_ULONG = 32;
         ret = fn_encrypt(
             session,
             CString::new(data).unwrap().into_raw() as *mut u8,


### PR DESCRIPTION
* The OsslParams construction was ignoring some values, which caused all RSA keys generated were always default 2k
* The CCM wrapping output length was dependent on the DataLen parameter, which is not really available for the caller at the time of calculation so changing to the length of provided data allows the caller to set the parameter to reasonable value for final operation to actually work
* Fix the expected lenght calculation for `AES_CBC_PAD` mechanism.

With these changes, the current set of tests in OpenSSL `p11test` works.