### PR TITLE
Add support for linking openssl dynamically

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [ossl3, fips, release]
+        name: [ossl3, fips, release, dynamic]
     container: fedora:latest
     steps:
       - name: Get Date for DNF cache entry
@@ -82,6 +82,9 @@ jobs:
           if [ "${{ matrix.name }}" = "release" ]; then
             cargo build -vv --release
           fi
+          if [ "${{ matrix.name }}" = "dynamic" ]; then
+            cargo build -vv --features dynamic
+          fi
 
       - name: Test
         run: |
@@ -93,6 +96,9 @@ jobs:
           fi
           if [ "${{ matrix.name }}" = "release" ]; then
             cargo test --release
+          fi
+          if [ "${{ matrix.name }}" = "dynamic" ]; then
+            cargo test --features dynamic
           fi
 
       - uses: actions/upload-artifact@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ test = false
 
 [build-dependencies]
 bindgen = "0.68"
+pkg-config = "0.3"
 
 [dependencies]
 asn1 = "0.16.2"
@@ -39,5 +40,6 @@ uuid = { version = "1.4.1", features = ["v4"] }
 zeroize = "1.6.0"
 
 [features]
+dynamic = [] # Builds against system libcrypto.so
 fips = ["rusqlite/bundled"]
 slow = [] # Enables slow tests

--- a/fips.h
+++ b/fips.h
@@ -2,6 +2,7 @@
 #define FIPS_MODULE 1
 
 #include "ossl.h"
+#include "crypto/evp.h"
 #include "openssl/fips_names.h"
 #include "internal/provider.h"
 #include "internal/property.h"

--- a/ossl.h
+++ b/ossl.h
@@ -4,6 +4,5 @@
 #include "openssl/core_names.h"
 #include "openssl/params.h"
 #include "openssl/evp.h"
-#include "crypto/evp.h"
 #include "openssl/obj_mac.h"
 #include "openssl/kdf.h"


### PR DESCRIPTION
For non-FIPS builds we can link to the system libcrypto without issues, so add that as an option.