### PR TITLE
Add support for CKA_ALWAYS_AUTHENTICATE behavior

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -132,6 +132,7 @@ impl Object {
     create_bool_checker! {make is_modifiable; from CKA_MODIFIABLE; def true}
     create_bool_checker! {make is_destroyable; from CKA_DESTROYABLE; def false}
     create_bool_checker! {make is_extractable; from CKA_EXTRACTABLE; def false}
+    create_bool_checker! {make always_auth; from CKA_ALWAYS_AUTHENTICATE; def false}
 
     pub fn get_attr(&self, ck_type: CK_ULONG) -> Option<&Attribute> {
         self.attributes.iter().find(|r| r.get_type() == ck_type)

--- a/src/token.rs
+++ b/src/token.rs
@@ -871,6 +871,13 @@ impl Token {
                     },
                 }
             }
+            CKU_CONTEXT_SPECIFIC => match self.check_user_login(pin) {
+                Ok(_) => CKR_OK,
+                Err(e) => match e {
+                    KError::RvError(e) => e.rv,
+                    _ => CKR_GENERAL_ERROR,
+                },
+            },
             _ => CKR_USER_TYPE_INVALID,
         }
     }


### PR DESCRIPTION
When a private key has this attribute set to true it commands that any operation (decryption/signature/etc..) done with this key requires an extra authentication to authorize the individual operation.

This is done by setting flags on the session that will control proper authentication is checked if necessary, and support for the special CKU_CONTEXT_SPECIFIC user type into the fn_login() function.

Fixes #70 