### PR TITLE
Improve safety of interfaces

### DIFF
--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -469,8 +469,8 @@ impl ECDHOperation {
     fn new_mechanism() -> Box<dyn Mechanism> {
         Box::new(EccMechanism {
             info: CK_MECHANISM_INFO {
-                ulMinKeySize: MIN_EC_SIZE_BITS as CK_ULONG,
-                ulMaxKeySize: MAX_EC_SIZE_BITS as CK_ULONG,
+                ulMinKeySize: CK_ULONG::try_from(MIN_EC_SIZE_BITS).unwrap(),
+                ulMaxKeySize: CK_ULONG::try_from(MAX_EC_SIZE_BITS).unwrap(),
                 flags: CKF_DERIVE,
             },
         })

--- a/src/error.rs
+++ b/src/error.rs
@@ -134,6 +134,18 @@ impl From<serde_json::Error> for Error {
     }
 }
 
+impl From<std::num::TryFromIntError> for Error {
+    fn from(error: std::num::TryFromIntError) -> Error {
+        Error::other_error(error)
+    }
+}
+
+impl From<std::convert::Infallible> for Error {
+    fn from(error: std::convert::Infallible) -> Error {
+        Error::other_error(error)
+    }
+}
+
 #[macro_export]
 macro_rules! some_or_err {
     ($action:expr) => {

--- a/src/fips/indicators.rs
+++ b/src/fips/indicators.rs
@@ -908,7 +908,7 @@ fn check_key(
         _ => {
             /* assume everything else is a symmetric key */
             match obj.get_attr_as_ulong(CKA_VALUE_LEN) {
-                Ok(l) => l as usize,
+                Ok(l) => usize::try_from(l).unwrap(),
                 Err(_) => return false,
             }
         }
@@ -1092,14 +1092,14 @@ pub fn check_kdf_fips_indicators(kctx: &mut EvpKdfCtx) -> Result<Option<bool>> {
     let mut params = OsslParam::with_capacity(1);
     params.add_owned_int(
         name_as_char(OSSL_KDF_PARAM_REDHAT_FIPS_INDICATOR),
-        EVP_KDF_REDHAT_FIPS_INDICATOR_UNDETERMINED as c_int,
+        c_int::try_from(EVP_KDF_REDHAT_FIPS_INDICATOR_UNDETERMINED)?,
     )?;
     params.finalize();
     unsafe { EVP_KDF_CTX_get_params(kctx.as_mut_ptr(), params.as_mut_ptr()) };
 
-    let indicator: c_uint = params
-        .get_int(name_as_char(OSSL_KDF_PARAM_REDHAT_FIPS_INDICATOR))?
-        as c_uint;
+    let indicator = c_uint::try_from(
+        params.get_int(name_as_char(OSSL_KDF_PARAM_REDHAT_FIPS_INDICATOR))?,
+    )?;
     /* in case of error it will remain undetermined */
     Ok(match indicator {
         EVP_KDF_REDHAT_FIPS_INDICATOR_UNDETERMINED => None,

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -79,7 +79,7 @@ impl HKDFOperation {
             Box::new(HKDFMechanism {
                 info: CK_MECHANISM_INFO {
                     ulMinKeySize: 0,
-                    ulMaxKeySize: std::u32::MAX as CK_ULONG,
+                    ulMaxKeySize: CK_ULONG::try_from(u32::MAX).unwrap(),
                     flags: CKF_DERIVE,
                 },
             }),
@@ -89,7 +89,7 @@ impl HKDFOperation {
             Box::new(HKDFMechanism {
                 info: CK_MECHANISM_INFO {
                     ulMinKeySize: 0,
-                    ulMaxKeySize: std::u32::MAX as CK_ULONG,
+                    ulMaxKeySize: CK_ULONG::try_from(u32::MAX).unwrap(),
                     flags: CKF_DERIVE,
                 },
             }),
@@ -135,7 +135,7 @@ impl HKDFOperation {
 
         if matchlen > 0 {
             let keylen = match key.get_attr_as_ulong(CKA_VALUE_LEN) {
-                Ok(len) => len as usize,
+                Ok(len) => usize::try_from(len)?,
                 Err(_) => match key.get_attr_as_bytes(CKA_VALUE) {
                     Ok(v) => v.len(),
                     Err(_) => 0,

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -142,11 +142,9 @@ impl HMACMechanism {
         if mech.ulParameterLen != sizeof!(CK_ULONG) {
             return err_rv!(CKR_MECHANISM_PARAM_INVALID);
         }
-        let genlen = unsafe {
-            let val: &[CK_ULONG] =
-                std::slice::from_raw_parts(mech.pParameter as *const _, 1);
-            val[0] as usize
-        };
+        let genlen = usize::try_from(unsafe {
+            std::slice::from_raw_parts(mech.pParameter as *const CK_ULONG, 1)[0]
+        })?;
         if genlen < self.minlen || genlen > self.maxlen {
             return err_rv!(CKR_MECHANISM_PARAM_INVALID);
         }

--- a/src/mechanism.rs
+++ b/src/mechanism.rs
@@ -79,10 +79,9 @@ pub trait Mechanism: Debug + Send + Sync {
         _: &CK_MECHANISM,
         _: &object::Object,
         _: &object::Object,
-        _: CK_BYTE_PTR,
-        _: CK_ULONG_PTR,
+        _: &mut [u8],
         _: &Box<dyn ObjectFactory>,
-    ) -> Result<()> {
+    ) -> Result<usize> {
         err_rv!(CKR_MECHANISM_INVALID)
     }
 
@@ -164,59 +163,47 @@ pub trait MechOperation: Debug + Send + Sync {
 }
 
 pub trait Encryption: MechOperation {
-    fn encrypt(
-        &mut self,
-        _plain: &[u8],
-        _cipher: CK_BYTE_PTR,
-        _cipher_len: CK_ULONG_PTR,
-    ) -> Result<()> {
+    fn encrypt(&mut self, _plain: &[u8], _cipher: &mut [u8]) -> Result<usize> {
         err_rv!(CKR_GENERAL_ERROR)
     }
     fn encrypt_update(
         &mut self,
         _plain: &[u8],
-        _cipher: CK_BYTE_PTR,
-        _cipher_len: CK_ULONG_PTR,
-    ) -> Result<()> {
+        _cipher: &mut [u8],
+    ) -> Result<usize> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn encrypt_final(
+    fn encrypt_final(&mut self, _cipher: &mut [u8]) -> Result<usize> {
+        err_rv!(CKR_GENERAL_ERROR)
+    }
+    fn encryption_len(
         &mut self,
-        _cipher: CK_BYTE_PTR,
-        _cipher_len: CK_ULONG_PTR,
-    ) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
-    }
-    fn encryption_len(&self, _data_len: usize) -> Result<usize> {
+        _data_len: usize,
+        _final: bool,
+    ) -> Result<usize> {
         err_rv!(CKR_GENERAL_ERROR)
     }
 }
 
 pub trait Decryption: MechOperation {
-    fn decrypt(
-        &mut self,
-        _cipher: &[u8],
-        _plain: CK_BYTE_PTR,
-        _plain_len: CK_ULONG_PTR,
-    ) -> Result<()> {
+    fn decrypt(&mut self, _cipher: &[u8], _plain: &mut [u8]) -> Result<usize> {
         err_rv!(CKR_GENERAL_ERROR)
     }
     fn decrypt_update(
         &mut self,
         _cipher: &[u8],
-        _plain: CK_BYTE_PTR,
-        _plain_len: CK_ULONG_PTR,
-    ) -> Result<()> {
+        _plain: &mut [u8],
+    ) -> Result<usize> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn decrypt_final(
+    fn decrypt_final(&mut self, _plain: &mut [u8]) -> Result<usize> {
+        err_rv!(CKR_GENERAL_ERROR)
+    }
+    fn decryption_len(
         &mut self,
-        _plain: CK_BYTE_PTR,
-        _plain_len: CK_ULONG_PTR,
-    ) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
-    }
-    fn decryption_len(&self, _data_len: usize) -> Result<usize> {
+        _data_len: usize,
+        _final: bool,
+    ) -> Result<usize> {
         err_rv!(CKR_GENERAL_ERROR)
     }
 }

--- a/src/mechanism.rs
+++ b/src/mechanism.rs
@@ -187,7 +187,7 @@ pub trait Encryption: MechOperation {
     ) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn encryption_len(&self, _data_len: CK_ULONG) -> Result<usize> {
+    fn encryption_len(&self, _data_len: usize) -> Result<usize> {
         err_rv!(CKR_GENERAL_ERROR)
     }
 }
@@ -216,7 +216,7 @@ pub trait Decryption: MechOperation {
     ) -> Result<()> {
         err_rv!(CKR_GENERAL_ERROR)
     }
-    fn decryption_len(&self, _data_len: CK_ULONG) -> Result<usize> {
+    fn decryption_len(&self, _data_len: usize) -> Result<usize> {
         err_rv!(CKR_GENERAL_ERROR)
     }
 }

--- a/src/ossl.rs
+++ b/src/ossl.rs
@@ -15,7 +15,7 @@ use super::interface;
 use error::Result;
 use interface::CKR_DEVICE_ERROR;
 
-use std::os::raw::{c_char, c_void};
+use std::ffi::{c_char, c_int, c_uint, c_void};
 use zeroize::Zeroize;
 
 struct OsslContext {

--- a/src/ossl/hkdf.rs
+++ b/src/ossl/hkdf.rs
@@ -40,19 +40,19 @@ impl Derive for HKDFOperation {
         if !self.expand && keysize != self.prflen {
             return err_rv!(CKR_TEMPLATE_INCONSISTENT);
         }
-        if keysize == 0 || keysize > (u32::MAX as usize) {
+        if keysize == 0 || keysize > usize::try_from(u32::MAX)? {
             return err_rv!(CKR_KEY_SIZE_RANGE);
         }
 
         let mode = if self.extract {
             if self.expand {
-                EVP_KDF_HKDF_MODE_EXTRACT_AND_EXPAND
+                c_int::try_from(EVP_KDF_HKDF_MODE_EXTRACT_AND_EXPAND)?
             } else {
-                EVP_KDF_HKDF_MODE_EXTRACT_ONLY
+                c_int::try_from(EVP_KDF_HKDF_MODE_EXTRACT_ONLY)?
             }
         } else {
-            EVP_KDF_HKDF_MODE_EXPAND_ONLY
-        } as c_int;
+            c_int::try_from(EVP_KDF_HKDF_MODE_EXPAND_ONLY)?
+        };
 
         let mut params = OsslParam::with_capacity(5);
         params.zeroize = true;

--- a/src/ossl/pbkdf2.rs
+++ b/src/ossl/pbkdf2.rs
@@ -17,7 +17,7 @@ impl PBKDF2 {
             .add_octet_string(name_as_char(OSSL_KDF_PARAM_SALT), &self.salt)?;
         params.add_owned_uint(
             name_as_char(OSSL_KDF_PARAM_ITER),
-            self.iter as c_uint,
+            c_uint::try_from(self.iter)?,
         )?;
         params.add_const_c_string(
             name_as_char(OSSL_KDF_PARAM_DIGEST),

--- a/src/ossl/rsa.rs
+++ b/src/ossl/rsa.rs
@@ -189,7 +189,7 @@ fn parse_pss_params(mech: &CK_MECHANISM) -> Result<RsaPssParams> {
             Ok(RsaPssParams {
                 hash: params.hashAlg,
                 mgf: params.mgf,
-                saltlen: params.sLen as c_int,
+                saltlen: c_int::try_from(params.sLen)?,
             })
         }
         _ => Ok(no_pss_params()),
@@ -262,8 +262,8 @@ impl RsaPKCSOperation {
     fn new_mechanism(flags: CK_FLAGS) -> Box<dyn Mechanism> {
         Box::new(RsaPKCSMechanism {
             info: CK_MECHANISM_INFO {
-                ulMinKeySize: MIN_RSA_SIZE_BITS as CK_ULONG,
-                ulMaxKeySize: MAX_RSA_SIZE_BITS as CK_ULONG,
+                ulMinKeySize: CK_ULONG::try_from(MIN_RSA_SIZE_BITS).unwrap(),
+                ulMaxKeySize: CK_ULONG::try_from(MAX_RSA_SIZE_BITS).unwrap(),
                 flags: flags,
             },
         })
@@ -820,7 +820,7 @@ impl Encryption for RsaPKCSOperation {
         return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
     }
 
-    fn encryption_len(&self, _data_len: CK_ULONG) -> Result<usize> {
+    fn encryption_len(&self, _data_len: usize) -> Result<usize> {
         match self.mech {
             CKM_RSA_PKCS | CKM_RSA_PKCS_OAEP => Ok(self.output_len),
             _ => err_rv!(CKR_GENERAL_ERROR),
@@ -927,7 +927,7 @@ impl Decryption for RsaPKCSOperation {
         return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
     }
 
-    fn decryption_len(&self, _data_len: CK_ULONG) -> Result<usize> {
+    fn decryption_len(&self, _data_len: usize) -> Result<usize> {
         match self.mech {
             CKM_RSA_PKCS | CKM_RSA_PKCS_OAEP => Ok(self.output_len),
             _ => err_rv!(CKR_GENERAL_ERROR),

--- a/src/ossl/sshkdf.rs
+++ b/src/ossl/sshkdf.rs
@@ -21,7 +21,7 @@ impl Derive for SSHKDFOperation {
         } else {
             misc::common_derive_key_object(key, template, objfactories, 0)
         }?;
-        if value_len == 0 || value_len > (u32::MAX as usize) {
+        if value_len == 0 || value_len > usize::try_from(u32::MAX)? {
             return err_rv!(CKR_TEMPLATE_INCONSISTENT);
         }
 

--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -402,7 +402,8 @@ impl Mechanism for RsaPKCSMechanism {
             return err_rv!(CKR_TEMPLATE_INCONSISTENT);
         }
 
-        let bits = pubkey.get_attr_as_ulong(CKA_MODULUS_BITS)? as usize;
+        let bits =
+            usize::try_from(pubkey.get_attr_as_ulong(CKA_MODULUS_BITS)?)?;
         let exponent: Vec<u8> = match pubkey.get_attr(CKA_PUBLIC_EXPONENT) {
             Some(a) => a.get_value().clone(),
             None => {

--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -446,10 +446,9 @@ impl Mechanism for RsaPKCSMechanism {
         mech: &CK_MECHANISM,
         wrapping_key: &Object,
         key: &Object,
-        data: CK_BYTE_PTR,
-        data_len: CK_ULONG_PTR,
+        data: &mut [u8],
         key_template: &Box<dyn ObjectFactory>,
-    ) -> Result<()> {
+    ) -> Result<usize> {
         if self.info.flags & CKF_WRAP != CKF_WRAP {
             return err_rv!(CKR_MECHANISM_INVALID);
         }
@@ -459,7 +458,6 @@ impl Mechanism for RsaPKCSMechanism {
             wrapping_key,
             key_template.export_for_wrapping(key)?,
             data,
-            data_len,
             &self.info,
         )
     }

--- a/src/sshkdf.rs
+++ b/src/sshkdf.rs
@@ -70,7 +70,7 @@ impl SSHKDFOperation {
             Box::new(SSHKDFMechanism {
                 info: CK_MECHANISM_INFO {
                     ulMinKeySize: 0,
-                    ulMaxKeySize: std::u32::MAX as CK_ULONG,
+                    ulMaxKeySize: CK_ULONG::try_from(u32::MAX).unwrap(),
                     flags: CKF_DERIVE,
                 },
             }),
@@ -150,7 +150,7 @@ impl Derive for SSHKDFOperation {
         } else {
             misc::common_derive_key_object(key, template, objfactories, 0)
         }?;
-        if value_len == 0 || value_len > (u32::MAX as usize) {
+        if value_len == 0 || value_len > usize::try_from(u32::MAX)? {
             return err_rv!(CKR_TEMPLATE_INCONSISTENT);
         }
 

--- a/src/storage/json.rs
+++ b/src/storage/json.rs
@@ -26,7 +26,7 @@ fn to_json_value(a: &Attribute) -> Value {
             Err(_) => Value::Null,
         },
         AttrType::NumType => match a.to_ulong() {
-            Ok(l) => Value::Number(Number::from(l as u64)),
+            Ok(l) => Value::Number(Number::from(l)),
             Err(_) => Value::Null,
         },
         AttrType::StringType => match a.to_string() {
@@ -93,7 +93,7 @@ impl JsonToken {
                         None => return err_rv!(CKR_ATTRIBUTE_VALUE_INVALID),
                     },
                     AttrType::NumType => match val.as_u64() {
-                        Some(n) => attribute::from_ulong(id, n as CK_ULONG),
+                        Some(n) => attribute::from_ulong(id, n),
                         None => return err_rv!(CKR_ATTRIBUTE_VALUE_INVALID),
                     },
                     AttrType::StringType => match val.as_str() {

--- a/src/tlskdf.rs
+++ b/src/tlskdf.rs
@@ -475,7 +475,7 @@ impl TLSKDFOperation {
         tmpl.add_missing_ulong(CKA_CLASS, &CKO_SECRET_KEY);
         tmpl.add_missing_ulong(CKA_KEY_TYPE, &CKK_GENERIC_SECRET);
         tmpl.add_missing_ulong(CKA_VALUE_LEN, &TLS_MASTER_SECRET_SIZE);
-        tmpl.add_missing_slice(CKA_ALLOWED_MECHANISMS, allowed);
+        tmpl.add_missing_slice(CKA_ALLOWED_MECHANISMS, allowed)?;
         tmpl.add_missing_bool(CKA_SIGN, &CK_TRUE);
         tmpl.add_missing_bool(CKA_VERIFY, &CK_TRUE);
         tmpl.add_missing_bool(CKA_DERIVE, &CK_TRUE);

--- a/src/token.rs
+++ b/src/token.rs
@@ -981,9 +981,9 @@ impl Token {
             };
             let aes = self.mechanisms.get(CKM_AES_GCM)?;
             let mut op = aes.encryption_new(&mech, &kek)?;
-            let mut clen: CK_ULONG =
-                (op.encryption_len(val.len() as CK_ULONG)? + DEFAULT_IV_SIZE)
-                    as CK_ULONG;
+            let mut clen = CK_ULONG::try_from(
+                op.encryption_len(val.len())? + DEFAULT_IV_SIZE,
+            )?;
             let mut cipher = Vec::<u8>::with_capacity(clen as usize);
             cipher.extend_from_slice(&iv);
             cipher.resize(clen as usize, 0);
@@ -1034,9 +1034,8 @@ impl Token {
             };
             let aes = self.mechanisms.get(CKM_AES_GCM)?;
             let mut op = aes.decryption_new(&mech, &kek)?;
-            let mut plen: CK_ULONG = op
-                .decryption_len((val.len() - DEFAULT_IV_SIZE) as CK_ULONG)?
-                as CK_ULONG;
+            let mut plen: CK_ULONG =
+                op.decryption_len(val.len() - DEFAULT_IV_SIZE)? as CK_ULONG;
             let mut plain = Vec::<u8>::with_capacity(plen as usize);
             op.decrypt(
                 &val.as_slice()[DEFAULT_IV_SIZE..],


### PR DESCRIPTION
Now that the code is more mature we can address two long standing safety issues.

1) The pervasive use of blind casting using the 'as' construct (#77), which is unwise in this code base that crosses the FFI boundary in so many places.
In fact a bug was found thanks to bound checks using TryFrom (See the relevant commit)

2) The use of raw pointers in the inner "operation" interfaces, which forced the use of even more unsafe code in the internal functions than was really needed. Again various potential issues were addressed implicitly here (no explicit test failures).

Fixes #77 