### PR TITLE
Fix creation of session objects

### DIFF
--- a/src/tests/objects.rs
+++ b/src/tests/objects.rs
@@ -82,14 +82,14 @@ fn test_create_objects() {
         (CKA_APPLICATION, "test".as_bytes()),
         (CKA_VALUE, "payload".as_bytes()),
     ];
+    let bool_values = [(CKA_TOKEN, true)];
 
     err_or_panic!(
-        import_object(session, CKO_DATA, &[], &byte_values, &[],),
-        CKR_USER_NOT_LOGGED_IN
+        import_object(session, CKO_DATA, &[], &byte_values, &bool_values,),
+        CKR_SESSION_READ_ONLY
     );
 
-    /* login */
-    testtokn.login();
+    let session = testtokn.get_session(true);
 
     let _ =
         ret_or_panic!(
@@ -97,24 +97,19 @@ fn test_create_objects() {
         );
 
     err_or_panic!(
-        import_object(
-            session,
-            CKO_DATA,
-            &[],
-            &byte_values,
-            &[(CKA_TOKEN, true)],
-        ),
-        CKR_SESSION_READ_ONLY
+        import_object(session, CKO_DATA, &[], &byte_values, &bool_values,),
+        CKR_USER_NOT_LOGGED_IN
     );
 
-    let session = testtokn.get_session(true);
+    /* login */
+    testtokn.login();
 
     let _ = ret_or_panic!(import_object(
         session,
         CKO_DATA,
         &[],
         &byte_values,
-        &[(CKA_TOKEN, true)],
+        &bool_values,
     ));
 
     let _ = ret_or_panic!(import_object(

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -31,11 +31,22 @@ macro_rules! err_or_panic {
         if !match $ret {
             Ok(_) => false,
             Err(e) => match e {
-                KError::RvError(r) => r.rv == $err,
+                KError::RvError(r) => {
+                    if r.rv != $err {
+                        panic!(
+                            "Should have returned error {}, but got {}",
+                            $err, r.rv
+                        );
+                    }
+                    true
+                }
                 _ => false,
             },
         } {
-            panic!("Should have returned error {}", $err);
+            panic!(
+                "Should have returned error {}, but got other error kind",
+                $err
+            );
         }
     };
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -1065,7 +1065,7 @@ impl Token {
             }
             None => return err_rv!(CKR_OBJECT_HANDLE_INVALID),
         };
-        if !is_logged_in && obj.is_private() {
+        if !is_logged_in && obj.is_token() && obj.is_private() {
             return err_rv!(CKR_USER_NOT_LOGGED_IN);
         }
         if obj.is_sensitive() {
@@ -1155,7 +1155,7 @@ impl Token {
             }
             None => return err_rv!(CKR_OBJECT_HANDLE_INVALID),
         };
-        if !is_logged && obj.is_private() {
+        if !is_logged && obj.is_token() && obj.is_private() {
             /* do not reveal if the object exists or not */
             return err_rv!(CKR_OBJECT_HANDLE_INVALID);
         }
@@ -1240,7 +1240,7 @@ impl Token {
             }
             None => return err_rv!(CKR_OBJECT_HANDLE_INVALID),
         };
-        if !is_logged_in && obj.is_private() {
+        if !is_logged_in && obj.is_token() && obj.is_private() {
             return err_rv!(CKR_USER_NOT_LOGGED_IN);
         }
         let newobj = self.object_factories.copy(&obj, template)?;
@@ -1256,10 +1256,6 @@ impl Token {
 
         /* First add internal session objects */
         for (_, o) in &self.session_objects {
-            if !is_logged_in && o.is_private() {
-                continue;
-            }
-
             if o.is_sensitive() {
                 match self.object_factories.check_sensitive(o, template) {
                     Err(_) => continue,

--- a/src/token.rs
+++ b/src/token.rs
@@ -1104,10 +1104,6 @@ impl Token {
         s_handle: CK_SESSION_HANDLE,
         template: &[CK_ATTRIBUTE],
     ) -> KResult<CK_OBJECT_HANDLE> {
-        if !self.is_logged_in(KRY_UNSPEC) {
-            return err_rv!(CKR_USER_NOT_LOGGED_IN);
-        }
-
         let object = self.object_factories.create(template)?;
         self.insert_object(s_handle, object)
     }


### PR DESCRIPTION
Creating a session object only requires a writable session, not full login.

Fixes #68 