### PR TITLE
Make OpenSSL context wrappers safer

### DIFF
--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -56,6 +56,7 @@ fn oid_to_curve_name(oid: asn1::ObjectIdentifier) -> KResult<&'static str> {
     }
 }
 
+#[cfg(test)]
 pub fn curve_name_to_ec_params(name: &'static str) -> KResult<&'static [u8]> {
     match name {
         NAME_SECP256R1 => Ok(STRING_SECP256R1),
@@ -65,6 +66,7 @@ pub fn curve_name_to_ec_params(name: &'static str) -> KResult<&'static [u8]> {
     }
 }
 
+#[cfg(test)]
 pub fn name_to_bits(name: &'static str) -> KResult<usize> {
     match name {
         NAME_SECP256R1 => Ok(BITS_SECP256R1),

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,6 +60,28 @@ impl fmt::Display for KError {
 }
 
 #[macro_export]
+macro_rules! some_or_err {
+    ($action:expr) => {
+        if let Some(ref x) = $action {
+            x
+        } else {
+            return Err(KError::RvError(error::CkRvError {
+                rv: interface::CKR_GENERAL_ERROR,
+            }));
+        }
+    };
+    (mut $action:expr) => {
+        if let Some(ref mut x) = $action {
+            x
+        } else {
+            return Err(KError::RvError(error::CkRvError {
+                rv: interface::CKR_GENERAL_ERROR,
+            }));
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! err_rv {
     ($ck_err:expr) => {
         Err(KError::RvError(error::CkRvError { rv: $ck_err }))

--- a/src/object.rs
+++ b/src/object.rs
@@ -58,7 +58,6 @@ pub struct Object {
     handle: CK_OBJECT_HANDLE,
     session: CK_SESSION_HANDLE,
     attributes: Vec<Attribute>,
-    modified: bool,
     zeroize: bool,
 }
 
@@ -78,7 +77,6 @@ impl Object {
             handle: CK_INVALID_HANDLE,
             session: CK_INVALID_HANDLE,
             attributes: Vec::new(),
-            modified: false,
             zeroize: false,
         }
     }
@@ -96,7 +94,6 @@ impl Object {
             let uuid = Uuid::new_v4().to_string();
             self.attributes
                 .push(attribute::from_string(CKA_UNIQUE_ID, uuid));
-            self.modified = true;
         }
     }
 
@@ -109,7 +106,6 @@ impl Object {
             }
             obj.attributes.push(attr.clone());
         }
-        obj.modified = true;
         Ok(obj)
     }
 
@@ -119,14 +115,6 @@ impl Object {
 
     pub fn get_handle(&self) -> CK_OBJECT_HANDLE {
         self.handle
-    }
-
-    pub fn reset_modified(&mut self) {
-        self.modified = false;
-    }
-
-    pub fn is_modified(&self) -> bool {
-        self.modified
     }
 
     pub fn set_session(&mut self, s: CK_SESSION_HANDLE) {
@@ -155,7 +143,6 @@ impl Object {
             Some(idx) => self.attributes[idx] = a,
             None => self.attributes.push(a),
         }
-        self.modified = true;
         Ok(())
     }
 
@@ -169,7 +156,6 @@ impl Object {
             }
             None => {
                 self.attributes.push(a);
-                self.modified = true;
             }
         }
         Ok(true)
@@ -178,7 +164,6 @@ impl Object {
     #[allow(dead_code)]
     pub fn del_attr(&mut self, ck_type: CK_ULONG) {
         self.attributes.retain(|a| a.get_type() != ck_type);
-        self.modified = true;
     }
 
     pub fn get_attributes(&self) -> &Vec<Attribute> {

--- a/src/ossl/common.rs
+++ b/src/ossl/common.rs
@@ -149,14 +149,6 @@ impl EvpPkeyCtx {
         Ok(EvpPkeyCtx { ptr: ptr })
     }
 
-    /*
-    pub fn empty() -> EvpPkeyCtx {
-        EvpPkeyCtx {
-            ptr: std::ptr::null_mut(),
-        }
-    }
-    */
-
     pub fn as_ptr(&self) -> *const EVP_PKEY_CTX {
         self.ptr
     }
@@ -229,12 +221,6 @@ impl EvpPkey {
             return err_rv!(CKR_DEVICE_ERROR);
         }
         Ok(EvpPkey { ptr: pkey })
-    }
-
-    pub fn empty() -> EvpPkey {
-        EvpPkey {
-            ptr: std::ptr::null_mut(),
-        }
     }
 
     pub fn new_ctx(&mut self) -> KResult<EvpPkeyCtx> {
@@ -637,14 +623,6 @@ impl OsslParam {
         }
         Ok(octet)
     }
-}
-
-pub fn empty_private_key() -> EvpPkey {
-    EvpPkey::empty()
-}
-
-pub fn empty_public_key() -> EvpPkey {
-    EvpPkey::empty()
 }
 
 pub fn mech_type_to_digest_name(mech: CK_MECHANISM_TYPE) -> *const c_char {

--- a/src/ossl/hash.rs
+++ b/src/ossl/hash.rs
@@ -14,17 +14,10 @@ pub struct HashState {
 
 impl HashState {
     pub fn new(alg: &[u8]) -> KResult<HashState> {
-        unsafe {
-            let libctx = get_libctx();
-            Ok(HashState {
-                md: EvpMd::from_ptr(EVP_MD_fetch(
-                    libctx,
-                    alg.as_ptr() as *const c_char,
-                    std::ptr::null_mut(),
-                ))?,
-                ctx: EvpMdCtx::from_ptr(EVP_MD_CTX_new())?,
-            })
-        }
+        Ok(HashState {
+            md: EvpMd::new(alg.as_ptr() as *const c_char)?,
+            ctx: EvpMdCtx::new()?,
+        })
     }
 }
 

--- a/src/ossl/hkdf.rs
+++ b/src/ossl/hkdf.rs
@@ -76,23 +76,7 @@ impl Derive for HKDFOperation {
         }
         params = params.finalize();
 
-        let mut kdf = match EvpKdf::from_ptr(unsafe {
-            EVP_KDF_fetch(
-                get_libctx(),
-                name_as_char(OSSL_KDF_NAME_HKDF),
-                std::ptr::null(),
-            )
-        }) {
-            Ok(ek) => ek,
-            Err(_) => return err_rv!(CKR_DEVICE_ERROR),
-        };
-        let mut kctx = match EvpKdfCtx::from_ptr(unsafe {
-            EVP_KDF_CTX_new(kdf.as_mut_ptr())
-        }) {
-            Ok(ekc) => ekc,
-            Err(_) => return err_rv!(CKR_DEVICE_ERROR),
-        };
-
+        let mut kctx = EvpKdfCtx::new(name_as_char(OSSL_KDF_NAME_HKDF))?;
         let mut dkm = vec![0u8; keysize];
         let res = unsafe {
             EVP_KDF_derive(

--- a/src/ossl/kdf.rs
+++ b/src/ossl/kdf.rs
@@ -408,23 +408,7 @@ impl Derive for Sp800Operation {
             self.addl_objects.push(obj);
         }
 
-        let mut kdf = match EvpKdf::from_ptr(unsafe {
-            EVP_KDF_fetch(
-                get_libctx(),
-                name_as_char(OSSL_KDF_NAME_KBKDF),
-                std::ptr::null(),
-            )
-        }) {
-            Ok(ek) => ek,
-            Err(_) => return err_rv!(CKR_DEVICE_ERROR),
-        };
-        let mut kctx = match EvpKdfCtx::from_ptr(unsafe {
-            EVP_KDF_CTX_new(kdf.as_mut_ptr())
-        }) {
-            Ok(ekc) => ekc,
-            Err(_) => return err_rv!(CKR_DEVICE_ERROR),
-        };
-
+        let mut kctx = EvpKdfCtx::new(name_as_char(OSSL_KDF_NAME_KBKDF))?;
         let mut dkm = vec![0u8; slen];
         let res = unsafe {
             EVP_KDF_derive(

--- a/src/ossl/pbkdf2.rs
+++ b/src/ossl/pbkdf2.rs
@@ -19,23 +19,7 @@ impl PBKDF2 {
             )?
             .finalize();
 
-        let mut kdf = match EvpKdf::from_ptr(unsafe {
-            EVP_KDF_fetch(
-                get_libctx(),
-                name_as_char(OSSL_KDF_NAME_PBKDF2),
-                std::ptr::null(),
-            )
-        }) {
-            Ok(ek) => ek,
-            Err(_) => return err_rv!(CKR_DEVICE_ERROR),
-        };
-        let mut kctx = match EvpKdfCtx::from_ptr(unsafe {
-            EVP_KDF_CTX_new(kdf.as_mut_ptr())
-        }) {
-            Ok(ekc) => ekc,
-            Err(_) => return err_rv!(CKR_DEVICE_ERROR),
-        };
-
+        let mut kctx = EvpKdfCtx::new(name_as_char(OSSL_KDF_NAME_PBKDF2))?;
         let mut dkm = vec![0u8; len];
         let res = unsafe {
             EVP_KDF_derive(

--- a/src/token.rs
+++ b/src/token.rs
@@ -926,7 +926,6 @@ impl Token {
         template: &[CK_ATTRIBUTE],
     ) -> KResult<Vec<CK_OBJECT_HANDLE>> {
         let mut handles = Vec::<CK_OBJECT_HANDLE>::new();
-        let mut needs_handle = Vec::<String>::new();
         let is_logged_in = self.is_logged_in(KRY_UNSPEC);
 
         /* First add internal session objects */


### PR DESCRIPTION
Instead of exposing raw pointers which is quite unsafe, internalize as many unsafe operations as possible on these raw pointers so that the actual interface of these wrapped type is mostly safe.

Declare interfaces that still deal with raw pointers as unsafe so that proper care is done when handling them.

Fixes #63 