### PR TITLE
Add PBKDF2 support

### DIFF
--- a/.github/codespell.sh
+++ b/.github/codespell.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-CODESPELL="codespell --ignore-words-list=sorce,clen,ot"
+CODESPELL="codespell --ignore-words-list=gost,sorce,clen,ot"
 
 result=0
 echo "Running codespell on source code..."
 $CODESPELL --skip **/bindings.rs src || result=1
 
 # assuming the main branch is there
-for COMMIT in $(git rev-list main.. --); do
+for COMMIT in $(git rev-list origin/main.. --); do
 	echo "Running codespell on commit message of $COMMIT..."
 	git show --format=%B -s "$COMMIT" | $CODESPELL - || result=1
 done

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -216,6 +216,8 @@ impl Mechanism for AesMechanism {
         &self,
         mech: &CK_MECHANISM,
         template: &[CK_ATTRIBUTE],
+        _: &Mechanisms,
+        _: &ObjectFactories,
     ) -> KResult<Object> {
         if mech.mechanism != CKM_AES_KEY_GEN {
             return err_rv!(CKR_MECHANISM_INVALID);

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -133,6 +133,15 @@ pub fn hash_size(hash: CK_MECHANISM_TYPE) -> usize {
     INVALID_HASH_SIZE
 }
 
+pub fn hmac_size(hmac: CK_MECHANISM_TYPE) -> usize {
+    for hs in &HASH_MECH_SET {
+        if hs.mac == hmac || hs.mac_general == hmac {
+            return hs.hash_size;
+        }
+    }
+    INVALID_HASH_SIZE
+}
+
 #[derive(Debug)]
 struct HashMechanism {
     info: CK_MECHANISM_INFO,

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -148,7 +148,7 @@ impl HMACOperation {
     pub fn register_mechanisms(mechs: &mut Mechanisms) {
         for hs in &HASH_MECH_SET {
             /* skip HMACs for which we do not have valid Hashes */
-            let hashop = match HashOperation::new(hs.hash) {
+            let _ = match HashOperation::new(hs.hash) {
                 Ok(op) => op,
                 Err(_) => continue,
             };

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -9,7 +9,7 @@ use super::interface;
 use super::mechanism;
 use super::object;
 
-use attribute::from_bytes;
+use attribute::{from_bool, from_bytes, from_ulong};
 use error::{KError, KResult};
 use hash::{hash_size, INVALID_HASH_SIZE};
 use interface::*;
@@ -40,6 +40,7 @@ macro_rules! bytes_to_slice {
 pub fn register(mechs: &mut Mechanisms, _: &mut ObjectFactories) {
     HKDFOperation::register_mechanisms(mechs);
     Sp800Operation::register_mechanisms(mechs);
+    PBKDF2Mechanism::register_mechanisms(mechs);
 }
 
 #[derive(Debug)]
@@ -668,3 +669,153 @@ include!("ossl/kdf.rs");
 include!("sp800_108.rs");
 
 include!("ossl/hkdf.rs");
+
+#[derive(Debug)]
+struct PBKDF2Mechanism {
+    info: CK_MECHANISM_INFO,
+}
+
+impl PBKDF2Mechanism {
+    fn register_mechanisms(mechs: &mut Mechanisms) {
+        mechs.add_mechanism(
+            CKM_PKCS5_PBKD2,
+            Box::new(PBKDF2Mechanism {
+                info: CK_MECHANISM_INFO {
+                    ulMinKeySize: 0,
+                    ulMaxKeySize: std::u32::MAX as CK_ULONG,
+                    flags: CKF_GENERATE,
+                },
+            }),
+        );
+    }
+
+    fn mock_password_object(&self, key: Vec<u8>) -> KResult<Object> {
+        let mut obj = Object::new();
+        obj.set_zeroize();
+        obj.set_attr(from_ulong(CKA_CLASS, CKO_SECRET_KEY))?;
+        obj.set_attr(from_ulong(CKA_KEY_TYPE, CKK_GENERIC_SECRET))?;
+        obj.set_attr(from_ulong(CKA_VALUE_LEN, key.len() as CK_ULONG))?;
+        obj.set_attr(from_bytes(CKA_VALUE, key))?;
+        obj.set_attr(from_bool(CKA_DERIVE, true))?;
+        Ok(obj)
+    }
+}
+
+impl Mechanism for PBKDF2Mechanism {
+    fn info(&self) -> &CK_MECHANISM_INFO {
+        &self.info
+    }
+
+    fn generate_key(
+        &self,
+        mech: &CK_MECHANISM,
+        template: &[CK_ATTRIBUTE],
+        mechanisms: &Mechanisms,
+        objfactories: &ObjectFactories,
+    ) -> KResult<Object> {
+        if self.info.flags & CKF_GENERATE != CKF_GENERATE {
+            return err_rv!(CKR_MECHANISM_INVALID);
+        }
+        if mech.mechanism != CKM_PKCS5_PBKD2 {
+            return err_rv!(CKR_MECHANISM_INVALID);
+        }
+
+        if mech.ulParameterLen as usize
+            != ::std::mem::size_of::<CK_PKCS5_PBKD2_PARAMS2>()
+        {
+            return err_rv!(CKR_ARGUMENTS_BAD);
+        }
+        let params =
+            unsafe { *(mech.pParameter as *const CK_PKCS5_PBKD2_PARAMS2) };
+
+        /* all the mechanism we support require this,
+         * if we ever add GOST support we'll have to add data */
+        if params.pPrfData != std::ptr::null_mut() || params.ulPrfDataLen != 0 {
+            return err_rv!(CKR_MECHANISM_PARAM_INVALID);
+        }
+
+        let pbkdf2 = PBKDF2 {
+            prf: match params.prf {
+                CKP_PKCS5_PBKD2_HMAC_SHA1 => CKM_SHA_1_HMAC,
+                CKP_PKCS5_PBKD2_HMAC_SHA224 => CKM_SHA224_HMAC,
+                CKP_PKCS5_PBKD2_HMAC_SHA256 => CKM_SHA256_HMAC,
+                CKP_PKCS5_PBKD2_HMAC_SHA384 => CKM_SHA384_HMAC,
+                CKP_PKCS5_PBKD2_HMAC_SHA512 => CKM_SHA512_HMAC,
+                _ => return err_rv!(CKR_MECHANISM_PARAM_INVALID),
+            },
+            pass: {
+                if params.pPassword == std::ptr::null_mut()
+                    || params.ulPasswordLen == 0
+                {
+                    return err_rv!(CKR_MECHANISM_PARAM_INVALID);
+                }
+                self.mock_password_object(bytes_to_vec!(
+                    params.pPassword,
+                    params.ulPasswordLen
+                ))?
+            },
+            salt: match params.saltSource {
+                CKZ_SALT_SPECIFIED => {
+                    if params.pSaltSourceData == std::ptr::null_mut()
+                        || params.ulSaltSourceDataLen == 0
+                    {
+                        return err_rv!(CKR_MECHANISM_PARAM_INVALID);
+                    }
+                    bytes_to_vec!(
+                        params.pSaltSourceData,
+                        params.ulSaltSourceDataLen
+                    )
+                }
+                _ => return err_rv!(CKR_MECHANISM_PARAM_INVALID),
+            },
+            iter: params.iterations as usize,
+        };
+
+        /* check early that we have key class and type defined */
+        let factory =
+            objfactories.get_obj_factory_from_key_template(template)?;
+
+        let keylen = match template.iter().find(|x| x.type_ == CKA_VALUE_LEN) {
+            Some(a) => a.to_ulong()? as usize,
+            None => {
+                let max = hash::hmac_size(pbkdf2.prf);
+                if max == CK_UNAVAILABLE_INFORMATION as usize {
+                    return err_rv!(CKR_MECHANISM_INVALID);
+                }
+                match factory.as_secret_key_factory()?.recommend_key_size(max) {
+                    Ok(len) => len,
+                    Err(_) => return err_rv!(CKR_TEMPLATE_INCONSISTENT),
+                }
+            }
+        };
+
+        let dkm = pbkdf2.derive(mechanisms, keylen)?;
+
+        let mut tmpl = template.to_vec();
+        tmpl.push(CK_ATTRIBUTE::from_slice(CKA_VALUE, dkm.as_slice()));
+
+        factory.create(tmpl.as_slice())
+    }
+}
+
+/* PKCS#11 in their infinite wisdom decided to implement this
+ * derivation as a mechanism key gen operation.
+ * Key Gen in Kryoptic does not go through an Operation trait,
+ * but we still want to be able to do both openssl and native
+ * backends, so we encapsulate the derivation function in a
+ * small structure and make implementations of the object in
+ * the relevant files for FIPS/non-FIPS */
+
+#[derive(Debug)]
+struct PBKDF2 {
+    prf: CK_MECHANISM_TYPE,
+    pass: Object,
+    salt: Vec<u8>,
+    iter: usize,
+}
+
+#[cfg(feature = "fips")]
+include!("ossl/pbkdf2.rs");
+
+#[cfg(not(feature = "fips"))]
+include!("pbkdf2.rs");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1496,12 +1496,14 @@ extern "C" fn fn_generate_key(
     let slot_id = session.get_slot_id();
     let mut token = res_or_ret!(rstate.get_token_from_slot_mut(slot_id));
 
-    let mech = res_or_ret!(token.get_mechanisms().get(data.mechanism));
+    let mechanisms = token.get_mechanisms();
+    let factories = token.get_object_factories();
+    let mech = res_or_ret!(mechanisms.get(data.mechanism));
     if mech.info().flags & CKF_GENERATE != CKF_GENERATE {
         return CKR_MECHANISM_INVALID;
     }
 
-    let result = mech.generate_key(data, tmpl);
+    let result = mech.generate_key(data, tmpl, mechanisms, factories);
     match result {
         Ok(obj) => {
             let kh = res_or_ret!(token.insert_object(s_handle, obj));

--- a/src/mechanism.rs
+++ b/src/mechanism.rs
@@ -59,6 +59,8 @@ pub trait Mechanism: Debug + Send + Sync {
         &self,
         _: &CK_MECHANISM,
         _: &[CK_ATTRIBUTE],
+        _: &Mechanisms,
+        _: &ObjectFactories,
     ) -> KResult<Object> {
         err_rv!(CKR_MECHANISM_INVALID)
     }

--- a/src/object.rs
+++ b/src/object.rs
@@ -1058,6 +1058,8 @@ impl Mechanism for GenericSecretKeyMechanism {
         &self,
         _mech: &CK_MECHANISM,
         template: &[CK_ATTRIBUTE],
+        _: &Mechanisms,
+        _: &ObjectFactories,
     ) -> KResult<Object> {
         let mut key =
             GENERIC_SECRET_FACTORY.default_object_generate(template)?;

--- a/src/ossl/common.rs
+++ b/src/ossl/common.rs
@@ -444,46 +444,55 @@ pub fn mech_type_to_digest_name(mech: CK_MECHANISM_TYPE) -> *const c_char {
         | CKM_ECDSA_SHA1
         | CKM_SHA1_RSA_PKCS_PSS
         | CKM_SHA_1_HMAC
+        | CKM_SHA_1_HMAC_GENERAL
         | CKM_SHA_1 => OSSL_DIGEST_NAME_SHA1.as_ptr(),
         CKM_SHA224_RSA_PKCS
         | CKM_ECDSA_SHA224
         | CKM_SHA224_RSA_PKCS_PSS
         | CKM_SHA224_HMAC
+        | CKM_SHA224_HMAC_GENERAL
         | CKM_SHA224 => OSSL_DIGEST_NAME_SHA2_224.as_ptr(),
         CKM_SHA256_RSA_PKCS
         | CKM_ECDSA_SHA256
         | CKM_SHA256_RSA_PKCS_PSS
         | CKM_SHA256_HMAC
+        | CKM_SHA256_HMAC_GENERAL
         | CKM_SHA256 => OSSL_DIGEST_NAME_SHA2_256.as_ptr(),
         CKM_SHA384_RSA_PKCS
         | CKM_ECDSA_SHA384
         | CKM_SHA384_RSA_PKCS_PSS
         | CKM_SHA384_HMAC
+        | CKM_SHA384_HMAC_GENERAL
         | CKM_SHA384 => OSSL_DIGEST_NAME_SHA2_384.as_ptr(),
         CKM_SHA512_RSA_PKCS
         | CKM_ECDSA_SHA512
         | CKM_SHA512_RSA_PKCS_PSS
         | CKM_SHA512_HMAC
+        | CKM_SHA512_HMAC_GENERAL
         | CKM_SHA512 => OSSL_DIGEST_NAME_SHA2_512.as_ptr(),
         CKM_SHA3_224_RSA_PKCS
         | CKM_ECDSA_SHA3_224
         | CKM_SHA3_224_RSA_PKCS_PSS
         | CKM_SHA3_224_HMAC
+        | CKM_SHA3_224_HMAC_GENERAL
         | CKM_SHA3_224 => OSSL_DIGEST_NAME_SHA3_224.as_ptr(),
         CKM_SHA3_256_RSA_PKCS
         | CKM_ECDSA_SHA3_256
         | CKM_SHA3_256_RSA_PKCS_PSS
         | CKM_SHA3_256_HMAC
+        | CKM_SHA3_256_HMAC_GENERAL
         | CKM_SHA3_256 => OSSL_DIGEST_NAME_SHA3_256.as_ptr(),
         CKM_SHA3_384_RSA_PKCS
         | CKM_ECDSA_SHA3_384
         | CKM_SHA3_384_RSA_PKCS_PSS
         | CKM_SHA3_384_HMAC
+        | CKM_SHA3_384_HMAC_GENERAL
         | CKM_SHA3_384 => OSSL_DIGEST_NAME_SHA3_384.as_ptr(),
         CKM_SHA3_512_RSA_PKCS
         | CKM_ECDSA_SHA3_512
         | CKM_SHA3_512_RSA_PKCS_PSS
         | CKM_SHA3_512_HMAC
+        | CKM_SHA3_512_HMAC_GENERAL
         | CKM_SHA3_512 => OSSL_DIGEST_NAME_SHA3_512.as_ptr(),
         _ => std::ptr::null(),
     }) as *const c_char

--- a/src/ossl/pbkdf2.rs
+++ b/src/ossl/pbkdf2.rs
@@ -1,0 +1,54 @@
+// Copyright 2024 Simo Sorce
+// See LICENSE.txt file for terms
+
+use core::ffi::c_uint;
+
+impl PBKDF2 {
+    fn derive(&self, _: &Mechanisms, len: usize) -> KResult<Vec<u8>> {
+        let params = OsslParam::with_capacity(4)
+            .set_zeroize()
+            .add_octet_string(
+                name_as_char(OSSL_KDF_PARAM_PASSWORD),
+                self.pass.get_attr_as_bytes(CKA_VALUE)?,
+            )?
+            .add_octet_string(name_as_char(OSSL_KDF_PARAM_SALT), &self.salt)?
+            .add_uint(name_as_char(OSSL_KDF_PARAM_ITER), self.iter as c_uint)?
+            .add_const_c_string(
+                name_as_char(OSSL_KDF_PARAM_DIGEST),
+                mech_type_to_digest_name(self.prf),
+            )?
+            .finalize();
+
+        let mut kdf = match EvpKdf::from_ptr(unsafe {
+            EVP_KDF_fetch(
+                get_libctx(),
+                name_as_char(OSSL_KDF_NAME_PBKDF2),
+                std::ptr::null(),
+            )
+        }) {
+            Ok(ek) => ek,
+            Err(_) => return err_rv!(CKR_DEVICE_ERROR),
+        };
+        let mut kctx = match EvpKdfCtx::from_ptr(unsafe {
+            EVP_KDF_CTX_new(kdf.as_mut_ptr())
+        }) {
+            Ok(ekc) => ekc,
+            Err(_) => return err_rv!(CKR_DEVICE_ERROR),
+        };
+
+        let mut dkm = vec![0u8; len];
+        let res = unsafe {
+            EVP_KDF_derive(
+                kctx.as_mut_ptr(),
+                dkm.as_mut_ptr(),
+                dkm.len(),
+                params.as_ptr(),
+            )
+        };
+        if res != 1 {
+            return err_rv!(CKR_DEVICE_ERROR);
+        }
+
+        Ok(dkm)
+    }
+}

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -1,0 +1,72 @@
+// Copyright 2024 Simo Sorce
+// See LICENSE.txt file for terms
+
+use std::mem::swap;
+
+/* https://www.rfc-editor.org/rfc/rfc8018#section-5.2 */
+impl PBKDF2 {
+    fn prf_fn(
+        &self,
+        mech: &Box<dyn Mechanism>,
+        i: &[u8],
+        o: &mut [u8],
+    ) -> KResult<()> {
+        mech.mac_new(
+            &CK_MECHANISM {
+                mechanism: self.prf,
+                pParameter: std::ptr::null_mut(),
+                ulParameterLen: 0,
+            },
+            &self.pass,
+            CKF_DERIVE,
+        )?
+        .mac(i, o)
+    }
+
+    fn derive(
+        &self,
+        mechanisms: &Mechanisms,
+        dklen: usize,
+    ) -> KResult<Vec<u8>> {
+        let hlen = hash::hmac_size(self.prf);
+        if hlen == CK_UNAVAILABLE_INFORMATION as usize {
+            return err_rv!(CKR_MECHANISM_INVALID);
+        }
+
+        if dklen > (hlen * (u32::MAX as usize)) {
+            return err_rv!(CKR_KEY_SIZE_RANGE);
+        }
+
+        let l = (dklen + hlen - 1) / hlen;
+
+        let mut dkm = vec![0u8; dklen];
+
+        let mech = mechanisms.get(self.prf)?;
+
+        for b in 0..l {
+            let i = b as u32 + 1;
+            let mut t_i = vec![0u8; hlen];
+            let mut u_out = vec![0u8; hlen];
+            let mut u_in = self.salt.clone();
+            u_in.extend_from_slice(&i.to_be_bytes());
+
+            for _ in 0..self.iter {
+                self.prf_fn(mech, u_in.as_slice(), u_out.as_mut_slice())?;
+                t_i.iter_mut().zip(u_out.iter()).for_each(|(a, b)| *a ^= *b);
+                if u_in.len() != u_out.len() {
+                    u_in.resize(u_out.len(), 0);
+                }
+                swap(&mut u_in, &mut u_out);
+            }
+
+            let t = b * hlen;
+            let mut r = dklen - t;
+            if r > hlen {
+                r = hlen
+            };
+            dkm[t..(t + r)].copy_from_slice(&t_i[0..r])
+        }
+
+        Ok(dkm)
+    }
+}

--- a/src/tests/aes.rs
+++ b/src/tests/aes.rs
@@ -21,6 +21,8 @@ fn test_aes_operations() {
     let handle = ret_or_panic!(generate_key(
         session,
         CKM_AES_KEY_GEN,
+        std::ptr::null_mut(),
+        0,
         &[(CKA_VALUE_LEN, 16),],
         &[],
         &[
@@ -754,6 +756,8 @@ fn test_aes_macs() {
     let handle = ret_or_panic!(generate_key(
         session,
         CKM_AES_KEY_GEN,
+        std::ptr::null_mut(),
+        0,
         &[(CKA_VALUE_LEN, 16),],
         &[],
         &[(CKA_SIGN, true), (CKA_VERIFY, true),],

--- a/src/tests/keys.rs
+++ b/src/tests/keys.rs
@@ -16,6 +16,8 @@ fn test_key() {
     let handle = ret_or_panic!(generate_key(
         session,
         CKM_GENERIC_SECRET_KEY_GEN,
+        std::ptr::null_mut(),
+        0,
         &[(CKA_KEY_TYPE, CKK_GENERIC_SECRET), (CKA_VALUE_LEN, 16),],
         &[],
         &[

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -439,6 +439,8 @@ pub fn import_object(
 pub fn generate_key(
     session: CK_ULONG,
     mech: CK_MECHANISM_TYPE,
+    mechdata: CK_VOID_PTR,
+    mechdlen: CK_ULONG,
     ulongs: &[(CK_ATTRIBUTE_TYPE, CK_ULONG)],
     bytes: &[(CK_ATTRIBUTE_TYPE, &[u8])],
     bools: &[(CK_ATTRIBUTE_TYPE, bool)],
@@ -453,8 +455,8 @@ pub fn generate_key(
 
     let mut mechanism: CK_MECHANISM = CK_MECHANISM {
         mechanism: mech,
-        pParameter: std::ptr::null_mut(),
-        ulParameterLen: 0,
+        pParameter: mechdata,
+        ulParameterLen: mechdlen,
     };
 
     let mut handle: CK_OBJECT_HANDLE = CK_INVALID_HANDLE;


### PR DESCRIPTION
This is another "good one" where PKCS#11 spec deviates from what you would expect, and uses C_GenerateKey to implemnt Key derivation instead of C_DeriveKey.

This means we now need to pass mechanisms and object factories to the generate function because the template can specify any key type, so we need to get the generate_key function from the PBKDF mechanism, but we need to be able to find the crate() mechanism for any supported key type ...