### PR TITLE
Bump bindgen to 0.69

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ test = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-bindgen = "0.68"
+bindgen = "0.69"
 pkg-config = "0.3"
 
 [dependencies]


### PR DESCRIPTION
The 0.68 is no longer available in Fedora packages and I do not think there is a reason to stay behind (if it will generally work with newer version).

I am not sure if this is the best approach or we should make it dependent on wider range of versions (or if we should set up dependabot or something to keep the dependencies updated in the long term).