### PR TITLE
Simplify error handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -171,41 +171,26 @@ impl From<std::convert::Infallible> for Error {
     }
 }
 
+impl From<interface::CK_RV> for Error {
+    fn from(error: interface::CK_RV) -> Error {
+        Error::ck_rv(error)
+    }
+}
+
 #[macro_export]
 macro_rules! some_or_err {
     ($action:expr) => {
         if let Some(ref x) = $action {
             x
         } else {
-            return Err(error::Error::ck_rv(interface::CKR_GENERAL_ERROR));
+            return Err(interface::CKR_GENERAL_ERROR)?;
         }
     };
     (mut $action:expr) => {
         if let Some(ref mut x) = $action {
             x
         } else {
-            return Err(error::Error::ck_rv(interface::CKR_GENERAL_ERROR));
+            return Err(interface::CKR_GENERAL_ERROR)?;
         }
-    };
-}
-
-#[macro_export]
-macro_rules! err_rv {
-    ($ck_err:expr) => {
-        Err(error::Error::ck_rv($ck_err))
-    };
-}
-
-#[macro_export]
-macro_rules! err_not_found {
-    ($err_str:expr) => {
-        Err(error::Error::not_found($err_str))
-    };
-}
-
-#[macro_export]
-macro_rules! to_rv {
-    ($ck_err:expr) => {
-        error::Error::ck_rv($ck_err)
     };
 }

--- a/src/fips/indicators.rs
+++ b/src/fips/indicators.rs
@@ -218,7 +218,7 @@ fn flag_to_op(flag: CK_FLAGS) -> Result<CK_ATTRIBUTE_TYPE> {
         CKF_WRAP => CKA_WRAP,
         CKF_UNWRAP => CKA_UNWRAP,
         CKF_DERIVE => CKA_DERIVE,
-        _ => return err_rv!(CKR_GENERAL_ERROR),
+        _ => return Err(CKR_GENERAL_ERROR)?,
     })
 }
 
@@ -1123,7 +1123,7 @@ macro_rules! check_ossl_fips_indicator {
                     [<EVP_ $up _REDHAT_FIPS_INDICATOR_UNDETERMINED>] => None,
                     [<EVP_ $up _REDHAT_FIPS_INDICATOR_APPROVED>] => Some(true),
                     [<EVP_ $up _REDHAT_FIPS_INDICATOR_NOT_APPROVED>] => Some(false),
-                    _ => return err_rv!(CKR_DEVICE_ERROR),
+                    _ => return Err(CKR_DEVICE_ERROR)?,
                 })
             }
         }

--- a/src/fips/mod.rs
+++ b/src/fips/mod.rs
@@ -22,7 +22,6 @@ use zeroize::Zeroize;
 
 use super::attr_element;
 use super::attribute;
-use super::err_rv;
 use super::error;
 use super::interface;
 use super::mechanism;
@@ -695,7 +694,7 @@ macro_rules! res_to_err {
         if $res == 1 {
             Ok(())
         } else {
-            err_rv!(CKR_DEVICE_ERROR)
+            Err(CKR_DEVICE_ERROR)?
         }
     };
 }
@@ -711,7 +710,7 @@ impl ProviderSignatureCtx {
         let sigtable =
             unsafe { EVP_SIGNATURE_fetch(get_libctx(), alg, std::ptr::null()) };
         if sigtable.is_null() {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
 
         let ctx = unsafe {
@@ -719,11 +718,11 @@ impl ProviderSignatureCtx {
                 Some(f) => {
                     f(FIPS_PROVIDER.provider as *mut c_void, std::ptr::null())
                 }
-                None => return err_rv!(CKR_DEVICE_ERROR),
+                None => return Err(CKR_DEVICE_ERROR)?,
             }
         };
         if ctx.is_null() {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
 
         Ok(ProviderSignatureCtx {
@@ -746,7 +745,7 @@ impl ProviderSignatureCtx {
                     (*pkey.as_ptr()).keydata as *mut c_void,
                     params
                 )),
-                None => err_rv!(CKR_DEVICE_ERROR),
+                None => Err(CKR_DEVICE_ERROR)?,
             }
         }
     }
@@ -759,7 +758,7 @@ impl ProviderSignatureCtx {
                     data.as_ptr() as *const c_uchar,
                     data.len()
                 )),
-                None => err_rv!(CKR_DEVICE_ERROR),
+                None => Err(CKR_DEVICE_ERROR)?,
             }
         }
     }
@@ -777,11 +776,11 @@ impl ProviderSignatureCtx {
                         signature.len(),
                     );
                     if res != 1 {
-                        return err_rv!(CKR_DEVICE_ERROR);
+                        return Err(CKR_DEVICE_ERROR)?;
                     }
                     Ok(siglen)
                 }
-                None => err_rv!(CKR_DEVICE_ERROR),
+                None => Err(CKR_DEVICE_ERROR)?,
             }
         }
     }
@@ -805,11 +804,11 @@ impl ProviderSignatureCtx {
                         tbs.len(),
                     );
                     if res != 1 {
-                        return err_rv!(CKR_DEVICE_ERROR);
+                        return Err(CKR_DEVICE_ERROR)?;
                     }
                     Ok(siglen)
                 }
-                None => err_rv!(CKR_DEVICE_ERROR),
+                None => Err(CKR_DEVICE_ERROR)?,
             }
         }
     }
@@ -828,7 +827,7 @@ impl ProviderSignatureCtx {
                     (*pkey.as_ptr()).keydata as *mut c_void,
                     params
                 )),
-                None => err_rv!(CKR_DEVICE_ERROR),
+                None => Err(CKR_DEVICE_ERROR)?,
             }
         }
     }
@@ -841,7 +840,7 @@ impl ProviderSignatureCtx {
                     data.as_ptr() as *const c_uchar,
                     data.len()
                 )),
-                None => err_rv!(CKR_DEVICE_ERROR),
+                None => Err(CKR_DEVICE_ERROR)?,
             }
         }
     }
@@ -854,7 +853,7 @@ impl ProviderSignatureCtx {
                     signature.as_ptr() as *const c_uchar,
                     signature.len()
                 )),
-                None => err_rv!(CKR_DEVICE_ERROR),
+                None => Err(CKR_DEVICE_ERROR)?,
             }
         }
     }
@@ -873,7 +872,7 @@ impl ProviderSignatureCtx {
                     tbs.as_ptr() as *const c_uchar,
                     tbs.len()
                 )),
-                None => err_rv!(CKR_DEVICE_ERROR),
+                None => Err(CKR_DEVICE_ERROR)?,
             }
         }
     }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -2,7 +2,6 @@
 // See LICENSE.txt file for terms
 
 use super::attribute;
-use super::err_rv;
 use super::error;
 use super::interface;
 use super::mechanism;
@@ -192,14 +191,14 @@ impl Mechanism for HashMechanism {
 
     fn digest_new(&self, mech: &CK_MECHANISM) -> Result<Box<dyn Digest>> {
         if self.info.flags & CKF_DIGEST != CKF_DIGEST {
-            return err_rv!(CKR_MECHANISM_INVALID);
+            return Err(CKR_MECHANISM_INVALID)?;
         }
         Ok(Box::new(HashOperation::new(mech.mechanism)?))
     }
 
     fn derive_operation(&self, mech: &CK_MECHANISM) -> Result<Operation> {
         if self.info.flags & CKF_DERIVE != CKF_DERIVE {
-            return err_rv!(CKR_MECHANISM_INVALID);
+            return Err(CKR_MECHANISM_INVALID)?;
         }
 
         for hs in &HASH_MECH_SET {
@@ -211,7 +210,7 @@ impl Mechanism for HashMechanism {
             }
         }
 
-        err_rv!(CKR_MECHANISM_INVALID)
+        Err(CKR_MECHANISM_INVALID)?
     }
 }
 
@@ -262,7 +261,7 @@ impl Derive for HashKDFOperation {
         objfactories: &ObjectFactories,
     ) -> Result<Vec<Object>> {
         if self.finalized {
-            return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
         }
         self.finalized = true;
 
@@ -292,7 +291,7 @@ impl Derive for HashKDFOperation {
             Some(a) => {
                 let size = a.to_ulong()?;
                 if size > keysize {
-                    return err_rv!(CKR_TEMPLATE_INCONSISTENT);
+                    return Err(CKR_TEMPLATE_INCONSISTENT)?;
                 }
                 keysize = size;
             }

--- a/src/kasn1.rs
+++ b/src/kasn1.rs
@@ -2,7 +2,6 @@
 // See LICENSE.txt file for terms
 
 // Helper routines to use with rust/asn1
-use super::err_rv;
 use super::error;
 use super::interface;
 
@@ -45,7 +44,7 @@ impl<'a> DerEncBigUint<'a> {
         /* check it works */
         match asn1::BigUint::new(&de.data) {
             Some(_) => Ok(de),
-            None => err_rv!(CKR_GENERAL_ERROR),
+            None => Err(CKR_GENERAL_ERROR)?,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,21 +155,21 @@ impl State {
 
     fn get_slot(&self, slot_id: CK_SLOT_ID) -> Result<&Slot> {
         if !self.is_initialized() {
-            return err_rv!(CKR_CRYPTOKI_NOT_INITIALIZED);
+            return Err(CKR_CRYPTOKI_NOT_INITIALIZED)?;
         }
         match self.slots.get(&slot_id) {
             Some(ref s) => Ok(s),
-            None => err_rv!(CKR_SLOT_ID_INVALID),
+            None => Err(CKR_SLOT_ID_INVALID)?,
         }
     }
 
     fn get_slot_mut(&mut self, slot_id: CK_SLOT_ID) -> Result<&mut Slot> {
         if !self.is_initialized() {
-            return err_rv!(CKR_CRYPTOKI_NOT_INITIALIZED);
+            return Err(CKR_CRYPTOKI_NOT_INITIALIZED)?;
         }
         match self.slots.get_mut(&slot_id) {
             Some(s) => Ok(s),
-            None => err_rv!(CKR_SLOT_ID_INVALID),
+            None => Err(CKR_SLOT_ID_INVALID)?,
         }
     }
 
@@ -196,7 +196,7 @@ impl State {
     ) -> Result<RwLockReadGuard<'_, Session>> {
         let slot_id = match self.sessionmap.get(&handle) {
             Some(s) => *s,
-            None => return err_rv!(CKR_SESSION_HANDLE_INVALID),
+            None => return Err(CKR_SESSION_HANDLE_INVALID)?,
         };
         self.get_slot(slot_id)?.get_session(handle)
     }
@@ -207,7 +207,7 @@ impl State {
     ) -> Result<RwLockWriteGuard<'_, Session>> {
         let slot_id = match self.sessionmap.get(&handle) {
             Some(s) => *s,
-            None => return err_rv!(CKR_SESSION_HANDLE_INVALID),
+            None => return Err(CKR_SESSION_HANDLE_INVALID)?,
         };
         self.get_slot(slot_id)?.get_session_mut(handle)
     }
@@ -250,7 +250,7 @@ impl State {
     fn drop_session(&mut self, handle: CK_SESSION_HANDLE) -> Result<()> {
         let slot_id = match self.sessionmap.get(&handle) {
             Some(s) => *s,
-            None => return err_rv!(CKR_SESSION_HANDLE_INVALID),
+            None => return Err(CKR_SESSION_HANDLE_INVALID)?,
         };
         self.get_slot_mut(slot_id)?.drop_session(handle);
         self.sessionmap.remove(&handle);
@@ -292,7 +292,7 @@ impl State {
     ) -> Result<RwLockReadGuard<'_, Token>> {
         let slot_id = match self.sessionmap.get(&handle) {
             Some(s) => *s,
-            None => return err_rv!(CKR_SESSION_HANDLE_INVALID),
+            None => return Err(CKR_SESSION_HANDLE_INVALID)?,
         };
         self.get_slot(slot_id)?.get_token()
     }
@@ -303,7 +303,7 @@ impl State {
     ) -> Result<RwLockWriteGuard<'_, Token>> {
         let slot_id = match self.sessionmap.get(&handle) {
             Some(s) => *s,
-            None => return err_rv!(CKR_SESSION_HANDLE_INVALID),
+            None => return Err(CKR_SESSION_HANDLE_INVALID)?,
         };
         self.get_slot(slot_id)?.get_token_mut(false)
     }
@@ -393,7 +393,7 @@ fn find_conf() -> Result<String> {
     if Path::new(&datafile).is_file() {
         Ok(datafile)
     } else {
-        err_rv!(CKR_ARGUMENTS_BAD)
+        Err(CKR_ARGUMENTS_BAD)?
     }
 }
 

--- a/src/mechanism.rs
+++ b/src/mechanism.rs
@@ -3,7 +3,6 @@
 
 use std::collections::BTreeMap;
 
-use super::err_rv;
 use super::error;
 use super::interface;
 use super::object;
@@ -20,17 +19,17 @@ pub trait Mechanism: Debug + Send + Sync {
         _: &CK_MECHANISM,
         _: &object::Object,
     ) -> Result<Box<dyn Encryption>> {
-        err_rv!(CKR_MECHANISM_INVALID)
+        Err(CKR_MECHANISM_INVALID)?
     }
     fn decryption_new(
         &self,
         _: &CK_MECHANISM,
         _: &object::Object,
     ) -> Result<Box<dyn Decryption>> {
-        err_rv!(CKR_MECHANISM_INVALID)
+        Err(CKR_MECHANISM_INVALID)?
     }
     fn digest_new(&self, _: &CK_MECHANISM) -> Result<Box<dyn Digest>> {
-        err_rv!(CKR_MECHANISM_INVALID)
+        Err(CKR_MECHANISM_INVALID)?
     }
     fn mac_new(
         &self,
@@ -38,21 +37,21 @@ pub trait Mechanism: Debug + Send + Sync {
         _: &object::Object,
         _: CK_FLAGS,
     ) -> Result<Box<dyn Mac>> {
-        err_rv!(CKR_MECHANISM_INVALID)
+        Err(CKR_MECHANISM_INVALID)?
     }
     fn sign_new(
         &self,
         _: &CK_MECHANISM,
         _: &object::Object,
     ) -> Result<Box<dyn Sign>> {
-        err_rv!(CKR_MECHANISM_INVALID)
+        Err(CKR_MECHANISM_INVALID)?
     }
     fn verify_new(
         &self,
         _: &CK_MECHANISM,
         _: &object::Object,
     ) -> Result<Box<dyn Verify>> {
-        err_rv!(CKR_MECHANISM_INVALID)
+        Err(CKR_MECHANISM_INVALID)?
     }
 
     fn generate_key(
@@ -62,7 +61,7 @@ pub trait Mechanism: Debug + Send + Sync {
         _: &Mechanisms,
         _: &ObjectFactories,
     ) -> Result<Object> {
-        err_rv!(CKR_MECHANISM_INVALID)
+        Err(CKR_MECHANISM_INVALID)?
     }
 
     fn generate_keypair(
@@ -71,7 +70,7 @@ pub trait Mechanism: Debug + Send + Sync {
         _pubkey_template: &[CK_ATTRIBUTE],
         _prikey_template: &[CK_ATTRIBUTE],
     ) -> Result<(Object, Object)> {
-        err_rv!(CKR_MECHANISM_INVALID)
+        Err(CKR_MECHANISM_INVALID)?
     }
 
     fn wrap_key(
@@ -82,7 +81,7 @@ pub trait Mechanism: Debug + Send + Sync {
         _: &mut [u8],
         _: &Box<dyn ObjectFactory>,
     ) -> Result<usize> {
-        err_rv!(CKR_MECHANISM_INVALID)
+        Err(CKR_MECHANISM_INVALID)?
     }
 
     fn unwrap_key(
@@ -93,11 +92,11 @@ pub trait Mechanism: Debug + Send + Sync {
         _: &[CK_ATTRIBUTE],
         _: &Box<dyn ObjectFactory>,
     ) -> Result<Object> {
-        err_rv!(CKR_MECHANISM_INVALID)
+        Err(CKR_MECHANISM_INVALID)?
     }
 
     fn derive_operation(&self, _: &CK_MECHANISM) -> Result<Operation> {
-        err_rv!(CKR_MECHANISM_INVALID)
+        Err(CKR_MECHANISM_INVALID)?
     }
 }
 
@@ -139,7 +138,7 @@ impl Mechanisms {
     pub fn get(&self, typ: CK_MECHANISM_TYPE) -> Result<&Box<dyn Mechanism>> {
         match self.tree.get(&typ) {
             Some(m) => Ok(m),
-            None => err_rv!(CKR_MECHANISM_INVALID),
+            None => Err(CKR_MECHANISM_INVALID)?,
         }
     }
 }
@@ -147,14 +146,14 @@ impl Mechanisms {
 pub trait MechOperation: Debug + Send + Sync {
     fn finalized(&self) -> bool;
     fn reset(&mut self) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn requires_objects(&self) -> Result<&[CK_OBJECT_HANDLE]> {
         /* nothing needed by default */
-        err_rv!(CKR_OK)
+        Err(CKR_OK)?
     }
     fn receives_objects(&mut self, _: &[&Object]) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     #[cfg(feature = "fips")]
     fn fips_approved(&self) -> Option<bool> {
@@ -167,69 +166,69 @@ pub trait MechOperation: Debug + Send + Sync {
 
 pub trait Encryption: MechOperation {
     fn encrypt(&mut self, _plain: &[u8], _cipher: &mut [u8]) -> Result<usize> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn encrypt_update(
         &mut self,
         _plain: &[u8],
         _cipher: &mut [u8],
     ) -> Result<usize> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn encrypt_final(&mut self, _cipher: &mut [u8]) -> Result<usize> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn encryption_len(
         &mut self,
         _data_len: usize,
         _final: bool,
     ) -> Result<usize> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
 }
 
 pub trait Decryption: MechOperation {
     fn decrypt(&mut self, _cipher: &[u8], _plain: &mut [u8]) -> Result<usize> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn decrypt_update(
         &mut self,
         _cipher: &[u8],
         _plain: &mut [u8],
     ) -> Result<usize> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn decrypt_final(&mut self, _plain: &mut [u8]) -> Result<usize> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn decryption_len(
         &mut self,
         _data_len: usize,
         _final: bool,
     ) -> Result<usize> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
 }
 
 pub trait SearchOperation: Debug + Send + Sync {
     fn finalized(&self) -> bool;
     fn results(&mut self, _max: usize) -> Result<Vec<CK_OBJECT_HANDLE>> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
 }
 
 pub trait Digest: MechOperation {
     fn digest(&mut self, _data: &[u8], _digest: &mut [u8]) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn digest_update(&mut self, _data: &[u8]) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn digest_final(&mut self, _digest: &mut [u8]) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn digest_len(&self) -> Result<usize> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
 }
 
@@ -237,47 +236,47 @@ pub trait Mac: MechOperation {
     /* not used in FIPS builds */
     #[allow(dead_code)]
     fn mac(&mut self, _data: &[u8], _digest: &mut [u8]) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn mac_update(&mut self, _data: &[u8]) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn mac_final(&mut self, _digest: &mut [u8]) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn mac_len(&self) -> Result<usize> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
 }
 
 pub trait Sign: MechOperation {
     fn sign(&mut self, _data: &[u8], _signature: &mut [u8]) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn sign_update(&mut self, _data: &[u8]) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn sign_final(&mut self, _signature: &mut [u8]) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn signature_len(&self) -> Result<usize> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
 }
 
 pub trait Verify: MechOperation {
     fn verify(&mut self, _data: &[u8], _signature: &[u8]) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn verify_update(&mut self, _data: &[u8]) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn verify_final(&mut self, _signature: &[u8]) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
 
     fn signature_len(&self) -> Result<usize> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
 }
 
@@ -289,7 +288,7 @@ pub trait Derive: MechOperation {
         _: &Mechanisms,
         _: &ObjectFactories,
     ) -> Result<Vec<Object>> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
 }
 
@@ -327,12 +326,12 @@ pub trait DRBG: Debug + Send + Sync {
         _nonce: &[u8],
         _pers: &[u8],
     ) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn reseed(&mut self, _entropy: &[u8], _addtl: &[u8]) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
     fn generate(&mut self, _addtl: &[u8], _output: &mut [u8]) -> Result<()> {
-        err_rv!(CKR_GENERAL_ERROR)
+        Err(CKR_GENERAL_ERROR)?
     }
 }

--- a/src/ossl.rs
+++ b/src/ossl.rs
@@ -9,7 +9,6 @@ include!("ossl/bindings.rs");
 
 use once_cell::sync::Lazy;
 
-use super::err_rv;
 use super::error;
 use super::interface;
 use error::Result;

--- a/src/ossl/common.rs
+++ b/src/ossl/common.rs
@@ -55,7 +55,7 @@ macro_rules! ptr_wrapper {
                         [<EVP_ $up _CTX_new>]()
                     };
                     if ptr.is_null() {
-                        return err_rv!(CKR_DEVICE_ERROR);
+                        return Err(CKR_DEVICE_ERROR)?;
                     }
                     Ok([<Evp $mix Ctx>] { ptr: ptr })
                 }
@@ -76,7 +76,7 @@ macro_rules! ptr_wrapper {
                         )
                     };
                     if ptr.is_null() {
-                        return err_rv!(CKR_DEVICE_ERROR);
+                        return Err(CKR_DEVICE_ERROR)?;
                     }
                     Ok([<Evp $mix >] { ptr: ptr })
                 }
@@ -102,7 +102,7 @@ macro_rules! ptr_wrapper {
                         )
                     };
                     if arg.is_null() {
-                        return err_rv!(CKR_DEVICE_ERROR);
+                        return Err(CKR_DEVICE_ERROR)?;
                     }
                     let ptr = unsafe {
                         /* This is safe and requires no lifetimes because
@@ -114,7 +114,7 @@ macro_rules! ptr_wrapper {
                         [<EVP_ $up _free>](arg);
                     }
                     if ptr.is_null() {
-                        return err_rv!(CKR_DEVICE_ERROR);
+                        return Err(CKR_DEVICE_ERROR)?;
                     }
                     Ok([<Evp $mix Ctx>] { ptr: ptr })
                 }
@@ -144,14 +144,14 @@ impl EvpPkeyCtx {
             EVP_PKEY_CTX_new_from_name(get_libctx(), name, std::ptr::null())
         };
         if ptr.is_null() {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         Ok(EvpPkeyCtx { ptr: ptr })
     }
 
     pub unsafe fn from_ptr(ptr: *mut EVP_PKEY_CTX) -> Result<EvpPkeyCtx> {
         if ptr.is_null() {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         Ok(EvpPkeyCtx { ptr: ptr })
     }
@@ -190,7 +190,7 @@ impl EvpPkey {
         let mut ctx = EvpPkeyCtx::new(pkey_name)?;
         let res = unsafe { EVP_PKEY_fromdata_init(ctx.as_mut_ptr()) };
         if res != 1 {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         let mut pkey: *mut EVP_PKEY = std::ptr::null_mut();
         let res = unsafe {
@@ -202,7 +202,7 @@ impl EvpPkey {
             )
         };
         if res != 1 {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         Ok(EvpPkey { ptr: pkey })
     }
@@ -214,18 +214,18 @@ impl EvpPkey {
         let mut ctx = EvpPkeyCtx::new(pkey_name)?;
         let res = unsafe { EVP_PKEY_keygen_init(ctx.as_mut_ptr()) };
         if res != 1 {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         let res = unsafe {
             EVP_PKEY_CTX_set_params(ctx.as_mut_ptr(), params.as_ptr())
         };
         if res != 1 {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         let mut pkey: *mut EVP_PKEY = std::ptr::null_mut();
         let res = unsafe { EVP_PKEY_generate(ctx.as_mut_ptr(), &mut pkey) };
         if res != 1 {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         Ok(EvpPkey { ptr: pkey })
     }
@@ -315,7 +315,7 @@ impl<'a> OsslParam<'a> {
 
     pub fn from_ptr(ptr: *mut OSSL_PARAM) -> Result<OsslParam<'static>> {
         if ptr.is_null() {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         /* get num of elements */
         let mut nelem = 0;
@@ -350,11 +350,11 @@ impl<'a> OsslParam<'a> {
 
     pub fn add_bn(&mut self, key: *const c_char, v: &Vec<u8>) -> Result<()> {
         if self.finalized {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         if key == std::ptr::null() {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         /* need to go through all these functions because,
@@ -371,7 +371,7 @@ impl<'a> OsslParam<'a> {
             )
         };
         if bn.is_null() {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         let mut size = usize::try_from((unsafe { BN_num_bits(bn) } + 7) / 8)?;
         if size == 0 {
@@ -386,7 +386,7 @@ impl<'a> OsslParam<'a> {
             )
         } < 1
         {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         let param = unsafe {
             OSSL_PARAM_construct_BN(
@@ -406,7 +406,7 @@ impl<'a> OsslParam<'a> {
         v: &'a Vec<u8>,
     ) -> Result<()> {
         if self.finalized {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         let param = unsafe {
@@ -426,11 +426,11 @@ impl<'a> OsslParam<'a> {
         v: Vec<u8>,
     ) -> Result<()> {
         if self.finalized {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         if key == std::ptr::null() {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         let param = unsafe {
@@ -451,11 +451,11 @@ impl<'a> OsslParam<'a> {
         val: *const c_char,
     ) -> Result<()> {
         if self.finalized {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         if key == std::ptr::null() || val == std::ptr::null() {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         let param =
@@ -470,11 +470,11 @@ impl<'a> OsslParam<'a> {
         v: &'a Vec<u8>,
     ) -> Result<()> {
         if self.finalized {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         if key == std::ptr::null() {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         let param = unsafe {
@@ -494,11 +494,11 @@ impl<'a> OsslParam<'a> {
         val: &'a usize,
     ) -> Result<()> {
         if self.finalized {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         if key == std::ptr::null() {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         let param = unsafe {
@@ -514,11 +514,11 @@ impl<'a> OsslParam<'a> {
         val: &'a c_uint,
     ) -> Result<()> {
         if self.finalized {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         if key == std::ptr::null() {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         let param = unsafe {
@@ -534,11 +534,11 @@ impl<'a> OsslParam<'a> {
         val: &'a c_int,
     ) -> Result<()> {
         if self.finalized {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         if key == std::ptr::null() {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         let param = unsafe {
@@ -554,11 +554,11 @@ impl<'a> OsslParam<'a> {
         val: c_uint,
     ) -> Result<()> {
         if self.finalized {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         if key == std::ptr::null() {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         let v = val.to_ne_bytes().to_vec();
@@ -580,11 +580,11 @@ impl<'a> OsslParam<'a> {
         val: c_int,
     ) -> Result<()> {
         if self.finalized {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         if key == std::ptr::null() {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         let v = val.to_ne_bytes().to_vec();
@@ -620,35 +620,35 @@ impl<'a> OsslParam<'a> {
 
     pub fn get_int(&self, key: *const c_char) -> Result<c_int> {
         if !self.finalized {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
         let p = unsafe {
             OSSL_PARAM_locate(self.p.as_ref().as_ptr() as *mut OSSL_PARAM, key)
         };
         if p.is_null() {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
         let mut val: c_int = 0;
         let res = unsafe { OSSL_PARAM_get_int(p, &mut val) };
         if res != 1 {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         Ok(val)
     }
 
     pub fn get_bn(&self, key: *const c_char) -> Result<Vec<u8>> {
         if !self.finalized {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
         let p = unsafe {
             OSSL_PARAM_locate(self.p.as_ref().as_ptr() as *mut OSSL_PARAM, key)
         };
         if p.is_null() {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
         let mut bn: *mut BIGNUM = std::ptr::null_mut();
         if unsafe { OSSL_PARAM_get_BN(p, &mut bn) } != 1 {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
         let len = bn_num_bytes(bn as *const BIGNUM);
         let mut vec = Vec::<u8>::with_capacity(len);
@@ -660,7 +660,7 @@ impl<'a> OsslParam<'a> {
                 )
             })?
         {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         unsafe {
             vec.set_len(len);
@@ -670,13 +670,13 @@ impl<'a> OsslParam<'a> {
 
     pub fn get_octet_string(&self, key: *const c_char) -> Result<&'a [u8]> {
         if !self.finalized {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
         let p = unsafe {
             OSSL_PARAM_locate(self.p.as_ref().as_ptr() as *mut OSSL_PARAM, key)
         };
         if p.is_null() {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
         let mut buf: *const c_void = std::ptr::null_mut();
         let mut buf_len: usize = 0;
@@ -684,7 +684,7 @@ impl<'a> OsslParam<'a> {
             OSSL_PARAM_get_octet_string_ptr(p, &mut buf, &mut buf_len)
         };
         if res != 1 {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         let octet =
             unsafe { std::slice::from_raw_parts(buf as *const u8, buf_len) };

--- a/src/ossl/drbg.rs
+++ b/src/ossl/drbg.rs
@@ -1,4 +1,3 @@
-use super::err_rv;
 use super::error;
 use super::interface;
 use super::mechanism;
@@ -83,7 +82,7 @@ impl DRBG for HmacSha256Drbg {
                 params.as_ptr(),
             );
             if res != 1 {
-                return err_rv!(CKR_DEVICE_ERROR);
+                return Err(CKR_DEVICE_ERROR)?;
             }
         }
         self.initialized = true;
@@ -91,7 +90,7 @@ impl DRBG for HmacSha256Drbg {
     }
     fn reseed(&mut self, entropy: &[u8], addtl: &[u8]) -> Result<()> {
         if !self.initialized {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
         unsafe {
             let res = EVP_RAND_reseed(
@@ -103,14 +102,14 @@ impl DRBG for HmacSha256Drbg {
                 addtl.len(),
             );
             if res != 1 {
-                return err_rv!(CKR_DEVICE_ERROR);
+                return Err(CKR_DEVICE_ERROR)?;
             }
         }
         Ok(())
     }
     fn generate(&mut self, addtl: &[u8], output: &mut [u8]) -> Result<()> {
         if !self.initialized {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
         let res = unsafe {
             EVP_RAND_generate(
@@ -124,7 +123,7 @@ impl DRBG for HmacSha256Drbg {
             )
         };
         if res != 1 {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         Ok(())
     }
@@ -203,7 +202,7 @@ impl DRBG for HmacSha512Drbg {
                 params.as_ptr(),
             );
             if res != 1 {
-                return err_rv!(CKR_DEVICE_ERROR);
+                return Err(CKR_DEVICE_ERROR)?;
             }
         }
         self.initialized = true;
@@ -211,7 +210,7 @@ impl DRBG for HmacSha512Drbg {
     }
     fn reseed(&mut self, entropy: &[u8], addtl: &[u8]) -> Result<()> {
         if !self.initialized {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
         unsafe {
             let res = EVP_RAND_reseed(
@@ -223,14 +222,14 @@ impl DRBG for HmacSha512Drbg {
                 addtl.len(),
             );
             if res != 1 {
-                return err_rv!(CKR_DEVICE_ERROR);
+                return Err(CKR_DEVICE_ERROR)?;
             }
         }
         Ok(())
     }
     fn generate(&mut self, addtl: &[u8], output: &mut [u8]) -> Result<()> {
         if !self.initialized {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
         let res = unsafe {
             EVP_RAND_generate(
@@ -244,7 +243,7 @@ impl DRBG for HmacSha512Drbg {
             )
         };
         if res != 1 {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         Ok(())
     }

--- a/src/ossl/hkdf.rs
+++ b/src/ossl/hkdf.rs
@@ -13,7 +13,7 @@ impl Derive for HKDFOperation {
         objfactories: &ObjectFactories,
     ) -> Result<Vec<Object>> {
         if self.finalized {
-            return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
         }
         self.finalized = true;
 
@@ -21,8 +21,8 @@ impl Derive for HKDFOperation {
 
         if self.salt.len() == 0 {
             match self.salt_type {
-                CKF_HKDF_SALT_KEY => return err_rv!(CKR_GENERAL_ERROR),
-                _ => return err_rv!(CKR_MECHANISM_PARAM_INVALID),
+                CKF_HKDF_SALT_KEY => return Err(CKR_GENERAL_ERROR)?,
+                _ => return Err(CKR_MECHANISM_PARAM_INVALID)?,
             }
         }
 
@@ -38,10 +38,10 @@ impl Derive for HKDFOperation {
         }?;
 
         if !self.expand && keysize != self.prflen {
-            return err_rv!(CKR_TEMPLATE_INCONSISTENT);
+            return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
         if keysize == 0 || keysize > usize::try_from(u32::MAX)? {
-            return err_rv!(CKR_KEY_SIZE_RANGE);
+            return Err(CKR_KEY_SIZE_RANGE)?;
         }
 
         let mode = if self.extract {
@@ -92,7 +92,7 @@ impl Derive for HKDFOperation {
             )
         };
         if res != 1 {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
 
         #[cfg(feature = "fips")]

--- a/src/ossl/hmac.rs
+++ b/src/ossl/hmac.rs
@@ -40,7 +40,7 @@ impl HMACOperation {
             )
         } != 1
         {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         Ok(HMACOperation {
             mech: mech,
@@ -57,14 +57,14 @@ impl HMACOperation {
 
     fn begin(&mut self) -> Result<()> {
         if self.in_use {
-            return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
         }
         Ok(())
     }
 
     fn update(&mut self, data: &[u8]) -> Result<()> {
         if self.finalized {
-            return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
         }
         self.in_use = true;
 
@@ -72,7 +72,7 @@ impl HMACOperation {
             EVP_MAC_update(self.ctx.as_mut_ptr(), data.as_ptr(), data.len())
         } != 1
         {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
 
         Ok(())
@@ -80,14 +80,14 @@ impl HMACOperation {
 
     fn finalize(&mut self, output: &mut [u8]) -> Result<()> {
         if self.finalized {
-            return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
         }
         /* It is valid to finalize without any update */
         self.in_use = true;
         self.finalized = true;
 
         if output.len() != self.outputlen {
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         let mut buf = vec![0u8; self.maclen];
@@ -101,11 +101,11 @@ impl HMACOperation {
             )
         } != 1
         {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         if outlen != self.maclen {
             buf.zeroize();
-            return err_rv!(CKR_GENERAL_ERROR);
+            return Err(CKR_GENERAL_ERROR)?;
         }
 
         output.copy_from_slice(&buf[..output.len()]);
@@ -129,7 +129,7 @@ impl HMACOperation {
             )
         } != 1
         {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
         self.finalized = false;
         self.in_use = false;

--- a/src/ossl/pbkdf2.rs
+++ b/src/ossl/pbkdf2.rs
@@ -36,7 +36,7 @@ impl PBKDF2 {
             )
         };
         if res != 1 {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
 
         Ok(dkm)

--- a/src/ossl/sshkdf.rs
+++ b/src/ossl/sshkdf.rs
@@ -10,7 +10,7 @@ impl Derive for SSHKDFOperation {
         objfactories: &ObjectFactories,
     ) -> Result<Vec<Object>> {
         if self.finalized {
-            return err_rv!(CKR_OPERATION_NOT_INITIALIZED);
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
         }
         self.finalized = true;
 
@@ -22,7 +22,7 @@ impl Derive for SSHKDFOperation {
             misc::common_derive_key_object(key, template, objfactories, 0)
         }?;
         if value_len == 0 || value_len > usize::try_from(u32::MAX)? {
-            return err_rv!(CKR_TEMPLATE_INCONSISTENT);
+            return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
 
         let sshkdf_type = vec![self.key_type, 0u8];
@@ -61,7 +61,7 @@ impl Derive for SSHKDFOperation {
             )
         };
         if res != 1 {
-            return err_rv!(CKR_DEVICE_ERROR);
+            return Err(CKR_DEVICE_ERROR)?;
         }
 
         self.fips_approved =

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -2,7 +2,6 @@
 // See LICENSE.txt file for terms
 
 use super::drbg;
-use super::err_rv;
 use super::error;
 use super::interface;
 use super::mechanism;
@@ -24,7 +23,7 @@ impl RNG {
             "HMAC DRBG SHA512" => Ok(RNG {
                 drbg: Box::new(drbg::HmacSha512Drbg::new()?),
             }),
-            _ => err_rv!(CKR_RANDOM_NO_RNG),
+            _ => Err(CKR_RANDOM_NO_RNG)?,
         }
     }
 

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -9,7 +9,6 @@ use super::interface;
 use super::session::Session;
 use super::token::Token;
 
-use super::err_rv;
 use error::Result;
 use interface::*;
 
@@ -57,10 +56,10 @@ impl Slot {
                 } else {
                     /* FIXME: once we have CKR_TOKEN_NOT_INITIALIZED as an
                      * available error, we should rreturn that instead */
-                    err_rv!(KRR_TOKEN_NOT_INITIALIZED)
+                    Err(KRR_TOKEN_NOT_INITIALIZED)?
                 }
             }
-            Err(_) => err_rv!(CKR_GENERAL_ERROR),
+            Err(_) => Err(CKR_GENERAL_ERROR)?,
         }
     }
 
@@ -77,10 +76,10 @@ impl Slot {
                 } else {
                     /* FIXME: once we have CKR_TOKEN_NOT_INITIALIZED as an
                      * available error, we should rreturn that instead */
-                    err_rv!(KRR_TOKEN_NOT_INITIALIZED)
+                    Err(KRR_TOKEN_NOT_INITIALIZED)?
                 }
             }
-            Err(_) => err_rv!(CKR_GENERAL_ERROR),
+            Err(_) => Err(CKR_GENERAL_ERROR)?,
         }
     }
 
@@ -95,9 +94,9 @@ impl Slot {
         match self.sessions.get(&handle) {
             Some(s) => match s.read() {
                 Ok(sess) => Ok(sess),
-                Err(_) => err_rv!(CKR_GENERAL_ERROR),
+                Err(_) => Err(CKR_GENERAL_ERROR)?,
             },
-            None => err_rv!(CKR_SESSION_HANDLE_INVALID),
+            None => Err(CKR_SESSION_HANDLE_INVALID)?,
         }
     }
 
@@ -108,9 +107,9 @@ impl Slot {
         match self.sessions.get(&handle) {
             Some(s) => match s.write() {
                 Ok(sess) => Ok(sess),
-                Err(_) => err_rv!(CKR_GENERAL_ERROR),
+                Err(_) => Err(CKR_GENERAL_ERROR)?,
             },
-            None => err_rv!(CKR_SESSION_HANDLE_INVALID),
+            None => Err(CKR_SESSION_HANDLE_INVALID)?,
         }
     }
 
@@ -132,7 +131,7 @@ impl Slot {
         for (_key, val) in self.sessions.iter() {
             let ret = val.write().unwrap().change_session_state(user_type);
             if ret != CKR_OK {
-                return err_rv!(ret);
+                return Err(ret)?;
             }
         }
         Ok(())

--- a/src/storage/json.rs
+++ b/src/storage/json.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::{from_reader, to_string_pretty, Map, Number, Value};
 
 use super::super::attribute;
-use super::super::err_rv;
 use super::super::error;
 use super::super::interface;
 use super::super::object;
@@ -90,31 +89,31 @@ impl JsonToken {
                 let attr = match atype {
                     AttrType::BoolType => match val.as_bool() {
                         Some(b) => attribute::from_bool(id, b),
-                        None => return err_rv!(CKR_ATTRIBUTE_VALUE_INVALID),
+                        None => return Err(CKR_ATTRIBUTE_VALUE_INVALID)?,
                     },
                     AttrType::NumType => match val.as_u64() {
                         Some(n) => attribute::from_ulong(id, n),
-                        None => return err_rv!(CKR_ATTRIBUTE_VALUE_INVALID),
+                        None => return Err(CKR_ATTRIBUTE_VALUE_INVALID)?,
                     },
                     AttrType::StringType => match val.as_str() {
                         Some(s) => attribute::from_string(id, s.to_string()),
-                        None => return err_rv!(CKR_ATTRIBUTE_VALUE_INVALID),
+                        None => return Err(CKR_ATTRIBUTE_VALUE_INVALID)?,
                     },
                     AttrType::BytesType => match val.as_str() {
                         Some(s) => {
                             let len = match BASE64.decode_len(s.len()) {
                                 Ok(l) => l,
-                                Err(_) => return err_rv!(CKR_GENERAL_ERROR),
+                                Err(_) => return Err(CKR_GENERAL_ERROR)?,
                             };
                             let mut v = vec![0; len];
                             match BASE64.decode_mut(s.as_bytes(), &mut v) {
                                 Ok(l) => {
                                     attribute::from_bytes(id, v[0..l].to_vec())
                                 }
-                                Err(_) => return err_rv!(CKR_GENERAL_ERROR),
+                                Err(_) => return Err(CKR_GENERAL_ERROR)?,
                             }
                         }
-                        None => return err_rv!(CKR_ATTRIBUTE_VALUE_INVALID),
+                        None => return Err(CKR_ATTRIBUTE_VALUE_INVALID)?,
                     },
                     AttrType::DateType => match val.as_str() {
                         Some(s) => {
@@ -128,7 +127,7 @@ impl JsonToken {
                                 )
                             }
                         }
-                        None => return err_rv!(CKR_ATTRIBUTE_VALUE_INVALID),
+                        None => return Err(CKR_ATTRIBUTE_VALUE_INVALID)?,
                     },
                     AttrType::DenyType => continue,
                     AttrType::IgnoreType => continue,
@@ -138,13 +137,13 @@ impl JsonToken {
                 if key == "CKA_UNIQUE_ID" {
                     uid = match val.as_str() {
                         Some(s) => Some(s.to_string()),
-                        None => return err_rv!(CKR_DEVICE_ERROR),
+                        None => return Err(CKR_DEVICE_ERROR)?,
                     }
                 }
             }
             match uid {
                 Some(u) => cache.store(&u, obj)?,
-                None => return err_rv!(CKR_DEVICE_ERROR),
+                None => return Err(CKR_DEVICE_ERROR)?,
             }
         }
         Ok(())

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -8,8 +8,7 @@ use std::collections::HashMap;
 
 use super::Storage;
 
-use super::super::{err_not_found, err_rv};
-use error::Result;
+use error::{Error, Result};
 use interface::*;
 use object::Object;
 
@@ -22,7 +21,7 @@ struct MemoryStorage {
 
 impl Storage for MemoryStorage {
     fn open(&mut self, _filename: &String) -> Result<()> {
-        return err_rv!(CKR_GENERAL_ERROR);
+        return Err(CKR_GENERAL_ERROR)?;
     }
     fn reinit(&mut self) -> Result<()> {
         self.objects.clear();
@@ -34,7 +33,7 @@ impl Storage for MemoryStorage {
     fn fetch_by_uid(&self, uid: &String) -> Result<Object> {
         match self.objects.get(uid) {
             Some(o) => Ok(o.clone()),
-            None => err_not_found! {uid.clone()},
+            None => Err(Error::not_found(uid.clone())),
         }
     }
     fn store(&mut self, uid: &String, obj: Object) -> Result<()> {

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -127,7 +127,7 @@ pub fn decrypt(
         key,
     );
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
 
     let mut dec_len: CK_ULONG = 0;
@@ -139,7 +139,7 @@ pub fn decrypt(
         &mut dec_len,
     );
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
 
     let mut dec = vec![0u8; dec_len as usize];
@@ -151,7 +151,7 @@ pub fn decrypt(
         &mut dec_len,
     );
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
     dec.resize(dec_len as usize, 0);
 
@@ -170,7 +170,7 @@ pub fn encrypt(
         key,
     );
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
 
     let mut enc_len: CK_ULONG = 0;
@@ -182,7 +182,7 @@ pub fn encrypt(
         &mut enc_len,
     );
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
 
     let mut enc = vec![0u8; enc_len as usize];
@@ -194,7 +194,7 @@ pub fn encrypt(
         &mut enc_len,
     );
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
     enc.resize(enc_len as usize, 0);
 
@@ -219,19 +219,19 @@ pub fn get_test_key_handle(
     ];
     let ret = fn_find_objects_init(session, template.as_mut_ptr(), 2);
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
     let mut count: CK_ULONG = 0;
     let ret = fn_find_objects(session, &mut handle, 1, &mut count);
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
     if count != 1 {
-        return err_not_found!(format!("count {} != 1", count));
+        return Err(error::Error::not_found(format!("count {} != 1", count)));
     }
     let ret = fn_find_objects_final(session);
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
 
     Ok(handle)
@@ -268,7 +268,7 @@ pub fn sig_gen(
     let ret =
         fn_sign_init(session, mechanism as *const _ as CK_MECHANISM_PTR, key);
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
 
     /* get signature length */
@@ -281,7 +281,7 @@ pub fn sig_gen(
         &mut siglen,
     );
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
 
     let mut signature: Vec<u8> = vec![0; siglen as usize];
@@ -293,7 +293,7 @@ pub fn sig_gen(
         &mut siglen,
     );
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
     signature.resize(siglen as usize, 0);
 
@@ -309,7 +309,7 @@ pub fn sig_gen_multipart(
     let ret =
         fn_sign_init(session, mechanism as *const _ as CK_MECHANISM_PTR, key);
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
 
     let half_len = data.len() / 2;
@@ -317,7 +317,7 @@ pub fn sig_gen_multipart(
     let ret =
         fn_sign_update(session, data.as_ptr() as *mut u8, half_len as CK_ULONG);
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
     let ret = fn_sign_update(
         session,
@@ -325,19 +325,19 @@ pub fn sig_gen_multipart(
         (data.len() - half_len) as CK_ULONG,
     );
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
     let mut siglen: CK_ULONG = 0;
     let ret = fn_sign_final(session, std::ptr::null_mut(), &mut siglen);
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
 
     let mut signature: Vec<u8> = vec![0; siglen as usize];
     let ret =
         fn_sign_final(session, signature.as_ptr() as *mut u8, &mut siglen);
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
     signature.resize(siglen as usize, 0);
 
@@ -433,7 +433,7 @@ pub fn import_object(
     );
 
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
     Ok(handle)
 }
@@ -471,7 +471,7 @@ pub fn generate_key(
     );
 
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
     Ok(handle)
 }
@@ -509,7 +509,7 @@ pub fn generate_key_pair(
     );
 
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
     Ok((pub_key, pri_key))
 }
@@ -636,7 +636,7 @@ pub fn extract_key_value(
         extract_template.len() as CK_ULONG,
     );
     if ret != CKR_OK {
-        return err_rv!(ret);
+        return Err(ret)?;
     }
     Ok(value)
 }


### PR DESCRIPTION
Remove a bunch of macros that can be simplified away by clever use of error casting.