### PR TITLE
Refactor Error handling

### DIFF
--- a/src/ecc_misc.rs
+++ b/src/ecc_misc.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 - 2024 Simo Sorce, Jakub Jelen
 // See LICENSE.txt file for terms
 
-use super::error::KResult;
+use super::error::Result;
 use super::kasn1;
 
 type Version = u64;
@@ -26,9 +26,7 @@ pub struct ECPrivateKey<'a> {
 }
 
 impl ECPrivateKey<'_> {
-    pub fn new_owned<'a>(
-        private_key: &'a Vec<u8>,
-    ) -> KResult<ECPrivateKey<'a>> {
+    pub fn new_owned<'a>(private_key: &'a Vec<u8>) -> Result<ECPrivateKey<'a>> {
         Ok(ECPrivateKey {
             version: 1,
             private_key: kasn1::DerEncOctetString::new(private_key.as_slice())?,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,61 +1,136 @@
 // Copyright 2023 Simo Sorce
 // See LICENSE.txt file for terms
 
-use serde_json;
-use std::{error::Error, fmt};
+use std::error;
+use std::fmt;
 
 use super::interface;
 
-pub type KResult<T> = Result<T, KError>;
+use serde_json;
 
-#[derive(Debug, Clone)]
-pub struct CkRvError {
-    pub rv: interface::CK_RV,
-}
-
-impl Error for CkRvError {}
-
-impl fmt::Display for CkRvError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.rv {
-            interface::CKR_GENERAL_ERROR => write!(f, "CKR_GENERAL_ERROR"),
-            interface::CKR_ATTRIBUTE_TYPE_INVALID => {
-                write!(f, "CKR_ATTRIBUTE_TYPE_INVALID")
-            }
-            _ => write!(f, "{}", self.rv),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct AttributeNotFound {
-    pub s: String,
-}
-
-impl Error for AttributeNotFound {}
-
-impl fmt::Display for AttributeNotFound {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} not found", self.s)
-    }
-}
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug)]
-pub enum KError {
-    RvError(CkRvError),
-    NotFound(AttributeNotFound),
-    FileError(std::io::Error),
-    JsonError(serde_json::error::Error),
+pub struct Error {
+    kind: ErrorKind,
+    origin: Option<Box<dyn error::Error>>,
+    errmsg: Option<String>,
+    ckrv: interface::CK_RV,
 }
 
-impl fmt::Display for KError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            KError::RvError(e) => write!(f, "CK_RV error: {}", e),
-            KError::NotFound(e) => write!(f, "attribute not found {}", e),
-            KError::FileError(e) => write!(f, "file error {}", e),
-            KError::JsonError(e) => write!(f, "json parsing error {}", e),
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    /* A Cryptoki-style error, see ckrv Error field */
+    CkError,
+    /* The attribute was not found, see errmsg */
+    AttributeNotFound,
+    /* Other error, see origin */
+    Nested,
+}
+
+impl Error {
+    pub fn ck_rv(ckrv: interface::CK_RV) -> Error {
+        Error {
+            kind: ErrorKind::CkError,
+            origin: None,
+            errmsg: None,
+            ckrv: ckrv,
         }
+    }
+
+    pub fn ck_rv_from_error<E>(ckrv: interface::CK_RV, error: E) -> Error
+    where
+        E: Into<Box<dyn error::Error>>,
+    {
+        Error {
+            kind: ErrorKind::CkError,
+            origin: Some(error.into()),
+            errmsg: None,
+            ckrv: ckrv,
+        }
+    }
+
+    pub fn ck_rv_with_errmsg(ckrv: interface::CK_RV, errmsg: String) -> Error {
+        Error {
+            kind: ErrorKind::CkError,
+            origin: None,
+            errmsg: Some(errmsg),
+            ckrv: ckrv,
+        }
+    }
+
+    pub fn not_found(errmsg: String) -> Error {
+        Error {
+            kind: ErrorKind::AttributeNotFound,
+            origin: None,
+            errmsg: Some(errmsg),
+            ckrv: interface::CKR_GENERAL_ERROR,
+        }
+    }
+
+    pub fn other_error<E>(error: E) -> Error
+    where
+        E: Into<Box<dyn error::Error>>,
+    {
+        Error {
+            kind: ErrorKind::Nested,
+            origin: Some(error.into()),
+            errmsg: None,
+            ckrv: interface::CKR_GENERAL_ERROR,
+        }
+    }
+
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    pub fn attr_not_found(&self) -> bool {
+        return self.kind == ErrorKind::AttributeNotFound;
+    }
+
+    pub fn rv(&self) -> interface::CK_RV {
+        self.ckrv
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.kind {
+            ErrorKind::CkError => {
+                if let Some(ref e) = self.errmsg {
+                    write!(f, "{}", e)
+                } else {
+                    match self.ckrv {
+                        interface::CKR_GENERAL_ERROR => {
+                            write!(f, std::stringify!(CKR_GENERAL_ERROR))
+                        }
+                        interface::CKR_ATTRIBUTE_TYPE_INVALID => {
+                            write!(f, "CKR_ATTRIBUTE_TYPE_INVALID")
+                        }
+                        _ => write!(f, "{}", self.ckrv),
+                    }
+                }
+            }
+            ErrorKind::AttributeNotFound => write!(
+                f,
+                "attribute not found: {}",
+                self.errmsg.as_ref().unwrap()
+            ),
+            ErrorKind::Nested => self.origin.as_ref().unwrap().fmt(f),
+        }
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(error: std::io::Error) -> Error {
+        Error::other_error(error)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Error {
+        Error::other_error(error)
     }
 }
 
@@ -65,18 +140,14 @@ macro_rules! some_or_err {
         if let Some(ref x) = $action {
             x
         } else {
-            return Err(KError::RvError(error::CkRvError {
-                rv: interface::CKR_GENERAL_ERROR,
-            }));
+            return Err(error::Error::ck_rv(interface::CKR_GENERAL_ERROR));
         }
     };
     (mut $action:expr) => {
         if let Some(ref mut x) = $action {
             x
         } else {
-            return Err(KError::RvError(error::CkRvError {
-                rv: interface::CKR_GENERAL_ERROR,
-            }));
+            return Err(error::Error::ck_rv(interface::CKR_GENERAL_ERROR));
         }
     };
 }
@@ -84,20 +155,20 @@ macro_rules! some_or_err {
 #[macro_export]
 macro_rules! err_rv {
     ($ck_err:expr) => {
-        Err(KError::RvError(error::CkRvError { rv: $ck_err }))
+        Err(error::Error::ck_rv($ck_err))
     };
 }
 
 #[macro_export]
 macro_rules! err_not_found {
     ($err_str:expr) => {
-        Err(KError::NotFound(error::AttributeNotFound { s: $err_str }))
+        Err(error::Error::not_found($err_str))
     };
 }
 
 #[macro_export]
 macro_rules! to_rv {
     ($ck_err:expr) => {
-        KError::RvError(error::CkRvError { rv: $ck_err })
+        error::Error::ck_rv($ck_err)
     };
 }

--- a/src/fips/indicators.rs
+++ b/src/fips/indicators.rs
@@ -88,7 +88,7 @@ impl ObjectFactory for ValidationFactory {
 pub static VALIDATION_FACTORY: Lazy<Box<dyn ObjectFactory>> =
     Lazy::new(|| Box::new(ValidationFactory::new()));
 
-pub fn insert_fips_validation(token: &mut Token) -> KResult<()> {
+pub fn insert_fips_validation(token: &mut Token) -> Result<()> {
     /* Synthesize a FIPS CKO_VALIDATION object */
     let mut obj = Object::new();
     obj.set_attr(attribute::from_bool(CKA_TOKEN, false))?;
@@ -209,7 +209,7 @@ macro_rules! restrict {
     };
 }
 
-fn flag_to_op(flag: CK_FLAGS) -> KResult<CK_ATTRIBUTE_TYPE> {
+fn flag_to_op(flag: CK_FLAGS) -> Result<CK_ATTRIBUTE_TYPE> {
     Ok(match flag {
         CKF_SIGN => CKA_SIGN,
         CKF_VERIFY => CKA_VERIFY,
@@ -1088,9 +1088,7 @@ pub fn is_approved(
     false
 }
 
-pub fn check_kdf_fips_indicators(
-    kctx: &mut EvpKdfCtx,
-) -> KResult<Option<bool>> {
+pub fn check_kdf_fips_indicators(kctx: &mut EvpKdfCtx) -> Result<Option<bool>> {
     let mut params = OsslParam::with_capacity(1);
     params.add_owned_int(
         name_as_char(OSSL_KDF_PARAM_REDHAT_FIPS_INDICATOR),

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -9,7 +9,7 @@ use super::mechanism;
 use super::object;
 
 use attribute::CkAttrs;
-use error::{KError, KResult};
+use error::Result;
 use interface::*;
 use mechanism::*;
 use object::{Object, ObjectFactories};
@@ -188,14 +188,14 @@ impl Mechanism for HashMechanism {
         &self.info
     }
 
-    fn digest_new(&self, mech: &CK_MECHANISM) -> KResult<Box<dyn Digest>> {
+    fn digest_new(&self, mech: &CK_MECHANISM) -> Result<Box<dyn Digest>> {
         if self.info.flags & CKF_DIGEST != CKF_DIGEST {
             return err_rv!(CKR_MECHANISM_INVALID);
         }
         Ok(Box::new(HashOperation::new(mech.mechanism)?))
     }
 
-    fn derive_operation(&self, mech: &CK_MECHANISM) -> KResult<Operation> {
+    fn derive_operation(&self, mech: &CK_MECHANISM) -> Result<Operation> {
         if self.info.flags & CKF_DERIVE != CKF_DERIVE {
             return err_rv!(CKR_MECHANISM_INVALID);
         }
@@ -226,7 +226,7 @@ struct HashKDFOperation {
 }
 
 impl HashKDFOperation {
-    fn new(prf: CK_MECHANISM_TYPE) -> KResult<HashKDFOperation> {
+    fn new(prf: CK_MECHANISM_TYPE) -> Result<HashKDFOperation> {
         Ok(HashKDFOperation {
             prf: prf,
             finalized: false,
@@ -247,7 +247,7 @@ impl Derive for HashKDFOperation {
         template: &[CK_ATTRIBUTE],
         _mechanisms: &Mechanisms,
         objfactories: &ObjectFactories,
-    ) -> KResult<Vec<Object>> {
+    ) -> Result<Vec<Object>> {
         if self.finalized {
             return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
         }
@@ -310,7 +310,7 @@ impl Derive for HashKDFOperation {
 }
 
 #[cfg(not(feature = "fips"))]
-pub fn internal_hash_op(hash: CK_MECHANISM_TYPE) -> KResult<Box<dyn Digest>> {
+pub fn internal_hash_op(hash: CK_MECHANISM_TYPE) -> Result<Box<dyn Digest>> {
     Ok(Box::new(HashOperation::new(hash)?))
 }
 

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -12,7 +12,7 @@ use super::misc;
 use super::object;
 
 use attribute::from_bytes;
-use error::{KError, KResult};
+use error::Result;
 use hash::INVALID_HASH_SIZE;
 use hmac::hmac_size;
 use interface::*;
@@ -42,7 +42,7 @@ impl Mechanism for HKDFMechanism {
         &self.info
     }
 
-    fn derive_operation(&self, mech: &CK_MECHANISM) -> KResult<Operation> {
+    fn derive_operation(&self, mech: &CK_MECHANISM) -> Result<Operation> {
         if self.info.flags & CKF_DERIVE != CKF_DERIVE {
             return err_rv!(CKR_MECHANISM_INVALID);
         }
@@ -100,7 +100,7 @@ impl HKDFOperation {
         );
     }
 
-    fn verify_key(&self, key: &Object, matchlen: usize) -> KResult<()> {
+    fn verify_key(&self, key: &Object, matchlen: usize) -> Result<()> {
         if let Ok(class) = key.get_attr_as_ulong(CKA_CLASS) {
             match class {
                 CKO_SECRET_KEY => {
@@ -149,7 +149,7 @@ impl HKDFOperation {
         Ok(())
     }
 
-    fn new(mech: &CK_MECHANISM) -> KResult<HKDFOperation> {
+    fn new(mech: &CK_MECHANISM) -> Result<HKDFOperation> {
         let params = cast_params!(mech, CK_HKDF_PARAMS);
         if params.bExtract == CK_FALSE && params.bExpand == CK_FALSE {
             return err_rv!(CKR_MECHANISM_PARAM_INVALID);
@@ -221,7 +221,7 @@ impl MechOperation for HKDFOperation {
     fn fips_approved(&self) -> Option<bool> {
         self.fips_approved
     }
-    fn requires_objects(&self) -> KResult<&[CK_OBJECT_HANDLE]> {
+    fn requires_objects(&self) -> Result<&[CK_OBJECT_HANDLE]> {
         if self.salt_type == CKF_HKDF_SALT_KEY {
             return Ok(&self.salt_key);
         } else {
@@ -229,7 +229,7 @@ impl MechOperation for HKDFOperation {
             return err_rv!(CKR_OK);
         }
     }
-    fn receives_objects(&mut self, objs: &[&Object]) -> KResult<()> {
+    fn receives_objects(&mut self, objs: &[&Object]) -> Result<()> {
         if objs.len() != 1 {
             return err_rv!(CKR_GENERAL_ERROR);
         }

--- a/src/kasn1.rs
+++ b/src/kasn1.rs
@@ -7,7 +7,7 @@ use super::error;
 use super::interface;
 
 use asn1;
-use error::{KError, KResult};
+use error::Result;
 use interface::*;
 use std::borrow::Cow;
 
@@ -18,7 +18,7 @@ pub struct DerEncBigUint<'a> {
 }
 
 impl<'a> DerEncBigUint<'a> {
-    pub fn new(data: &'a [u8]) -> KResult<Self> {
+    pub fn new(data: &'a [u8]) -> Result<Self> {
         let mut de = DerEncBigUint {
             data: Cow::from(data),
         };
@@ -98,7 +98,7 @@ pub struct DerEncOctetString<'a> {
 }
 
 impl<'a> DerEncOctetString<'a> {
-    pub fn new(data: &'a [u8]) -> KResult<Self> {
+    pub fn new(data: &'a [u8]) -> Result<Self> {
         Ok(DerEncOctetString {
             data: Cow::from(data),
         })
@@ -159,7 +159,7 @@ impl PrivateKeyInfo<'_> {
     pub fn new<'a>(
         private_key_asn1: &'a [u8],
         oid: asn1::ObjectIdentifier,
-    ) -> KResult<PrivateKeyInfo<'a>> {
+    ) -> Result<PrivateKeyInfo<'a>> {
         Ok(PrivateKeyInfo {
             version: 0,
             private_key_algorithm: oid,

--- a/src/mechanism.rs
+++ b/src/mechanism.rs
@@ -7,7 +7,7 @@ use super::err_rv;
 use super::error;
 use super::interface;
 use super::object;
-use error::{KError, KResult};
+use error::Result;
 use interface::*;
 use object::{Object, ObjectFactories, ObjectFactory};
 
@@ -19,17 +19,17 @@ pub trait Mechanism: Debug + Send + Sync {
         &self,
         _: &CK_MECHANISM,
         _: &object::Object,
-    ) -> KResult<Box<dyn Encryption>> {
+    ) -> Result<Box<dyn Encryption>> {
         err_rv!(CKR_MECHANISM_INVALID)
     }
     fn decryption_new(
         &self,
         _: &CK_MECHANISM,
         _: &object::Object,
-    ) -> KResult<Box<dyn Decryption>> {
+    ) -> Result<Box<dyn Decryption>> {
         err_rv!(CKR_MECHANISM_INVALID)
     }
-    fn digest_new(&self, _: &CK_MECHANISM) -> KResult<Box<dyn Digest>> {
+    fn digest_new(&self, _: &CK_MECHANISM) -> Result<Box<dyn Digest>> {
         err_rv!(CKR_MECHANISM_INVALID)
     }
     fn mac_new(
@@ -37,21 +37,21 @@ pub trait Mechanism: Debug + Send + Sync {
         _: &CK_MECHANISM,
         _: &object::Object,
         _: CK_FLAGS,
-    ) -> KResult<Box<dyn Mac>> {
+    ) -> Result<Box<dyn Mac>> {
         err_rv!(CKR_MECHANISM_INVALID)
     }
     fn sign_new(
         &self,
         _: &CK_MECHANISM,
         _: &object::Object,
-    ) -> KResult<Box<dyn Sign>> {
+    ) -> Result<Box<dyn Sign>> {
         err_rv!(CKR_MECHANISM_INVALID)
     }
     fn verify_new(
         &self,
         _: &CK_MECHANISM,
         _: &object::Object,
-    ) -> KResult<Box<dyn Verify>> {
+    ) -> Result<Box<dyn Verify>> {
         err_rv!(CKR_MECHANISM_INVALID)
     }
 
@@ -61,7 +61,7 @@ pub trait Mechanism: Debug + Send + Sync {
         _: &[CK_ATTRIBUTE],
         _: &Mechanisms,
         _: &ObjectFactories,
-    ) -> KResult<Object> {
+    ) -> Result<Object> {
         err_rv!(CKR_MECHANISM_INVALID)
     }
 
@@ -70,7 +70,7 @@ pub trait Mechanism: Debug + Send + Sync {
         _: &CK_MECHANISM,
         _pubkey_template: &[CK_ATTRIBUTE],
         _prikey_template: &[CK_ATTRIBUTE],
-    ) -> KResult<(Object, Object)> {
+    ) -> Result<(Object, Object)> {
         err_rv!(CKR_MECHANISM_INVALID)
     }
 
@@ -82,7 +82,7 @@ pub trait Mechanism: Debug + Send + Sync {
         _: CK_BYTE_PTR,
         _: CK_ULONG_PTR,
         _: &Box<dyn ObjectFactory>,
-    ) -> KResult<()> {
+    ) -> Result<()> {
         err_rv!(CKR_MECHANISM_INVALID)
     }
 
@@ -93,11 +93,11 @@ pub trait Mechanism: Debug + Send + Sync {
         _: &[u8],
         _: &[CK_ATTRIBUTE],
         _: &Box<dyn ObjectFactory>,
-    ) -> KResult<Object> {
+    ) -> Result<Object> {
         err_rv!(CKR_MECHANISM_INVALID)
     }
 
-    fn derive_operation(&self, _: &CK_MECHANISM) -> KResult<Operation> {
+    fn derive_operation(&self, _: &CK_MECHANISM) -> Result<Operation> {
         err_rv!(CKR_MECHANISM_INVALID)
     }
 }
@@ -137,7 +137,7 @@ impl Mechanisms {
         }
     }
 
-    pub fn get(&self, typ: CK_MECHANISM_TYPE) -> KResult<&Box<dyn Mechanism>> {
+    pub fn get(&self, typ: CK_MECHANISM_TYPE) -> Result<&Box<dyn Mechanism>> {
         match self.tree.get(&typ) {
             Some(m) => Ok(m),
             None => err_rv!(CKR_MECHANISM_INVALID),
@@ -147,14 +147,14 @@ impl Mechanisms {
 
 pub trait MechOperation: Debug + Send + Sync {
     fn finalized(&self) -> bool;
-    fn reset(&mut self) -> KResult<()> {
+    fn reset(&mut self) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn requires_objects(&self) -> KResult<&[CK_OBJECT_HANDLE]> {
+    fn requires_objects(&self) -> Result<&[CK_OBJECT_HANDLE]> {
         /* nothing needed by default */
         err_rv!(CKR_OK)
     }
-    fn receives_objects(&mut self, _: &[&Object]) -> KResult<()> {
+    fn receives_objects(&mut self, _: &[&Object]) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
     #[cfg(feature = "fips")]
@@ -169,7 +169,7 @@ pub trait Encryption: MechOperation {
         _plain: &[u8],
         _cipher: CK_BYTE_PTR,
         _cipher_len: CK_ULONG_PTR,
-    ) -> KResult<()> {
+    ) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
     fn encrypt_update(
@@ -177,17 +177,17 @@ pub trait Encryption: MechOperation {
         _plain: &[u8],
         _cipher: CK_BYTE_PTR,
         _cipher_len: CK_ULONG_PTR,
-    ) -> KResult<()> {
+    ) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
     fn encrypt_final(
         &mut self,
         _cipher: CK_BYTE_PTR,
         _cipher_len: CK_ULONG_PTR,
-    ) -> KResult<()> {
+    ) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn encryption_len(&self, _data_len: CK_ULONG) -> KResult<usize> {
+    fn encryption_len(&self, _data_len: CK_ULONG) -> Result<usize> {
         err_rv!(CKR_GENERAL_ERROR)
     }
 }
@@ -198,7 +198,7 @@ pub trait Decryption: MechOperation {
         _cipher: &[u8],
         _plain: CK_BYTE_PTR,
         _plain_len: CK_ULONG_PTR,
-    ) -> KResult<()> {
+    ) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
     fn decrypt_update(
@@ -206,85 +206,85 @@ pub trait Decryption: MechOperation {
         _cipher: &[u8],
         _plain: CK_BYTE_PTR,
         _plain_len: CK_ULONG_PTR,
-    ) -> KResult<()> {
+    ) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
     fn decrypt_final(
         &mut self,
         _plain: CK_BYTE_PTR,
         _plain_len: CK_ULONG_PTR,
-    ) -> KResult<()> {
+    ) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn decryption_len(&self, _data_len: CK_ULONG) -> KResult<usize> {
+    fn decryption_len(&self, _data_len: CK_ULONG) -> Result<usize> {
         err_rv!(CKR_GENERAL_ERROR)
     }
 }
 
 pub trait SearchOperation: Debug + Send + Sync {
     fn finalized(&self) -> bool;
-    fn results(&mut self, _max: usize) -> KResult<Vec<CK_OBJECT_HANDLE>> {
+    fn results(&mut self, _max: usize) -> Result<Vec<CK_OBJECT_HANDLE>> {
         err_rv!(CKR_GENERAL_ERROR)
     }
 }
 
 pub trait Digest: MechOperation {
-    fn digest(&mut self, _data: &[u8], _digest: &mut [u8]) -> KResult<()> {
+    fn digest(&mut self, _data: &[u8], _digest: &mut [u8]) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn digest_update(&mut self, _data: &[u8]) -> KResult<()> {
+    fn digest_update(&mut self, _data: &[u8]) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn digest_final(&mut self, _digest: &mut [u8]) -> KResult<()> {
+    fn digest_final(&mut self, _digest: &mut [u8]) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn digest_len(&self) -> KResult<usize> {
+    fn digest_len(&self) -> Result<usize> {
         err_rv!(CKR_GENERAL_ERROR)
     }
 }
 
 pub trait Mac: MechOperation {
-    fn mac(&mut self, _data: &[u8], _digest: &mut [u8]) -> KResult<()> {
+    fn mac(&mut self, _data: &[u8], _digest: &mut [u8]) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn mac_update(&mut self, _data: &[u8]) -> KResult<()> {
+    fn mac_update(&mut self, _data: &[u8]) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn mac_final(&mut self, _digest: &mut [u8]) -> KResult<()> {
+    fn mac_final(&mut self, _digest: &mut [u8]) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn mac_len(&self) -> KResult<usize> {
+    fn mac_len(&self) -> Result<usize> {
         err_rv!(CKR_GENERAL_ERROR)
     }
 }
 
 pub trait Sign: MechOperation {
-    fn sign(&mut self, _data: &[u8], _signature: &mut [u8]) -> KResult<()> {
+    fn sign(&mut self, _data: &[u8], _signature: &mut [u8]) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn sign_update(&mut self, _data: &[u8]) -> KResult<()> {
+    fn sign_update(&mut self, _data: &[u8]) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn sign_final(&mut self, _signature: &mut [u8]) -> KResult<()> {
+    fn sign_final(&mut self, _signature: &mut [u8]) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn signature_len(&self) -> KResult<usize> {
+    fn signature_len(&self) -> Result<usize> {
         err_rv!(CKR_GENERAL_ERROR)
     }
 }
 
 pub trait Verify: MechOperation {
-    fn verify(&mut self, _data: &[u8], _signature: &[u8]) -> KResult<()> {
+    fn verify(&mut self, _data: &[u8], _signature: &[u8]) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn verify_update(&mut self, _data: &[u8]) -> KResult<()> {
+    fn verify_update(&mut self, _data: &[u8]) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn verify_final(&mut self, _signature: &[u8]) -> KResult<()> {
+    fn verify_final(&mut self, _signature: &[u8]) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
 
-    fn signature_len(&self) -> KResult<usize> {
+    fn signature_len(&self) -> Result<usize> {
         err_rv!(CKR_GENERAL_ERROR)
     }
 }
@@ -296,7 +296,7 @@ pub trait Derive: MechOperation {
         _: &[CK_ATTRIBUTE],
         _: &Mechanisms,
         _: &ObjectFactories,
-    ) -> KResult<Vec<Object>> {
+    ) -> Result<Vec<Object>> {
         err_rv!(CKR_GENERAL_ERROR)
     }
 }
@@ -334,13 +334,13 @@ pub trait DRBG: Debug + Send + Sync {
         _entropy: &[u8],
         _nonce: &[u8],
         _pers: &[u8],
-    ) -> KResult<()> {
+    ) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn reseed(&mut self, _entropy: &[u8], _addtl: &[u8]) -> KResult<()> {
+    fn reseed(&mut self, _entropy: &[u8], _addtl: &[u8]) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn generate(&mut self, _addtl: &[u8], _output: &mut [u8]) -> KResult<()> {
+    fn generate(&mut self, _addtl: &[u8], _output: &mut [u8]) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
 }

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -9,7 +9,7 @@ use super::interface;
 use super::object;
 
 use attribute::{from_ulong, CkAttrs};
-use error::{KError, KResult};
+use error::Result;
 use interface::*;
 
 pub const CK_ULONG_SIZE: usize = std::mem::size_of::<interface::CK_ULONG>();
@@ -87,7 +87,7 @@ pub fn common_derive_data_object(
     template: &[CK_ATTRIBUTE],
     objfactories: &object::ObjectFactories,
     default_len: usize,
-) -> KResult<(object::Object, usize)> {
+) -> Result<(object::Object, usize)> {
     let default_class = CKO_DATA;
     let mut tmpl = CkAttrs::from(template);
     tmpl.add_missing_ulong(CKA_CLASS, &default_class);
@@ -115,7 +115,7 @@ pub fn common_derive_key_object(
     template: &[CK_ATTRIBUTE],
     objfactories: &object::ObjectFactories,
     default_len: usize,
-) -> KResult<(object::Object, usize)> {
+) -> Result<(object::Object, usize)> {
     let default_class = CKO_SECRET_KEY;
     let mut tmpl = CkAttrs::from(template);
     tmpl.add_missing_ulong(CKA_CLASS, &default_class);

--- a/src/ossl.rs
+++ b/src/ossl.rs
@@ -12,7 +12,7 @@ use once_cell::sync::Lazy;
 use super::err_rv;
 use super::error;
 use super::interface;
-use error::{KError, KResult};
+use error::Result;
 use interface::CKR_DEVICE_ERROR;
 
 use std::os::raw::{c_char, c_void};

--- a/src/ossl/aes_mac.rs
+++ b/src/ossl/aes_mac.rs
@@ -28,7 +28,7 @@ impl AesMacOperation {
         }
     }
 
-    fn init(mech: &CK_MECHANISM, key: &Object) -> KResult<AesMacOperation> {
+    fn init(mech: &CK_MECHANISM, key: &Object) -> Result<AesMacOperation> {
         let maclen = match mech.mechanism {
             CKM_AES_MAC_GENERAL => {
                 let params = cast_params!(mech, CK_MAC_GENERAL_PARAMS);
@@ -65,14 +65,14 @@ impl AesMacOperation {
         })
     }
 
-    fn begin(&mut self) -> KResult<()> {
+    fn begin(&mut self) -> Result<()> {
         if self.in_use {
             return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
         }
         Ok(())
     }
 
-    fn update(&mut self, data: &[u8]) -> KResult<()> {
+    fn update(&mut self, data: &[u8]) -> Result<()> {
         if self.finalized {
             return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
         }
@@ -133,7 +133,7 @@ impl AesMacOperation {
         Ok(())
     }
 
-    fn finalize(&mut self, output: &mut [u8]) -> KResult<()> {
+    fn finalize(&mut self, output: &mut [u8]) -> Result<()> {
         if !self.in_use {
             return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
         }
@@ -176,37 +176,37 @@ impl MechOperation for AesMacOperation {
 }
 
 impl Sign for AesMacOperation {
-    fn sign(&mut self, data: &[u8], signature: &mut [u8]) -> KResult<()> {
+    fn sign(&mut self, data: &[u8], signature: &mut [u8]) -> Result<()> {
         self.begin()?;
         self.update(data)?;
         self.finalize(signature)
     }
 
-    fn sign_update(&mut self, data: &[u8]) -> KResult<()> {
+    fn sign_update(&mut self, data: &[u8]) -> Result<()> {
         self.update(data)
     }
 
-    fn sign_final(&mut self, signature: &mut [u8]) -> KResult<()> {
+    fn sign_final(&mut self, signature: &mut [u8]) -> Result<()> {
         self.finalize(signature)
     }
 
-    fn signature_len(&self) -> KResult<usize> {
+    fn signature_len(&self) -> Result<usize> {
         Ok(self.maclen)
     }
 }
 
 impl Verify for AesMacOperation {
-    fn verify(&mut self, data: &[u8], signature: &[u8]) -> KResult<()> {
+    fn verify(&mut self, data: &[u8], signature: &[u8]) -> Result<()> {
         self.begin()?;
         self.update(data)?;
         self.verify_final(signature)
     }
 
-    fn verify_update(&mut self, data: &[u8]) -> KResult<()> {
+    fn verify_update(&mut self, data: &[u8]) -> Result<()> {
         self.update(data)
     }
 
-    fn verify_final(&mut self, signature: &[u8]) -> KResult<()> {
+    fn verify_final(&mut self, signature: &[u8]) -> Result<()> {
         let mut verify: Vec<u8> = vec![0; self.maclen];
         self.finalize(verify.as_mut_slice())?;
         if !constant_time_eq(&verify, signature) {
@@ -215,7 +215,7 @@ impl Verify for AesMacOperation {
         Ok(())
     }
 
-    fn signature_len(&self) -> KResult<usize> {
+    fn signature_len(&self) -> Result<usize> {
         Ok(self.maclen)
     }
 }

--- a/src/ossl/common.rs
+++ b/src/ossl/common.rs
@@ -49,7 +49,7 @@ macro_rules! ptr_wrapper {
         ptr_wrapper_struct!($name; $ossl);
 
         impl $name {
-            pub fn new() -> KResult<$name> {
+            pub fn new() -> Result<$name> {
                 let ptr = unsafe {
                     $newctx()
                 };
@@ -69,7 +69,7 @@ macro_rules! ptr_wrapper {
         ptr_wrapper_struct!($name; $ossl);
 
         impl $name {
-            pub fn new(name: *const c_char) -> KResult<$name> {
+            pub fn new(name: *const c_char) -> Result<$name> {
                 let arg = unsafe {
                     $in_fetch(get_libctx(), name, std::ptr::null_mut())
                 };
@@ -100,7 +100,7 @@ macro_rules! ptr_wrapper {
         ptr_wrapper_struct!($name; $ossl);
 
         impl $name {
-            pub fn new(name: *const c_char) -> KResult<$name> {
+            pub fn new(name: *const c_char) -> Result<$name> {
                 let ptr = unsafe {
                     $fetch(get_libctx(), name, std::ptr::null_mut())
                 };
@@ -132,7 +132,7 @@ pub struct EvpPkeyCtx {
 }
 
 impl EvpPkeyCtx {
-    pub fn new(name: *const c_char) -> KResult<EvpPkeyCtx> {
+    pub fn new(name: *const c_char) -> Result<EvpPkeyCtx> {
         let ptr = unsafe {
             EVP_PKEY_CTX_new_from_name(get_libctx(), name, std::ptr::null())
         };
@@ -142,7 +142,7 @@ impl EvpPkeyCtx {
         Ok(EvpPkeyCtx { ptr: ptr })
     }
 
-    pub unsafe fn from_ptr(ptr: *mut EVP_PKEY_CTX) -> KResult<EvpPkeyCtx> {
+    pub unsafe fn from_ptr(ptr: *mut EVP_PKEY_CTX) -> Result<EvpPkeyCtx> {
         if ptr.is_null() {
             return err_rv!(CKR_DEVICE_ERROR);
         }
@@ -179,7 +179,7 @@ impl EvpPkey {
         pkey_name: *const c_char,
         pkey_type: u32,
         params: &OsslParam,
-    ) -> KResult<EvpPkey> {
+    ) -> Result<EvpPkey> {
         let mut ctx = EvpPkeyCtx::new(pkey_name)?;
         let res = unsafe { EVP_PKEY_fromdata_init(ctx.as_mut_ptr()) };
         if res != 1 {
@@ -203,7 +203,7 @@ impl EvpPkey {
     pub fn generate(
         pkey_name: *const c_char,
         params: &OsslParam,
-    ) -> KResult<EvpPkey> {
+    ) -> Result<EvpPkey> {
         let mut ctx = EvpPkeyCtx::new(pkey_name)?;
         let res = unsafe { EVP_PKEY_keygen_init(ctx.as_mut_ptr()) };
         if res != 1 {
@@ -223,7 +223,7 @@ impl EvpPkey {
         Ok(EvpPkey { ptr: pkey })
     }
 
-    pub fn new_ctx(&mut self) -> KResult<EvpPkeyCtx> {
+    pub fn new_ctx(&mut self) -> Result<EvpPkeyCtx> {
         /* this function takes care of checking for NULL */
         unsafe {
             EvpPkeyCtx::from_ptr(
@@ -306,7 +306,7 @@ impl<'a> OsslParam<'a> {
         }
     }
 
-    pub fn from_ptr(ptr: *mut OSSL_PARAM) -> KResult<OsslParam<'static>> {
+    pub fn from_ptr(ptr: *mut OSSL_PARAM) -> Result<OsslParam<'static>> {
         if ptr.is_null() {
             return err_rv!(CKR_DEVICE_ERROR);
         }
@@ -341,7 +341,7 @@ impl<'a> OsslParam<'a> {
         p
     }
 
-    pub fn add_bn(&mut self, key: *const c_char, v: &Vec<u8>) -> KResult<()> {
+    pub fn add_bn(&mut self, key: *const c_char, v: &Vec<u8>) -> Result<()> {
         if self.finalized {
             return err_rv!(CKR_GENERAL_ERROR);
         }
@@ -397,7 +397,7 @@ impl<'a> OsslParam<'a> {
         &mut self,
         key: *const c_char,
         v: &'a Vec<u8>,
-    ) -> KResult<()> {
+    ) -> Result<()> {
         if self.finalized {
             return err_rv!(CKR_GENERAL_ERROR);
         }
@@ -417,7 +417,7 @@ impl<'a> OsslParam<'a> {
         &mut self,
         key: *const c_char,
         v: Vec<u8>,
-    ) -> KResult<()> {
+    ) -> Result<()> {
         if self.finalized {
             return err_rv!(CKR_GENERAL_ERROR);
         }
@@ -442,7 +442,7 @@ impl<'a> OsslParam<'a> {
         &mut self,
         key: *const c_char,
         val: *const c_char,
-    ) -> KResult<()> {
+    ) -> Result<()> {
         if self.finalized {
             return err_rv!(CKR_GENERAL_ERROR);
         }
@@ -461,7 +461,7 @@ impl<'a> OsslParam<'a> {
         &mut self,
         key: *const c_char,
         v: &'a Vec<u8>,
-    ) -> KResult<()> {
+    ) -> Result<()> {
         if self.finalized {
             return err_rv!(CKR_GENERAL_ERROR);
         }
@@ -485,7 +485,7 @@ impl<'a> OsslParam<'a> {
         &mut self,
         key: *const c_char,
         val: &'a usize,
-    ) -> KResult<()> {
+    ) -> Result<()> {
         if self.finalized {
             return err_rv!(CKR_GENERAL_ERROR);
         }
@@ -505,7 +505,7 @@ impl<'a> OsslParam<'a> {
         &mut self,
         key: *const c_char,
         val: &'a c_uint,
-    ) -> KResult<()> {
+    ) -> Result<()> {
         if self.finalized {
             return err_rv!(CKR_GENERAL_ERROR);
         }
@@ -525,7 +525,7 @@ impl<'a> OsslParam<'a> {
         &mut self,
         key: *const c_char,
         val: &'a c_int,
-    ) -> KResult<()> {
+    ) -> Result<()> {
         if self.finalized {
             return err_rv!(CKR_GENERAL_ERROR);
         }
@@ -545,7 +545,7 @@ impl<'a> OsslParam<'a> {
         &mut self,
         key: *const c_char,
         val: c_uint,
-    ) -> KResult<()> {
+    ) -> Result<()> {
         if self.finalized {
             return err_rv!(CKR_GENERAL_ERROR);
         }
@@ -571,7 +571,7 @@ impl<'a> OsslParam<'a> {
         &mut self,
         key: *const c_char,
         val: c_int,
-    ) -> KResult<()> {
+    ) -> Result<()> {
         if self.finalized {
             return err_rv!(CKR_GENERAL_ERROR);
         }
@@ -611,7 +611,7 @@ impl<'a> OsslParam<'a> {
         self.p.to_mut().as_mut_ptr()
     }
 
-    pub fn get_int(&self, key: *const c_char) -> KResult<c_int> {
+    pub fn get_int(&self, key: *const c_char) -> Result<c_int> {
         if !self.finalized {
             return err_rv!(CKR_GENERAL_ERROR);
         }
@@ -629,7 +629,7 @@ impl<'a> OsslParam<'a> {
         Ok(val)
     }
 
-    pub fn get_bn(&self, key: *const c_char) -> KResult<Vec<u8>> {
+    pub fn get_bn(&self, key: *const c_char) -> Result<Vec<u8>> {
         if !self.finalized {
             return err_rv!(CKR_GENERAL_ERROR);
         }
@@ -660,7 +660,7 @@ impl<'a> OsslParam<'a> {
         Ok(vec)
     }
 
-    pub fn get_octet_string(&self, key: *const c_char) -> KResult<&'a [u8]> {
+    pub fn get_octet_string(&self, key: *const c_char) -> Result<&'a [u8]> {
         if !self.finalized {
             return err_rv!(CKR_GENERAL_ERROR);
         }

--- a/src/ossl/drbg.rs
+++ b/src/ossl/drbg.rs
@@ -2,7 +2,7 @@ use super::err_rv;
 use super::error;
 use super::interface;
 use super::mechanism;
-use error::{KError, KResult};
+use error::Result;
 use interface::*;
 use mechanism::*;
 use std::fmt::Debug;
@@ -28,7 +28,7 @@ impl Drop for HmacSha256Drbg {
 }
 
 impl HmacSha256Drbg {
-    pub fn new() -> KResult<HmacSha256Drbg> {
+    pub fn new() -> Result<HmacSha256Drbg> {
         unsafe {
             let rng_spec: &[u8; 10] = b"HMAC-DRBG\0";
             let rand = EVP_RAND_fetch(
@@ -56,7 +56,7 @@ impl DRBG for HmacSha256Drbg {
         _entropy: &[u8],
         _nonce: &[u8],
         pers: &[u8],
-    ) -> KResult<()> {
+    ) -> Result<()> {
         unsafe {
             let rng_mac = b"HMAC\0";
             let rng_digest = b"SHA256\0";
@@ -89,7 +89,7 @@ impl DRBG for HmacSha256Drbg {
         self.initialized = true;
         Ok(())
     }
-    fn reseed(&mut self, entropy: &[u8], addtl: &[u8]) -> KResult<()> {
+    fn reseed(&mut self, entropy: &[u8], addtl: &[u8]) -> Result<()> {
         if !self.initialized {
             return err_rv!(CKR_GENERAL_ERROR);
         }
@@ -108,7 +108,7 @@ impl DRBG for HmacSha256Drbg {
         }
         Ok(())
     }
-    fn generate(&mut self, addtl: &[u8], output: &mut [u8]) -> KResult<()> {
+    fn generate(&mut self, addtl: &[u8], output: &mut [u8]) -> Result<()> {
         if !self.initialized {
             return err_rv!(CKR_GENERAL_ERROR);
         }
@@ -148,7 +148,7 @@ impl Drop for HmacSha512Drbg {
 }
 
 impl HmacSha512Drbg {
-    pub fn new() -> KResult<HmacSha512Drbg> {
+    pub fn new() -> Result<HmacSha512Drbg> {
         unsafe {
             let rng_spec = b"HMAC-DRBG\0";
             let rand = EVP_RAND_fetch(
@@ -176,7 +176,7 @@ impl DRBG for HmacSha512Drbg {
         _entropy: &[u8],
         _nonce: &[u8],
         pers: &[u8],
-    ) -> KResult<()> {
+    ) -> Result<()> {
         unsafe {
             let rng_mac = b"HMAC\0";
             let rng_digest = b"SHA512\0";
@@ -209,7 +209,7 @@ impl DRBG for HmacSha512Drbg {
         self.initialized = true;
         Ok(())
     }
-    fn reseed(&mut self, entropy: &[u8], addtl: &[u8]) -> KResult<()> {
+    fn reseed(&mut self, entropy: &[u8], addtl: &[u8]) -> Result<()> {
         if !self.initialized {
             return err_rv!(CKR_GENERAL_ERROR);
         }
@@ -228,7 +228,7 @@ impl DRBG for HmacSha512Drbg {
         }
         Ok(())
     }
-    fn generate(&mut self, addtl: &[u8], output: &mut [u8]) -> KResult<()> {
+    fn generate(&mut self, addtl: &[u8], output: &mut [u8]) -> Result<()> {
         if !self.initialized {
             return err_rv!(CKR_GENERAL_ERROR);
         }

--- a/src/ossl/hkdf.rs
+++ b/src/ossl/hkdf.rs
@@ -11,7 +11,7 @@ impl Derive for HKDFOperation {
         template: &[CK_ATTRIBUTE],
         _mechanisms: &Mechanisms,
         objfactories: &ObjectFactories,
-    ) -> KResult<Vec<Object>> {
+    ) -> Result<Vec<Object>> {
         if self.finalized {
             return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
         }

--- a/src/ossl/hmac.rs
+++ b/src/ossl/hmac.rs
@@ -18,7 +18,7 @@ impl HMACOperation {
         hash: CK_MECHANISM_TYPE,
         key: HmacKey,
         outputlen: usize,
-    ) -> KResult<HMACOperation> {
+    ) -> Result<HMACOperation> {
         let mut ctx = EvpMacCtx::new(name_as_char(OSSL_MAC_NAME_HMAC))?;
         let mut params = OsslParam::with_capacity(1);
         params.add_const_c_string(
@@ -48,14 +48,14 @@ impl HMACOperation {
         })
     }
 
-    fn begin(&mut self) -> KResult<()> {
+    fn begin(&mut self) -> Result<()> {
         if self.in_use {
             return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
         }
         Ok(())
     }
 
-    fn update(&mut self, data: &[u8]) -> KResult<()> {
+    fn update(&mut self, data: &[u8]) -> Result<()> {
         if self.finalized {
             return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
         }
@@ -71,7 +71,7 @@ impl HMACOperation {
         Ok(())
     }
 
-    fn finalize(&mut self, output: &mut [u8]) -> KResult<()> {
+    fn finalize(&mut self, output: &mut [u8]) -> Result<()> {
         if self.finalized {
             return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
         }
@@ -106,7 +106,7 @@ impl HMACOperation {
         Ok(())
     }
 
-    fn reinit(&mut self) -> KResult<()> {
+    fn reinit(&mut self) -> Result<()> {
         if unsafe {
             EVP_MAC_init(
                 self.ctx.as_mut_ptr(),

--- a/src/ossl/kbkdf.rs
+++ b/src/ossl/kbkdf.rs
@@ -9,7 +9,7 @@ const SP800_MODE_FEEDBACK: &[u8; 9] = b"feedback\0";
 fn prep_counter_kdf<'a>(
     sparams: &'a Vec<Sp800Params>,
     params: &mut OsslParam<'a>,
-) -> KResult<()> {
+) -> Result<()> {
     if sparams.len() < 1 {
         return err_rv!(CKR_MECHANISM_PARAM_INVALID);
     }
@@ -119,7 +119,7 @@ fn prep_counter_kdf<'a>(
 fn prep_feedback_kdf<'a>(
     sparams: &'a Vec<Sp800Params>,
     params: &mut OsslParam<'a>,
-) -> KResult<()> {
+) -> Result<()> {
     if sparams.len() < 1 {
         return err_rv!(CKR_MECHANISM_PARAM_INVALID);
     }
@@ -242,7 +242,7 @@ fn prep_feedback_kdf<'a>(
 fn get_segment_size(
     mechanisms: &Mechanisms,
     hmac: CK_MECHANISM_TYPE,
-) -> KResult<usize> {
+) -> Result<usize> {
     let mech = CK_MECHANISM {
         mechanism: match hmac {
             CKM_SHA_1_HMAC => CKM_SHA_1,
@@ -277,7 +277,7 @@ impl Derive for Sp800Operation {
         template: &[CK_ATTRIBUTE],
         mechanisms: &Mechanisms,
         objfactories: &ObjectFactories,
-    ) -> KResult<Vec<Object>> {
+    ) -> Result<Vec<Object>> {
         if self.finalized {
             return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
         }

--- a/src/ossl/pbkdf2.rs
+++ b/src/ossl/pbkdf2.rs
@@ -6,7 +6,7 @@ use core::ffi::c_uint;
 use fips::*;
 
 impl PBKDF2 {
-    fn derive(&self, _: &Mechanisms, len: usize) -> KResult<Vec<u8>> {
+    fn derive(&self, _: &Mechanisms, len: usize) -> Result<Vec<u8>> {
         let mut params = OsslParam::with_capacity(4);
         params.zeroize = true;
         params.add_octet_string(

--- a/src/ossl/sshkdf.rs
+++ b/src/ossl/sshkdf.rs
@@ -8,7 +8,7 @@ impl Derive for SSHKDFOperation {
         template: &[CK_ATTRIBUTE],
         _mechanisms: &Mechanisms,
         objfactories: &ObjectFactories,
-    ) -> KResult<Vec<Object>> {
+    ) -> Result<Vec<Object>> {
         if self.finalized {
             return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
         }

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -10,7 +10,7 @@ use super::object;
 use super::{cast_params, err_rv};
 
 use attribute::{from_bool, from_bytes, from_ulong, CkAttrs};
-use error::{KError, KResult};
+use error::Result;
 use interface::*;
 use mechanism::*;
 use object::{Object, ObjectFactories};
@@ -45,7 +45,7 @@ impl PBKDF2Mechanism {
         );
     }
 
-    fn mock_password_object(&self, key: Vec<u8>) -> KResult<Object> {
+    fn mock_password_object(&self, key: Vec<u8>) -> Result<Object> {
         let mut obj = Object::new();
         obj.set_zeroize();
         obj.set_attr(from_ulong(CKA_CLASS, CKO_SECRET_KEY))?;
@@ -68,7 +68,7 @@ impl Mechanism for PBKDF2Mechanism {
         template: &[CK_ATTRIBUTE],
         mechanisms: &Mechanisms,
         objfactories: &ObjectFactories,
-    ) -> KResult<Object> {
+    ) -> Result<Object> {
         if self.info.flags & CKF_GENERATE != CKF_GENERATE {
             return err_rv!(CKR_MECHANISM_INVALID);
         }
@@ -171,7 +171,7 @@ impl PBKDF2 {
         mech: &Box<dyn Mechanism>,
         i: &[u8],
         o: &mut [u8],
-    ) -> KResult<()> {
+    ) -> Result<()> {
         mech.mac_new(
             &CK_MECHANISM {
                 mechanism: self.prf,
@@ -184,11 +184,7 @@ impl PBKDF2 {
         .mac(i, o)
     }
 
-    fn derive(
-        &self,
-        mechanisms: &Mechanisms,
-        dklen: usize,
-    ) -> KResult<Vec<u8>> {
+    fn derive(&self, mechanisms: &Mechanisms, dklen: usize) -> Result<Vec<u8>> {
         let hlen = hmac::hmac_size(self.prf);
         if hlen == CK_UNAVAILABLE_INFORMATION as usize {
             return err_rv!(CKR_MECHANISM_INVALID);

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -7,7 +7,7 @@ use super::error;
 use super::interface;
 use super::mechanism;
 
-use error::{KError, KResult};
+use error::Result;
 use interface::*;
 
 #[derive(Debug)]
@@ -16,7 +16,7 @@ pub struct RNG {
 }
 
 impl RNG {
-    pub fn new(alg: &str) -> KResult<RNG> {
+    pub fn new(alg: &str) -> Result<RNG> {
         match alg {
             "HMAC DRBG SHA256" => Ok(RNG {
                 drbg: Box::new(drbg::HmacSha256Drbg::new()?),
@@ -28,7 +28,7 @@ impl RNG {
         }
     }
 
-    pub fn generate_random(&mut self, buffer: &mut [u8]) -> KResult<()> {
+    pub fn generate_random(&mut self, buffer: &mut [u8]) -> Result<()> {
         let noaddtl: [u8; 0] = [];
         self.drbg.generate(&noaddtl, buffer)
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -9,7 +9,7 @@ use super::mechanism;
 use super::token;
 
 use super::err_rv;
-use error::{KError, KResult};
+use error::Result;
 use interface::*;
 use mechanism::{Operation, SearchOperation};
 use token::Token;
@@ -24,7 +24,7 @@ pub struct SessionSearch {
 }
 
 impl SearchOperation for SessionSearch {
-    fn results(&mut self, max: usize) -> KResult<Vec<CK_OBJECT_HANDLE>> {
+    fn results(&mut self, max: usize) -> Result<Vec<CK_OBJECT_HANDLE>> {
         if !self.in_use {
             return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
         }
@@ -63,7 +63,7 @@ impl Session {
         slotid: CK_SLOT_ID,
         user_type: CK_USER_TYPE,
         flags: CK_FLAGS,
-    ) -> KResult<Session> {
+    ) -> Result<Session> {
         if flags & CKF_SERIAL_SESSION != CKF_SERIAL_SESSION {
             return err_rv!(CKR_ARGUMENTS_BAD);
         }
@@ -197,7 +197,7 @@ impl Session {
         &mut self,
         token: &mut Token,
         template: &[CK_ATTRIBUTE],
-    ) -> KResult<()> {
+    ) -> Result<()> {
         if !self.operation.finalized() {
             return err_rv!(CKR_OPERATION_ACTIVE);
         }
@@ -214,7 +214,7 @@ impl Session {
         &self.operation
     }
 
-    pub fn get_operation(&self) -> KResult<&Operation> {
+    pub fn get_operation(&self) -> Result<&Operation> {
         match self.login_status {
             OpLoginStatus::NotInitialized => err_rv!(CKR_GENERAL_ERROR),
             OpLoginStatus::NotRequired => Ok(&self.operation),
@@ -223,7 +223,7 @@ impl Session {
         }
     }
 
-    pub fn get_operation_mut(&mut self) -> KResult<&mut Operation> {
+    pub fn get_operation_mut(&mut self) -> Result<&mut Operation> {
         match self.login_status {
             OpLoginStatus::NotInitialized => err_rv!(CKR_GENERAL_ERROR),
             OpLoginStatus::NotRequired => Ok(&mut self.operation),

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -10,7 +10,7 @@ use super::session::Session;
 use super::token::Token;
 
 use super::err_rv;
-use error::{KError, KResult};
+use error::Result;
 use interface::*;
 
 static SLOT_DESCRIPTION: [CK_UTF8CHAR; 64usize] =
@@ -26,7 +26,7 @@ pub struct Slot {
 }
 
 impl Slot {
-    pub fn new(filename: String) -> KResult<Slot> {
+    pub fn new(filename: String) -> Result<Slot> {
         Ok(Slot {
             slot_info: CK_SLOT_INFO {
                 slotDescription: SLOT_DESCRIPTION,
@@ -49,7 +49,7 @@ impl Slot {
         *tok.get_token_info()
     }
 
-    pub fn get_token(&self) -> KResult<RwLockReadGuard<'_, Token>> {
+    pub fn get_token(&self) -> Result<RwLockReadGuard<'_, Token>> {
         match self.token.read() {
             Ok(token) => {
                 if token.is_initialized() {
@@ -67,7 +67,7 @@ impl Slot {
     pub fn get_token_mut(
         &self,
         nochecks: bool,
-    ) -> KResult<RwLockWriteGuard<'_, Token>> {
+    ) -> Result<RwLockWriteGuard<'_, Token>> {
         match self.token.write() {
             Ok(token) => {
                 if nochecks {
@@ -91,7 +91,7 @@ impl Slot {
     pub fn get_session(
         &self,
         handle: CK_SESSION_HANDLE,
-    ) -> KResult<RwLockReadGuard<'_, Session>> {
+    ) -> Result<RwLockReadGuard<'_, Session>> {
         match self.sessions.get(&handle) {
             Some(s) => match s.read() {
                 Ok(sess) => Ok(sess),
@@ -104,7 +104,7 @@ impl Slot {
     pub fn get_session_mut(
         &self,
         handle: CK_SESSION_HANDLE,
-    ) -> KResult<RwLockWriteGuard<'_, Session>> {
+    ) -> Result<RwLockWriteGuard<'_, Session>> {
         match self.sessions.get(&handle) {
             Some(s) => match s.write() {
                 Ok(sess) => Ok(sess),
@@ -128,10 +128,7 @@ impl Slot {
         false
     }
 
-    pub fn change_session_states(
-        &self,
-        user_type: CK_USER_TYPE,
-    ) -> KResult<()> {
+    pub fn change_session_states(&self, user_type: CK_USER_TYPE) -> Result<()> {
         for (_key, val) in self.sessions.iter() {
             let ret = val.write().unwrap().change_session_state(user_type);
             if ret != CKR_OK {
@@ -164,7 +161,7 @@ impl Slot {
         handles
     }
 
-    pub fn finalize(&mut self) -> KResult<()> {
+    pub fn finalize(&mut self) -> Result<()> {
         self.drop_all_sessions();
         self.token.write().unwrap().save()
     }

--- a/src/sshkdf.rs
+++ b/src/sshkdf.rs
@@ -11,7 +11,7 @@ use super::misc;
 use super::object;
 
 use attribute::from_bytes;
-use error::{KError, KResult};
+use error::Result;
 use interface::*;
 use mechanism::*;
 use object::{Object, ObjectFactories};
@@ -37,7 +37,7 @@ impl Mechanism for SSHKDFMechanism {
         &self.info
     }
 
-    fn derive_operation(&self, mech: &CK_MECHANISM) -> KResult<Operation> {
+    fn derive_operation(&self, mech: &CK_MECHANISM) -> Result<Operation> {
         if self.info.flags & CKF_DERIVE != CKF_DERIVE {
             return err_rv!(CKR_MECHANISM_INVALID);
         }
@@ -77,7 +77,7 @@ impl SSHKDFOperation {
         );
     }
 
-    fn new(mech: &CK_MECHANISM) -> KResult<SSHKDFOperation> {
+    fn new(mech: &CK_MECHANISM) -> Result<SSHKDFOperation> {
         let params = cast_params!(mech, KR_SSHKDF_PARAMS);
 
         if !hash::is_valid_hash(params.prfHashMechanism) {
@@ -128,7 +128,7 @@ impl Derive for SSHKDFOperation {
         template: &[CK_ATTRIBUTE],
         mechanisms: &Mechanisms,
         objfactories: &ObjectFactories,
-    ) -> KResult<Vec<Object>> {
+    ) -> Result<Vec<Object>> {
         if self.finalized {
             return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
         }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -5,20 +5,20 @@ use super::error;
 use super::interface;
 use super::object;
 
-use error::KResult;
+use error::Result;
 use interface::CK_ATTRIBUTE;
 use object::Object;
 
 use std::fmt::Debug;
 
 pub trait Storage: Debug + Send + Sync {
-    fn open(&mut self, filename: &String) -> KResult<()>;
-    fn reinit(&mut self) -> KResult<()>;
-    fn flush(&mut self) -> KResult<()>;
-    fn fetch_by_uid(&self, uid: &String) -> KResult<Object>;
-    fn store(&mut self, uid: &String, obj: Object) -> KResult<()>;
-    fn search(&self, template: &[CK_ATTRIBUTE]) -> KResult<Vec<Object>>;
-    fn remove_by_uid(&mut self, uid: &String) -> KResult<()>;
+    fn open(&mut self, filename: &String) -> Result<()>;
+    fn reinit(&mut self) -> Result<()>;
+    fn flush(&mut self) -> Result<()>;
+    fn fetch_by_uid(&self, uid: &String) -> Result<Object>;
+    fn store(&mut self, uid: &String, obj: Object) -> Result<()>;
+    fn search(&self, template: &[CK_ATTRIBUTE]) -> Result<Vec<Object>>;
+    fn remove_by_uid(&mut self, uid: &String) -> Result<()>;
 }
 
 pub mod json;

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use super::Storage;
 
 use super::super::{err_not_found, err_rv};
-use error::{KError, KResult};
+use error::Result;
 use interface::*;
 use object::Object;
 
@@ -21,27 +21,27 @@ struct MemoryStorage {
 }
 
 impl Storage for MemoryStorage {
-    fn open(&mut self, _filename: &String) -> KResult<()> {
+    fn open(&mut self, _filename: &String) -> Result<()> {
         return err_rv!(CKR_GENERAL_ERROR);
     }
-    fn reinit(&mut self) -> KResult<()> {
+    fn reinit(&mut self) -> Result<()> {
         self.objects.clear();
         Ok(())
     }
-    fn flush(&mut self) -> KResult<()> {
+    fn flush(&mut self) -> Result<()> {
         Ok(())
     }
-    fn fetch_by_uid(&self, uid: &String) -> KResult<Object> {
+    fn fetch_by_uid(&self, uid: &String) -> Result<Object> {
         match self.objects.get(uid) {
             Some(o) => Ok(o.clone()),
             None => err_not_found! {uid.clone()},
         }
     }
-    fn store(&mut self, uid: &String, obj: Object) -> KResult<()> {
+    fn store(&mut self, uid: &String, obj: Object) -> Result<()> {
         self.objects.insert(uid.clone(), obj);
         Ok(())
     }
-    fn search(&self, template: &[CK_ATTRIBUTE]) -> KResult<Vec<Object>> {
+    fn search(&self, template: &[CK_ATTRIBUTE]) -> Result<Vec<Object>> {
         let mut ret = Vec::<Object>::new();
         for (_, o) in self.objects.iter() {
             if o.match_template(template) {
@@ -50,7 +50,7 @@ impl Storage for MemoryStorage {
         }
         Ok(ret)
     }
-    fn remove_by_uid(&mut self, uid: &String) -> KResult<()> {
+    fn remove_by_uid(&mut self, uid: &String) -> Result<()> {
         self.objects.remove(uid);
         Ok(())
     }


### PR DESCRIPTION
Change codebase to use the customery Error and Result names instead of KError and KResult which are not familiar names in the ecosystem.

Simplify the actual code and provide more syntactic sugar features like automatic conversion of error types in some cases.

Redesign inspired by the recommendations at:
https://nrc.github.io/error-docs/error-design/error-type-design.html