### PR TITLE
Remove caching layer from the storage interface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -823,7 +823,7 @@ extern "C" fn fn_encrypt_init(
     let data: &CK_MECHANISM = unsafe { &*mechanism };
     let slot_id = session.get_slot_id();
     let mut token = res_or_ret!(rstate.get_token_from_slot_mut(slot_id));
-    let obj = res_or_ret!(token.get_object_by_handle(key)).clone();
+    let obj = res_or_ret!(token.get_object_by_handle(key));
     let mech = res_or_ret!(token.get_mechanisms().get(data.mechanism));
     if mech.info().flags & CKF_ENCRYPT == CKF_ENCRYPT {
         let operation = res_or_ret!(mech.encryption_new(data, &obj));
@@ -937,7 +937,7 @@ extern "C" fn fn_decrypt_init(
     let data: &CK_MECHANISM = unsafe { &*mechanism };
     let slot_id = session.get_slot_id();
     let mut token = res_or_ret!(rstate.get_token_from_slot_mut(slot_id));
-    let obj = res_or_ret!(token.get_object_by_handle(key)).clone();
+    let obj = res_or_ret!(token.get_object_by_handle(key));
     let mech = res_or_ret!(token.get_mechanisms().get(data.mechanism));
     if mech.info().flags & CKF_DECRYPT == CKF_DECRYPT {
         let operation = res_or_ret!(mech.decryption_new(data, &obj));
@@ -1197,7 +1197,7 @@ extern "C" fn fn_sign_init(
     let data: &CK_MECHANISM = unsafe { &*mechanism };
     let slot_id = session.get_slot_id();
     let mut token = res_or_ret!(rstate.get_token_from_slot_mut(slot_id));
-    let obj = res_or_ret!(token.get_object_by_handle(key)).clone();
+    let obj = res_or_ret!(token.get_object_by_handle(key));
     let mech = res_or_ret!(token.get_mechanisms().get(data.mechanism));
     if mech.info().flags & CKF_SIGN == CKF_SIGN {
         let operation = res_or_ret!(mech.sign_new(data, &obj));
@@ -1338,7 +1338,7 @@ extern "C" fn fn_verify_init(
     let data: &CK_MECHANISM = unsafe { &*mechanism };
     let slot_id = session.get_slot_id();
     let mut token = res_or_ret!(rstate.get_token_from_slot_mut(slot_id));
-    let obj = res_or_ret!(token.get_object_by_handle(key)).clone();
+    let obj = res_or_ret!(token.get_object_by_handle(key));
     let mech = res_or_ret!(token.get_mechanisms().get(data.mechanism));
     if mech.info().flags & CKF_VERIFY == CKF_VERIFY {
         let operation = res_or_ret!(mech.verify_new(data, &obj));
@@ -1591,8 +1591,8 @@ extern "C" fn fn_wrap_key(
     let ck_mech: &CK_MECHANISM = unsafe { &*mechanism };
     let slot_id = session.get_slot_id();
     let mut token = res_or_ret!(rstate.get_token_from_slot_mut(slot_id));
-    let kobj = res_or_ret!(token.get_object_by_handle(key)).clone();
-    let wkobj = res_or_ret!(token.get_object_by_handle(wrapping_key)).clone();
+    let kobj = res_or_ret!(token.get_object_by_handle(key));
+    let wkobj = res_or_ret!(token.get_object_by_handle(wrapping_key));
     let factories = token.get_object_factories();
     let factory = res_or_ret!(factories.get_object_factory(&kobj));
     let mech = res_or_ret!(token.get_mechanisms().get(ck_mech.mechanism));
@@ -1644,7 +1644,7 @@ extern "C" fn fn_unwrap_key(
     }
     let slot_id = session.get_slot_id();
     let mut token = res_or_ret!(rstate.get_token_from_slot_mut(slot_id));
-    let kobj = res_or_ret!(token.get_object_by_handle(unwrapping_key)).clone();
+    let kobj = res_or_ret!(token.get_object_by_handle(unwrapping_key));
     let factories = token.get_object_factories();
     let factory =
         res_or_ret!(factories.get_obj_factory_from_key_template(tmpl));
@@ -1694,8 +1694,7 @@ extern "C" fn fn_derive_key(
     }
     let slot_id = session.get_slot_id();
     let mut token = res_or_ret!(rstate.get_token_from_slot_mut(slot_id));
-    let mut bkey = res_or_ret!(token.get_object_by_handle(base_key)).clone();
-    bkey.set_zeroize();
+    let bkey = res_or_ret!(token.get_object_by_handle(base_key));
 
     /* key checks */
     if !res_or_ret!(bkey.get_attr_as_bool(CKA_DERIVE)) {
@@ -1717,10 +1716,7 @@ extern "C" fn fn_derive_key(
         Ok(handles) => {
             let mut objs = Vec::<object::Object>::with_capacity(handles.len());
             for h in handles {
-                let mut kobj =
-                    res_or_ret!(token.get_object_by_handle(*h)).clone();
-                kobj.set_zeroize();
-                objs.push(kobj);
+                objs.push(res_or_ret!(token.get_object_by_handle(*h)));
             }
             /* shenanigans to deal with borrow checkr on token */
             let mut send = Vec::<&object::Object>::with_capacity(objs.len());

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -15,12 +15,9 @@ pub trait Storage: Debug + Send + Sync {
     fn open(&mut self, filename: &String) -> KResult<()>;
     fn reinit(&mut self) -> KResult<()>;
     fn flush(&mut self) -> KResult<()>;
-    fn fetch_by_uid(&mut self, uid: &String) -> KResult<&Object>;
-    fn get_cached_by_uid(&self, uid: &String) -> KResult<&Object>;
-    fn get_cached_by_uid_mut(&mut self, uid: &String) -> KResult<&mut Object>;
+    fn fetch_by_uid(&self, uid: &String) -> KResult<Object>;
     fn store(&mut self, uid: &String, obj: Object) -> KResult<()>;
-    fn get_all_cached(&self) -> Vec<&Object>;
-    fn search(&mut self, template: &[CK_ATTRIBUTE]) -> KResult<Vec<&Object>>;
+    fn search(&self, template: &[CK_ATTRIBUTE]) -> KResult<Vec<Object>>;
     fn remove_by_uid(&mut self, uid: &String) -> KResult<()>;
 }
 

--- a/src/storage/json.rs
+++ b/src/storage/json.rs
@@ -159,7 +159,7 @@ impl JsonToken {
             if !o.is_token() {
                 continue;
             }
-            jt.objects.push(JsonObject::from_object(o));
+            jt.objects.push(JsonObject::from_object(&o));
         }
 
         jt
@@ -197,23 +197,14 @@ impl Storage for JsonStorage {
         let token = JsonToken::from_cache(&mut self.cache);
         token.save(&self.filename)
     }
-    fn fetch_by_uid(&mut self, uid: &String) -> KResult<&Object> {
+    fn fetch_by_uid(&self, uid: &String) -> KResult<Object> {
         self.cache.fetch_by_uid(uid)
-    }
-    fn get_cached_by_uid(&self, uid: &String) -> KResult<&Object> {
-        self.cache.get_cached_by_uid(uid)
-    }
-    fn get_cached_by_uid_mut(&mut self, uid: &String) -> KResult<&mut Object> {
-        self.cache.get_cached_by_uid_mut(uid)
     }
     fn store(&mut self, uid: &String, obj: Object) -> KResult<()> {
         self.cache.store(uid, obj)?;
         self.flush()
     }
-    fn get_all_cached(&self) -> Vec<&Object> {
-        self.cache.get_all_cached()
-    }
-    fn search(&mut self, template: &[CK_ATTRIBUTE]) -> KResult<Vec<&Object>> {
+    fn search(&self, template: &[CK_ATTRIBUTE]) -> KResult<Vec<Object>> {
         self.cache.search(template)
     }
     fn remove_by_uid(&mut self, uid: &String) -> KResult<()> {

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -31,18 +31,9 @@ impl Storage for MemoryStorage {
     fn flush(&mut self) -> KResult<()> {
         Ok(())
     }
-    fn fetch_by_uid(&mut self, uid: &String) -> KResult<&Object> {
-        self.get_cached_by_uid(uid)
-    }
-    fn get_cached_by_uid(&self, uid: &String) -> KResult<&Object> {
+    fn fetch_by_uid(&self, uid: &String) -> KResult<Object> {
         match self.objects.get(uid) {
-            Some(o) => Ok(o),
-            None => err_not_found! {uid.clone()},
-        }
-    }
-    fn get_cached_by_uid_mut(&mut self, uid: &String) -> KResult<&mut Object> {
-        match self.objects.get_mut(uid) {
-            Some(o) => Ok(o),
+            Some(o) => Ok(o.clone()),
             None => err_not_found! {uid.clone()},
         }
     }
@@ -50,18 +41,11 @@ impl Storage for MemoryStorage {
         self.objects.insert(uid.clone(), obj);
         Ok(())
     }
-    fn get_all_cached(&self) -> Vec<&Object> {
-        let mut ret = Vec::<&Object>::with_capacity(self.objects.len());
-        for (_, o) in self.objects.iter() {
-            ret.push(o);
-        }
-        ret
-    }
-    fn search(&mut self, template: &[CK_ATTRIBUTE]) -> KResult<Vec<&Object>> {
-        let mut ret = Vec::<&Object>::new();
+    fn search(&self, template: &[CK_ATTRIBUTE]) -> KResult<Vec<Object>> {
+        let mut ret = Vec::<Object>::new();
         for (_, o) in self.objects.iter() {
             if o.match_template(template) {
-                ret.push(o);
+                ret.push(o.clone());
             }
         }
         Ok(ret)


### PR DESCRIPTION
This caching layer was a premature optimization, and cause the interfaces to require mutability in places where it wasn't really warranted, and in the end many callers would end up calling .clone() anyway for various reasons.

Will follow up with other PRs later to further change this.