### PR TITLE
Implement support for CKA_ALLOWED_MECHANISMS

### DIFF
--- a/src/misc.rs
+++ b/src/misc.rs
@@ -2,6 +2,9 @@
 // See LICENSE.txt file for terms
 
 /* misc utilities that do not really belong in any module */
+use super::interface;
+
+pub const CK_ULONG_SIZE: usize = std::mem::size_of::<interface::CK_ULONG>();
 
 #[macro_export]
 macro_rules! bytes_to_vec {


### PR DESCRIPTION
Filters at operation init time and returns an error if the key indicated that it has a list of allowed mechanisms and the mechanism presented is not in the list.

A missing attribute is handled as if any mechanism is allowed.

Fixes #71 