### PR TITLE
Improve use of CK_ATTRIBUTE arrays

### DIFF
--- a/src/eddsa.rs
+++ b/src/eddsa.rs
@@ -267,16 +267,12 @@ impl Mechanism for EddsaMechanism {
 }
 
 pub fn register(mechs: &mut Mechanisms, ot: &mut ObjectFactories) {
-    /* TODO enable in FIPS Mode when our OpenSSL will have the EdDSA support */
-    #[cfg(not(feature = "fips"))]
     EddsaOperation::register_mechanisms(mechs);
 
-    #[cfg(not(feature = "fips"))]
     ot.add_factory(
         ObjectType::new(CKO_PUBLIC_KEY, CKK_EC_EDWARDS),
         &PUBLIC_KEY_FACTORY,
     );
-    #[cfg(not(feature = "fips"))]
     ot.add_factory(
         ObjectType::new(CKO_PRIVATE_KEY, CKK_EC_EDWARDS),
         &PRIVATE_KEY_FACTORY,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ mod aes;
 mod drbg;
 mod ecc;
 mod ecc_misc;
+#[cfg(not(feature = "fips"))]
 mod eddsa;
 mod hash;
 mod hkdf;

--- a/src/ossl/ecc.rs
+++ b/src/ossl/ecc.rs
@@ -10,6 +10,7 @@ use {super::ossl, ossl::*};
 use super::mechanism;
 use super::some_or_err;
 
+use attribute::CkAttrs;
 use kasn1::DerEncBigUint;
 use mechanism::*;
 
@@ -810,12 +811,9 @@ impl Derive for ECDHOperation {
             return err_rv!(CKR_DEVICE_ERROR);
         }
 
-        let mut tmpl = template.to_vec();
-
-        tmpl.push(CK_ATTRIBUTE::from_slice(
-            CKA_VALUE,
-            &secret[(secret_len - keylen)..],
-        ));
+        let mut tmpl = CkAttrs::from(template);
+        tmpl.add_owned_slice(CKA_VALUE, &secret[(secret_len - keylen)..])?;
+        tmpl.zeroize = true;
         let mut obj = factory.create(tmpl.as_slice())?;
 
         object::default_key_attributes(&mut obj, self.mech)?;

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -9,7 +9,7 @@ use super::mechanism;
 use super::object;
 use super::{cast_params, err_rv};
 
-use attribute::{from_bool, from_bytes, from_ulong};
+use attribute::{from_bool, from_bytes, from_ulong, CkAttrs};
 use error::{KError, KResult};
 use interface::*;
 use mechanism::*;
@@ -134,8 +134,9 @@ impl Mechanism for PBKDF2Mechanism {
 
         let dkm = pbkdf2.derive(mechanisms, keylen)?;
 
-        let mut tmpl = template.to_vec();
-        tmpl.push(CK_ATTRIBUTE::from_slice(CKA_VALUE, dkm.as_slice()));
+        let mut tmpl = CkAttrs::from(template);
+        tmpl.add_vec(CKA_VALUE, dkm)?;
+        tmpl.zeroize = true;
 
         let mut key = factory.create(tmpl.as_slice())?;
         object::default_key_attributes(&mut key, mech.mechanism)?;

--- a/src/token.rs
+++ b/src/token.rs
@@ -8,6 +8,7 @@ use std::vec::Vec;
 use super::aes;
 use super::attribute;
 use super::ecc;
+#[cfg(not(feature = "fips"))]
 use super::eddsa;
 use super::error;
 use super::hash;
@@ -202,6 +203,7 @@ impl Token {
         aes::register(&mut token.mechanisms, &mut token.object_factories);
         rsa::register(&mut token.mechanisms, &mut token.object_factories);
         ecc::register(&mut token.mechanisms, &mut token.object_factories);
+        #[cfg(not(feature = "fips"))]
         eddsa::register(&mut token.mechanisms, &mut token.object_factories);
         hash::register(&mut token.mechanisms, &mut token.object_factories);
         hmac::register(&mut token.mechanisms, &mut token.object_factories);

--- a/src/token.rs
+++ b/src/token.rs
@@ -443,13 +443,12 @@ impl Token {
         let keytyp = CKK_AES;
         let keylen = aes::MAX_AES_SIZE_BYTES as CK_ULONG;
         let truebool: CK_BBOOL = CK_TRUE;
-        let template: [CK_ATTRIBUTE; 5] = [
-            CK_ATTRIBUTE::from_ulong(CKA_CLASS, &class),
-            CK_ATTRIBUTE::from_ulong(CKA_KEY_TYPE, &keytyp),
-            CK_ATTRIBUTE::from_ulong(CKA_VALUE_LEN, &keylen),
-            CK_ATTRIBUTE::from_bool(CKA_WRAP, &truebool),
-            CK_ATTRIBUTE::from_bool(CKA_UNWRAP, &truebool),
-        ];
+        let mut template = attribute::CkAttrs::with_capacity(5);
+        template.add_ulong(CKA_CLASS, &class);
+        template.add_ulong(CKA_KEY_TYPE, &keytyp);
+        template.add_ulong(CKA_VALUE_LEN, &keylen);
+        template.add_bool(CKA_WRAP, &truebool);
+        template.add_bool(CKA_UNWRAP, &truebool);
         let pbkdf2 = self.mechanisms.get(CKM_PKCS5_PBKD2)?;
         pbkdf2.generate_key(
             &CK_MECHANISM {
@@ -457,7 +456,7 @@ impl Token {
                 pParameter: &params as *const _ as *mut _,
                 ulParameterLen: sizeof!(CK_PKCS5_PBKD2_PARAMS2),
             },
-            &template,
+            template.as_slice(),
             &self.mechanisms,
             &self.object_factories,
         )
@@ -508,13 +507,12 @@ impl Token {
         let keytyp = CKK_AES;
         let keylen = aes::MAX_AES_SIZE_BYTES as CK_ULONG;
         let truebool: CK_BBOOL = CK_TRUE;
-        let template: [CK_ATTRIBUTE; 5] = [
-            CK_ATTRIBUTE::from_ulong(CKA_CLASS, &class),
-            CK_ATTRIBUTE::from_ulong(CKA_KEY_TYPE, &keytyp),
-            CK_ATTRIBUTE::from_ulong(CKA_VALUE_LEN, &keylen),
-            CK_ATTRIBUTE::from_bool(CKA_ENCRYPT, &truebool),
-            CK_ATTRIBUTE::from_bool(CKA_DECRYPT, &truebool),
-        ];
+        let mut template = attribute::CkAttrs::with_capacity(5);
+        template.add_ulong(CKA_CLASS, &class);
+        template.add_ulong(CKA_KEY_TYPE, &keytyp);
+        template.add_ulong(CKA_VALUE_LEN, &keylen);
+        template.add_bool(CKA_ENCRYPT, &truebool);
+        template.add_bool(CKA_DECRYPT, &truebool);
         let aes = self.mechanisms.get(CKM_AES_GCM)?;
         Ok(aes.unwrap_key(
             &CK_MECHANISM {
@@ -524,9 +522,9 @@ impl Token {
             },
             wrapper,
             wrapped,
-            &template,
+            template.as_slice(),
             self.object_factories
-                .get_obj_factory_from_key_template(&template)?,
+                .get_obj_factory_from_key_template(template.as_slice())?,
         )?)
     }
 
@@ -596,11 +594,10 @@ impl Token {
         let class = CKO_SECRET_KEY;
         let keytyp = CKK_AES;
         let keylen = aes::MAX_AES_SIZE_BYTES as CK_ULONG;
-        let template: [CK_ATTRIBUTE; 3] = [
-            CK_ATTRIBUTE::from_ulong(CKA_CLASS, &class),
-            CK_ATTRIBUTE::from_ulong(CKA_KEY_TYPE, &keytyp),
-            CK_ATTRIBUTE::from_ulong(CKA_VALUE_LEN, &keylen),
-        ];
+        let mut template = attribute::CkAttrs::with_capacity(3);
+        template.add_ulong(CKA_CLASS, &class);
+        template.add_ulong(CKA_KEY_TYPE, &keytyp);
+        template.add_ulong(CKA_VALUE_LEN, &keylen);
         let aes = self.mechanisms.get(CKM_AES_KEY_GEN)?;
         let kek = aes.generate_key(
             &CK_MECHANISM {
@@ -608,7 +605,7 @@ impl Token {
                 pParameter: std::ptr::null_mut(),
                 ulParameterLen: 0,
             },
-            &template,
+            template.as_slice(),
             &self.mechanisms,
             &self.object_factories,
         )?;


### PR DESCRIPTION
This code improves usage of CK_ATTRIBUTE arrays by creating a structure partially inspired by OsslParam, but using better methods to deal with lifetimes and avoiding copies where not needed.