### PR TITLE
RSA: Accept empty OAEP parameter label

### DIFF
--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -182,7 +182,7 @@ impl Sp800Operation {
     }
 
     fn parse_byte_array(p: &CK_PRF_DATA_PARAM) -> KResult<Vec<u8>> {
-        if p.ulValueLen == 0 {
+        if p.ulValueLen == 0 || p.pValue == std::ptr::null_mut() {
             return err_rv!(CKR_MECHANISM_PARAM_INVALID);
         }
         Ok(bytes_to_vec!(p.pValue, p.ulValueLen))

--- a/src/ossl/aes.rs
+++ b/src/ossl/aes.rs
@@ -273,6 +273,9 @@ impl AesOperation {
                 }
                 let iv = unsafe { (*gcm_params).pIv };
                 let ivlen = unsafe { (*gcm_params).ulIvLen };
+                if ivlen < 1 || iv == std::ptr::null_mut() {
+                    return err_rv!(CKR_MECHANISM_PARAM_INVALID);
+                }
                 let aad = unsafe { (*gcm_params).pAAD };
                 let aadlen = unsafe { (*gcm_params).ulAADLen };
                 let tagbits = unsafe { (*gcm_params).ulTagBits } as usize;

--- a/src/ossl/rsa.rs
+++ b/src/ossl/rsa.rs
@@ -281,10 +281,13 @@ fn parse_oaep_params(mech: &CK_MECHANISM) -> KResult<RsaOaepParams> {
             }
             None
         }
-        CKZ_DATA_SPECIFIED => Some(bytes_to_vec!(
-            unsafe { (*oaep_params).pSourceData },
-            unsafe { (*oaep_params).ulSourceDataLen }
-        )),
+        CKZ_DATA_SPECIFIED => match unsafe { (*oaep_params).ulSourceDataLen } {
+            0 => None,
+            _ => Some(bytes_to_vec!(
+                unsafe { (*oaep_params).pSourceData },
+                unsafe { (*oaep_params).ulSourceDataLen }
+            )),
+        },
         _ => return err_rv!(CKR_MECHANISM_PARAM_INVALID),
     };
 

--- a/src/tests/rsa.rs
+++ b/src/tests/rsa.rs
@@ -258,7 +258,7 @@ fn test_rsa_operations() {
     let params = CK_RSA_PKCS_OAEP_PARAMS {
         hashAlg: CKM_SHA512,
         mgf: CKG_MGF1_SHA512,
-        source: 0,
+        source: CKZ_DATA_SPECIFIED,
         pSourceData: std::ptr::null_mut(),
         ulSourceDataLen: 0,
     };


### PR DESCRIPTION
My reading of the PKCS#11 specs is that the RSA-OAEP parameters source needs to be `CKZ_DATA_SPECIFIED` regardless if the lablel is specified or not. Currently, the combination of `source=CKZ_DATA_SPECIFIED` and NULL source data and `ulSourceDataLen=0` is crashing now.