### PR TITLE
Refactor attribute code to use methods

### DIFF
--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -3,8 +3,7 @@
 
 use std::fmt::Debug;
 
-use crate::attribute;
-use crate::attribute::{from_bool, from_bytes};
+use crate::attribute::Attribute;
 use crate::ecc_misc::*;
 use crate::error::Result;
 use crate::interface::*;
@@ -143,8 +142,8 @@ impl ECCPubFactory {
         data.attributes.append(&mut data.init_common_key_attrs());
         data.attributes
             .append(&mut data.init_common_public_key_attrs());
-        data.attributes.push(attr_element!(CKA_EC_PARAMS; OAFlags::AlwaysRequired | OAFlags::Unchangeable; from_bytes; val Vec::new()));
-        data.attributes.push(attr_element!(CKA_EC_POINT; OAFlags::RequiredOnCreate | OAFlags::SettableOnlyOnCreate | OAFlags::Unchangeable; from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(CKA_EC_PARAMS; OAFlags::AlwaysRequired | OAFlags::Unchangeable; Attribute::from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(CKA_EC_POINT; OAFlags::RequiredOnCreate | OAFlags::SettableOnlyOnCreate | OAFlags::Unchangeable; Attribute::from_bytes; val Vec::new()));
         data
     }
 }
@@ -184,11 +183,18 @@ impl ECCPrivFactory {
         data.attributes.append(&mut data.init_common_key_attrs());
         data.attributes
             .append(&mut data.init_common_private_key_attrs());
-        data.attributes.push(attr_element!(CKA_EC_PARAMS; OAFlags::RequiredOnCreate | OAFlags::Unchangeable; from_bytes; val Vec::new()));
-        data.attributes.push(attr_element!(CKA_VALUE; OAFlags::Sensitive | OAFlags::RequiredOnCreate | OAFlags::SettableOnlyOnCreate | OAFlags::Unchangeable; from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(
+            CKA_EC_PARAMS; OAFlags::RequiredOnCreate | OAFlags::Unchangeable;
+            Attribute::from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(
+            CKA_VALUE; OAFlags::Sensitive | OAFlags::RequiredOnCreate
+            | OAFlags::SettableOnlyOnCreate | OAFlags::Unchangeable;
+            Attribute::from_bytes; val Vec::new()));
 
         /* default to private */
-        let private = attr_element!(CKA_PRIVATE; OAFlags::Defval | OAFlags::ChangeOnCopy; from_bool; val true);
+        let private = attr_element!(
+            CKA_PRIVATE; OAFlags::Defval | OAFlags::ChangeOnCopy;
+            Attribute::from_bool; val true);
         match data
             .attributes
             .iter()
@@ -274,14 +280,14 @@ impl PrivKeyFactory for ECCPrivFactory {
     ) -> Result<Object> {
         let mut key = self.default_object_unwrap(template)?;
 
-        if !key.check_or_set_attr(attribute::from_ulong(
+        if !key.check_or_set_attr(Attribute::from_ulong(
             CKA_CLASS,
             CKO_PRIVATE_KEY,
         ))? {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
         if !key
-            .check_or_set_attr(attribute::from_ulong(CKA_KEY_TYPE, CKK_EC))?
+            .check_or_set_attr(Attribute::from_ulong(CKA_KEY_TYPE, CKK_EC))?
         {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
@@ -310,7 +316,7 @@ impl PrivKeyFactory for ECCPrivFactory {
             Err(_) => return Err(CKR_WRAPPED_KEY_INVALID)?,
         };
 
-        if !key.check_or_set_attr(attribute::from_bytes(
+        if !key.check_or_set_attr(Attribute::from_bytes(
             CKA_EC_PARAMS,
             oid_encoded.to_vec(),
         ))? {
@@ -324,7 +330,7 @@ impl PrivKeyFactory for ECCPrivFactory {
             Err(_) => return Err(CKR_WRAPPED_KEY_INVALID)?,
         };
 
-        if !key.check_or_set_attr(attribute::from_bytes(
+        if !key.check_or_set_attr(Attribute::from_bytes(
             CKA_VALUE,
             ecpkey.private_key.as_bytes().to_vec(),
         ))? {
@@ -414,28 +420,28 @@ impl Mechanism for EccMechanism {
     ) -> Result<(Object, Object)> {
         let mut pubkey =
             PUBLIC_KEY_FACTORY.default_object_generate(pubkey_template)?;
-        if !pubkey.check_or_set_attr(attribute::from_ulong(
+        if !pubkey.check_or_set_attr(Attribute::from_ulong(
             CKA_CLASS,
             CKO_PUBLIC_KEY,
         ))? {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
         if !pubkey
-            .check_or_set_attr(attribute::from_ulong(CKA_KEY_TYPE, CKK_EC))?
+            .check_or_set_attr(Attribute::from_ulong(CKA_KEY_TYPE, CKK_EC))?
         {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
 
         let mut privkey =
             PRIVATE_KEY_FACTORY.default_object_generate(prikey_template)?;
-        if !privkey.check_or_set_attr(attribute::from_ulong(
+        if !privkey.check_or_set_attr(Attribute::from_ulong(
             CKA_CLASS,
             CKO_PRIVATE_KEY,
         ))? {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
         if !privkey
-            .check_or_set_attr(attribute::from_ulong(CKA_KEY_TYPE, CKK_EC))?
+            .check_or_set_attr(Attribute::from_ulong(CKA_KEY_TYPE, CKK_EC))?
         {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
@@ -446,7 +452,7 @@ impl Mechanism for EccMechanism {
                 return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;
             }
         };
-        if !privkey.check_or_set_attr(attribute::from_bytes(
+        if !privkey.check_or_set_attr(Attribute::from_bytes(
             CKA_EC_PARAMS,
             ec_params,
         ))? {

--- a/src/eddsa.rs
+++ b/src/eddsa.rs
@@ -3,8 +3,7 @@
 
 use std::fmt::Debug;
 
-use crate::attribute;
-use crate::attribute::{from_bool, from_bytes};
+use crate::attribute::Attribute;
 use crate::ecc_misc::*;
 use crate::error::Result;
 use crate::interface::*;
@@ -34,8 +33,13 @@ impl EDDSAPubFactory {
         data.attributes.append(&mut data.init_common_key_attrs());
         data.attributes
             .append(&mut data.init_common_public_key_attrs());
-        data.attributes.push(attr_element!(CKA_EC_PARAMS; OAFlags::AlwaysRequired | OAFlags::Unchangeable; from_bytes; val Vec::new()));
-        data.attributes.push(attr_element!(CKA_EC_POINT; OAFlags::RequiredOnCreate | OAFlags::SettableOnlyOnCreate | OAFlags::Unchangeable; from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(
+            CKA_EC_PARAMS; OAFlags::AlwaysRequired | OAFlags::Unchangeable;
+            Attribute::from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(
+            CKA_EC_POINT; OAFlags::RequiredOnCreate
+            | OAFlags::SettableOnlyOnCreate | OAFlags::Unchangeable;
+            Attribute::from_bytes; val Vec::new()));
         data
     }
 }
@@ -75,11 +79,18 @@ impl EDDSAPrivFactory {
         data.attributes.append(&mut data.init_common_key_attrs());
         data.attributes
             .append(&mut data.init_common_private_key_attrs());
-        data.attributes.push(attr_element!(CKA_EC_PARAMS; OAFlags::RequiredOnCreate | OAFlags::Unchangeable; from_bytes; val Vec::new()));
-        data.attributes.push(attr_element!(CKA_VALUE; OAFlags::Sensitive | OAFlags::RequiredOnCreate | OAFlags::SettableOnlyOnCreate | OAFlags::Unchangeable; from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(
+            CKA_EC_PARAMS; OAFlags::RequiredOnCreate | OAFlags::Unchangeable;
+            Attribute::from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(
+            CKA_VALUE; OAFlags::Sensitive | OAFlags::RequiredOnCreate
+            | OAFlags::SettableOnlyOnCreate | OAFlags::Unchangeable;
+            Attribute::from_bytes; val Vec::new()));
 
         /* default to private */
-        let private = attr_element!(CKA_PRIVATE; OAFlags::Defval | OAFlags::ChangeOnCopy; from_bool; val true);
+        let private = attr_element!(
+            CKA_PRIVATE; OAFlags::Defval | OAFlags::ChangeOnCopy;
+            Attribute::from_bool; val true);
         match data
             .attributes
             .iter()
@@ -206,13 +217,13 @@ impl Mechanism for EddsaMechanism {
     ) -> Result<(Object, Object)> {
         let mut pubkey =
             PUBLIC_KEY_FACTORY.default_object_generate(pubkey_template)?;
-        if !pubkey.check_or_set_attr(attribute::from_ulong(
+        if !pubkey.check_or_set_attr(Attribute::from_ulong(
             CKA_CLASS,
             CKO_PUBLIC_KEY,
         ))? {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
-        if !pubkey.check_or_set_attr(attribute::from_ulong(
+        if !pubkey.check_or_set_attr(Attribute::from_ulong(
             CKA_KEY_TYPE,
             CKK_EC_EDWARDS,
         ))? {
@@ -221,13 +232,13 @@ impl Mechanism for EddsaMechanism {
 
         let mut privkey =
             PRIVATE_KEY_FACTORY.default_object_generate(prikey_template)?;
-        if !privkey.check_or_set_attr(attribute::from_ulong(
+        if !privkey.check_or_set_attr(Attribute::from_ulong(
             CKA_CLASS,
             CKO_PRIVATE_KEY,
         ))? {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
-        if !privkey.check_or_set_attr(attribute::from_ulong(
+        if !privkey.check_or_set_attr(Attribute::from_ulong(
             CKA_KEY_TYPE,
             CKK_EC_EDWARDS,
         ))? {
@@ -240,7 +251,7 @@ impl Mechanism for EddsaMechanism {
                 return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;
             }
         };
-        if !privkey.check_or_set_attr(attribute::from_bytes(
+        if !privkey.check_or_set_attr(Attribute::from_bytes(
             CKA_EC_PARAMS,
             ec_params,
         ))? {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@
 use std::error;
 use std::fmt;
 
-use super::interface;
+use crate::interface;
 
 use serde_json;
 

--- a/src/fips/indicators.rs
+++ b/src/fips/indicators.rs
@@ -2,8 +2,7 @@
 // See LICENSE.txt file for terms
 
 use crate::attr_element;
-use crate::attribute;
-use crate::attribute::{from_bytes, from_string, from_ulong};
+use crate::attribute::Attribute;
 use crate::ecc::ec_key_curve_size;
 use crate::error::Result;
 use crate::interface::*;
@@ -36,49 +35,49 @@ impl ValidationFactory {
         data.attributes
             .append(&mut data.init_common_storage_attrs());
         data.attributes.push(attr_element!(
-                CKA_VALIDATION_TYPE;
-                OAFlags::AlwaysRequired | OAFlags::NeverSettable
-                | OAFlags::Unchangeable; from_ulong; val 0));
+                CKA_VALIDATION_TYPE; OAFlags::AlwaysRequired
+                | OAFlags::NeverSettable | OAFlags::Unchangeable;
+                Attribute::from_ulong; val 0));
         data.attributes.push(attr_element!(
-                CKA_VALIDATION_VERSION;
-                OAFlags::AlwaysRequired | OAFlags::NeverSettable
-                | OAFlags::Unchangeable; from_bytes; val Vec::new()));
+                CKA_VALIDATION_VERSION; OAFlags::AlwaysRequired
+                | OAFlags::NeverSettable | OAFlags::Unchangeable;
+                Attribute::from_bytes; val Vec::new()));
         data.attributes.push(attr_element!(
-                CKA_VALIDATION_LEVEL;
-                OAFlags::AlwaysRequired | OAFlags::NeverSettable
-                | OAFlags::Unchangeable; from_ulong; val 0));
+                CKA_VALIDATION_LEVEL; OAFlags::AlwaysRequired
+                | OAFlags::NeverSettable | OAFlags::Unchangeable;
+                Attribute::from_ulong; val 0));
         data.attributes.push(attr_element!(
-                CKA_VALIDATION_MODULE_ID;
-                OAFlags::AlwaysRequired | OAFlags::NeverSettable
-                | OAFlags::Unchangeable; from_string; val String::new()));
+                CKA_VALIDATION_MODULE_ID; OAFlags::AlwaysRequired
+                | OAFlags::NeverSettable | OAFlags::Unchangeable;
+                Attribute::from_string; val String::new()));
         data.attributes.push(attr_element!(
-                CKA_VALIDATION_FLAG;
-                OAFlags::AlwaysRequired | OAFlags::NeverSettable
-                | OAFlags::Unchangeable; from_ulong; val 0));
+                CKA_VALIDATION_FLAG; OAFlags::AlwaysRequired
+                | OAFlags::NeverSettable | OAFlags::Unchangeable;
+                Attribute::from_ulong; val 0));
         data.attributes.push(attr_element!(
-                CKA_VALIDATION_AUTHORITY_TYPE;
-                OAFlags::AlwaysRequired | OAFlags::NeverSettable
-                | OAFlags::Unchangeable; from_ulong; val 0));
+                CKA_VALIDATION_AUTHORITY_TYPE; OAFlags::AlwaysRequired
+                | OAFlags::NeverSettable | OAFlags::Unchangeable;
+                Attribute::from_ulong; val 0));
         data.attributes.push(attr_element!(
-                CKA_VALIDATION_COUNTRY;
-                OAFlags::AlwaysRequired | OAFlags::NeverSettable
-                | OAFlags::Unchangeable; from_string; val String::new()));
+                CKA_VALIDATION_COUNTRY; OAFlags::AlwaysRequired
+                | OAFlags::NeverSettable | OAFlags::Unchangeable;
+                Attribute::from_string; val String::new()));
         data.attributes.push(attr_element!(
-                CKA_VALIDATION_CERTIFICATE_IDENTIFIER;
-                OAFlags::AlwaysRequired | OAFlags::NeverSettable
-                | OAFlags::Unchangeable; from_string; val String::new()));
+                CKA_VALIDATION_CERTIFICATE_IDENTIFIER; OAFlags::AlwaysRequired
+                | OAFlags::NeverSettable | OAFlags::Unchangeable;
+                Attribute::from_string; val String::new()));
         data.attributes.push(attr_element!(
-                CKA_VALIDATION_CERTIFICATE_URI;
-                OAFlags::AlwaysRequired | OAFlags::NeverSettable
-                | OAFlags::Unchangeable; from_string; val String::new()));
+                CKA_VALIDATION_CERTIFICATE_URI; OAFlags::AlwaysRequired
+                | OAFlags::NeverSettable | OAFlags::Unchangeable;
+                Attribute::from_string; val String::new()));
         data.attributes.push(attr_element!(
-                CKA_VALIDATION_VENDOR_URI;
-                OAFlags::AlwaysRequired | OAFlags::NeverSettable
-                | OAFlags::Unchangeable; from_string; val String::new()));
+                CKA_VALIDATION_VENDOR_URI; OAFlags::AlwaysRequired
+                | OAFlags::NeverSettable | OAFlags::Unchangeable;
+                Attribute::from_string; val String::new()));
         data.attributes.push(attr_element!(
-                CKA_VALIDATION_PROFILE;
-                OAFlags::AlwaysRequired | OAFlags::NeverSettable
-                | OAFlags::Unchangeable; from_string; val String::new()));
+                CKA_VALIDATION_PROFILE; OAFlags::AlwaysRequired
+                | OAFlags::NeverSettable | OAFlags::Unchangeable;
+                Attribute::from_string; val String::new()));
         data
     }
 }
@@ -95,50 +94,50 @@ pub static VALIDATION_FACTORY: Lazy<Box<dyn ObjectFactory>> =
 pub fn insert_fips_validation(token: &mut Token) -> Result<()> {
     /* Synthesize a FIPS CKO_VALIDATION object */
     let mut obj = Object::new();
-    obj.set_attr(attribute::from_bool(CKA_TOKEN, false))?;
-    obj.set_attr(attribute::from_bool(CKA_DESTROYABLE, false))?;
-    obj.set_attr(attribute::from_bool(CKA_MODIFIABLE, false))?;
-    obj.set_attr(attribute::from_bool(CKA_PRIVATE, false))?;
-    obj.set_attr(attribute::from_bool(CKA_SENSITIVE, false))?;
-    obj.set_attr(attribute::from_ulong(CKA_CLASS, CKO_VALIDATION))?;
-    obj.set_attr(attribute::from_ulong(
+    obj.set_attr(Attribute::from_bool(CKA_TOKEN, false))?;
+    obj.set_attr(Attribute::from_bool(CKA_DESTROYABLE, false))?;
+    obj.set_attr(Attribute::from_bool(CKA_MODIFIABLE, false))?;
+    obj.set_attr(Attribute::from_bool(CKA_PRIVATE, false))?;
+    obj.set_attr(Attribute::from_bool(CKA_SENSITIVE, false))?;
+    obj.set_attr(Attribute::from_ulong(CKA_CLASS, CKO_VALIDATION))?;
+    obj.set_attr(Attribute::from_ulong(
         CKA_VALIDATION_TYPE,
         CKV_TYPE_SOFTWARE,
     ))?;
-    obj.set_attr(attribute::from_bytes(
+    obj.set_attr(Attribute::from_bytes(
         CKA_VALIDATION_VERSION,
         vec![3u8, 0u8],
     ))?;
-    obj.set_attr(attribute::from_ulong(CKA_VALIDATION_LEVEL, 1))?;
+    obj.set_attr(Attribute::from_ulong(CKA_VALIDATION_LEVEL, 1))?;
     /* TODO: This should be generated at build time */
-    obj.set_attr(attribute::from_string(
+    obj.set_attr(Attribute::from_string(
         CKA_VALIDATION_MODULE_ID,
         String::from("Kryoptic FIPS Module - v1"),
     ))?;
-    obj.set_attr(attribute::from_ulong(CKA_VALIDATION_FLAG, KRF_FIPS))?;
-    obj.set_attr(attribute::from_ulong(
+    obj.set_attr(Attribute::from_ulong(CKA_VALIDATION_FLAG, KRF_FIPS))?;
+    obj.set_attr(Attribute::from_ulong(
         CKA_VALIDATION_AUTHORITY_TYPE,
         CKV_AUTHORITY_TYPE_NIST_CMVP,
     ))?;
 
     /* TODO: The following attributes should all be determined at build time */
-    obj.set_attr(attribute::from_string(
+    obj.set_attr(Attribute::from_string(
         CKA_VALIDATION_COUNTRY,
         String::from("US"),
     ))?;
-    obj.set_attr(attribute::from_string(
+    obj.set_attr(Attribute::from_string(
         CKA_VALIDATION_CERTIFICATE_IDENTIFIER,
         String::from("Pending"),
     ))?;
-    obj.set_attr(attribute::from_string(
+    obj.set_attr(Attribute::from_string(
         CKA_VALIDATION_CERTIFICATE_URI,
         String::from(""),
     ))?;
-    obj.set_attr(attribute::from_string(
+    obj.set_attr(Attribute::from_string(
         CKA_VALIDATION_VENDOR_URI,
         String::from("https://github.com/latchset/kryoptic"),
     ))?;
-    obj.set_attr(attribute::from_string(
+    obj.set_attr(Attribute::from_string(
         CKA_VALIDATION_PROFILE,
         String::from(""),
     ))?;
@@ -1071,7 +1070,10 @@ pub fn is_approved(
                         Ok(f) => f,
                         Err(_) => 0,
                     } | KRF_FIPS;
-                    let _ = obj.set_attr(from_ulong(CKA_VALIDATION_FLAG, flag));
+                    let _ = obj.set_attr(Attribute::from_ulong(
+                        CKA_VALIDATION_FLAG,
+                        flag,
+                    ));
                     return true;
                 } else {
                     /* special case for HKDF which can return a DATA object */

--- a/src/kasn1.rs
+++ b/src/kasn1.rs
@@ -1,16 +1,15 @@
 // Copyright 2023 Simo Sorce
 // See LICENSE.txt file for terms
 
-// Helper routines to use with rust/asn1
-use super::error;
-use super::interface;
-
-use asn1;
-use error::Result;
-use interface::*;
 use std::borrow::Cow;
 
+use crate::error::Result;
+use crate::interface::*;
+
+use asn1;
 use zeroize::Zeroize;
+
+/* Helper routines to use with rust/asn1 */
 
 pub struct DerEncBigUint<'a> {
     data: Cow<'a, [u8]>,

--- a/src/mechanism.rs
+++ b/src/mechanism.rs
@@ -3,12 +3,9 @@
 
 use std::collections::BTreeMap;
 
-use super::error;
-use super::interface;
-use super::object;
-use error::Result;
-use interface::*;
-use object::{Object, ObjectFactories, ObjectFactory};
+use crate::error::Result;
+use crate::interface::*;
+use crate::object::{Object, ObjectFactories, ObjectFactory};
 
 use std::fmt::Debug;
 
@@ -17,14 +14,14 @@ pub trait Mechanism: Debug + Send + Sync {
     fn encryption_new(
         &self,
         _: &CK_MECHANISM,
-        _: &object::Object,
+        _: &Object,
     ) -> Result<Box<dyn Encryption>> {
         Err(CKR_MECHANISM_INVALID)?
     }
     fn decryption_new(
         &self,
         _: &CK_MECHANISM,
-        _: &object::Object,
+        _: &Object,
     ) -> Result<Box<dyn Decryption>> {
         Err(CKR_MECHANISM_INVALID)?
     }
@@ -34,22 +31,18 @@ pub trait Mechanism: Debug + Send + Sync {
     fn mac_new(
         &self,
         _: &CK_MECHANISM,
-        _: &object::Object,
+        _: &Object,
         _: CK_FLAGS,
     ) -> Result<Box<dyn Mac>> {
         Err(CKR_MECHANISM_INVALID)?
     }
-    fn sign_new(
-        &self,
-        _: &CK_MECHANISM,
-        _: &object::Object,
-    ) -> Result<Box<dyn Sign>> {
+    fn sign_new(&self, _: &CK_MECHANISM, _: &Object) -> Result<Box<dyn Sign>> {
         Err(CKR_MECHANISM_INVALID)?
     }
     fn verify_new(
         &self,
         _: &CK_MECHANISM,
-        _: &object::Object,
+        _: &Object,
     ) -> Result<Box<dyn Verify>> {
         Err(CKR_MECHANISM_INVALID)?
     }
@@ -76,8 +69,8 @@ pub trait Mechanism: Debug + Send + Sync {
     fn wrap_key(
         &self,
         _: &CK_MECHANISM,
-        _: &object::Object,
-        _: &object::Object,
+        _: &Object,
+        _: &Object,
         _: &mut [u8],
         _: &Box<dyn ObjectFactory>,
     ) -> Result<usize> {
@@ -87,7 +80,7 @@ pub trait Mechanism: Debug + Send + Sync {
     fn unwrap_key(
         &self,
         _: &CK_MECHANISM,
-        _: &object::Object,
+        _: &Object,
         _: &[u8],
         _: &[CK_ATTRIBUTE],
         _: &Box<dyn ObjectFactory>,
@@ -283,7 +276,7 @@ pub trait Verify: MechOperation {
 pub trait Derive: MechOperation {
     fn derive(
         &mut self,
-        _: &object::Object,
+        _: &Object,
         _: &[CK_ATTRIBUTE],
         _: &Mechanisms,
         _: &ObjectFactories,

--- a/src/native/sp800_108.rs
+++ b/src/native/sp800_108.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use crate::attribute::from_bytes;
+use crate::attribute::Attribute;
 use crate::error;
 use crate::error::Result;
 use crate::interface::*;
@@ -467,7 +467,7 @@ impl Derive for Sp800Operation {
         for key in &mut keys {
             let keysize =
                 usize::try_from(key.get_attr_as_ulong(CKA_VALUE_LEN)?)?;
-            key.set_attr(from_bytes(
+            key.set_attr(Attribute::from_bytes(
                 CKA_VALUE,
                 dkm[cursor..(cursor + keysize)].to_vec(),
             ))?;

--- a/src/native/sshkdf.rs
+++ b/src/native/sshkdf.rs
@@ -3,7 +3,7 @@
 
 use std::fmt::Debug;
 
-use crate::attribute::from_bytes;
+use crate::attribute::Attribute;
 use crate::error::Result;
 use crate::hash;
 use crate::interface::*;
@@ -129,7 +129,7 @@ impl Derive for SSHKDFOperation {
             curlen += len;
         }
 
-        dobj.set_attr(from_bytes(CKA_VALUE, dkm))?;
+        dobj.set_attr(Attribute::from_bytes(CKA_VALUE, dkm))?;
         Ok(vec![dobj])
     }
 }

--- a/src/object.rs
+++ b/src/object.rs
@@ -8,6 +8,7 @@ use crate::attribute::{AttrType, Attribute};
 use crate::error::{Error, Result};
 use crate::interface::*;
 use crate::mechanism::{Mechanism, Mechanisms};
+use crate::CSPRNG;
 
 use bitflags::bitflags;
 use once_cell::sync::Lazy;
@@ -1200,7 +1201,7 @@ pub fn default_secret_key_generate(key: &mut Object) -> Result<()> {
     let value_len = usize::try_from(key.get_attr_as_ulong(CKA_VALUE_LEN)?)?;
 
     let mut value: Vec<u8> = vec![0; value_len];
-    match super::CSPRNG
+    match CSPRNG
         .with(|rng| rng.borrow_mut().generate_random(value.as_mut_slice()))
     {
         Ok(()) => (),

--- a/src/ossl/common.rs
+++ b/src/ossl/common.rs
@@ -4,14 +4,13 @@
 use std::borrow::Cow;
 use std::ffi::{c_char, c_int, c_uint, c_void};
 
-use super::super::interface::*;
-use super::super::{byte_ptr, void_ptr};
 use crate::error::Result;
+use crate::interface::*;
+use crate::ossl::bindings::*;
+use crate::ossl::get_libctx;
+use crate::{byte_ptr, void_ptr};
 
 use zeroize::Zeroize;
-
-use super::bindings::*;
-use super::get_libctx;
 
 macro_rules! ptr_wrapper_struct {
     ($name:ident; $ctx:ident) => {

--- a/src/ossl/ecc.rs
+++ b/src/ossl/ecc.rs
@@ -4,8 +4,7 @@
 use core::ffi::{c_char, c_int, c_uint};
 use std::borrow::Cow;
 
-use crate::attribute;
-use crate::attribute::CkAttrs;
+use crate::attribute::{Attribute, CkAttrs};
 use crate::ecc::*;
 use crate::ecc_misc::*;
 use crate::error::Result;
@@ -324,10 +323,10 @@ impl EccOperation {
             Ok(b) => b,
             Err(_) => return Err(CKR_GENERAL_ERROR)?,
         };
-        pubkey.set_attr(attribute::from_bytes(CKA_EC_POINT, point_encoded))?;
+        pubkey.set_attr(Attribute::from_bytes(CKA_EC_POINT, point_encoded))?;
 
         /* Private Key */
-        privkey.set_attr(attribute::from_bytes(
+        privkey.set_attr(Attribute::from_bytes(
             CKA_VALUE,
             params.get_bn(name_as_char(OSSL_PKEY_PARAM_PRIV_KEY))?,
         ))?;

--- a/src/ossl/eddsa.rs
+++ b/src/ossl/eddsa.rs
@@ -3,7 +3,7 @@
 
 use std::ffi::{c_char, c_int};
 
-use crate::attribute;
+use crate::attribute::Attribute;
 use crate::ecc_misc::*;
 use crate::error::Result;
 use crate::interface::*;
@@ -293,13 +293,13 @@ impl EddsaOperation {
             Ok(b) => b,
             Err(_) => return Err(CKR_GENERAL_ERROR)?,
         };
-        pubkey.set_attr(attribute::from_bytes(CKA_EC_POINT, point_encoded))?;
+        pubkey.set_attr(Attribute::from_bytes(CKA_EC_POINT, point_encoded))?;
 
         /* Private Key */
         let value = params
             .get_octet_string(name_as_char(OSSL_PKEY_PARAM_PRIV_KEY))?
             .to_vec();
-        privkey.set_attr(attribute::from_bytes(CKA_VALUE, value))?;
+        privkey.set_attr(Attribute::from_bytes(CKA_VALUE, value))?;
         Ok(())
     }
 }

--- a/src/ossl/fips.rs
+++ b/src/ossl/fips.rs
@@ -1,9 +1,6 @@
 // Copyright 2023 Simo Sorce
 // See LICENSE.txt file for terms
 
-use getrandom;
-use libc;
-use once_cell::sync::Lazy;
 use std::ffi::CStr;
 use std::ffi::{c_char, c_int, c_uchar, c_uint, c_void};
 use std::fs::File;
@@ -12,13 +9,16 @@ use std::io::Seek;
 use std::io::SeekFrom;
 use std::path::Path;
 use std::slice;
-use zeroize::Zeroize;
 
 use crate::error::Result;
 use crate::interface::*;
+use crate::ossl::bindings::*;
+use crate::ossl::common::*;
 
-use super::bindings::*;
-use super::common::*;
+use getrandom;
+use libc;
+use once_cell::sync::Lazy;
+use zeroize::Zeroize;
 
 /* Entropy Stuff */
 

--- a/src/ossl/hkdf.rs
+++ b/src/ossl/hkdf.rs
@@ -4,7 +4,7 @@
 use core::ffi::c_int;
 use std::fmt::Debug;
 
-use crate::attribute::from_bytes;
+use crate::attribute::Attribute;
 use crate::error::Result;
 use crate::hash::INVALID_HASH_SIZE;
 use crate::hmac::hmac_size;
@@ -285,7 +285,7 @@ impl Derive for HKDFOperation {
             self.fips_approved = check_kdf_fips_indicators(&mut kctx)?;
         }
 
-        obj.set_attr(from_bytes(CKA_VALUE, dkm))?;
+        obj.set_attr(Attribute::from_bytes(CKA_VALUE, dkm))?;
 
         Ok(vec![obj])
     }

--- a/src/ossl/kbkdf.rs
+++ b/src/ossl/kbkdf.rs
@@ -3,7 +3,7 @@
 
 use std::ffi::c_int;
 
-use crate::attribute::from_bytes;
+use crate::attribute::Attribute;
 use crate::error;
 use crate::error::Result;
 use crate::interface::*;
@@ -544,7 +544,7 @@ impl Derive for Sp800Operation {
         for key in &mut keys {
             let keysize =
                 usize::try_from(key.get_attr_as_ulong(CKA_VALUE_LEN)?)?;
-            key.set_attr(from_bytes(
+            key.set_attr(Attribute::from_bytes(
                 CKA_VALUE,
                 dkm[cursor..(cursor + keysize)].to_vec(),
             ))?;

--- a/src/ossl/rsa.rs
+++ b/src/ossl/rsa.rs
@@ -3,7 +3,7 @@
 
 use core::ffi::{c_char, c_int, c_uint};
 
-use crate::attribute;
+use crate::attribute::Attribute;
 use crate::error::{Error, Result};
 use crate::hash::{hash_size, INVALID_HASH_SIZE};
 use crate::interface::*;
@@ -418,41 +418,41 @@ impl RsaPKCSOperation {
         }
         let params = OsslParam::from_ptr(params)?;
         /* Public Key (has E already set) */
-        pubkey.set_attr(attribute::from_bytes(
+        pubkey.set_attr(Attribute::from_bytes(
             CKA_MODULUS,
             params.get_bn(name_as_char(OSSL_PKEY_PARAM_RSA_N))?,
         ))?;
 
         /* Private Key */
-        privkey.set_attr(attribute::from_bytes(
+        privkey.set_attr(Attribute::from_bytes(
             CKA_MODULUS,
             params.get_bn(name_as_char(OSSL_PKEY_PARAM_RSA_N))?,
         ))?;
-        privkey.set_attr(attribute::from_bytes(
+        privkey.set_attr(Attribute::from_bytes(
             CKA_PUBLIC_EXPONENT,
             params.get_bn(name_as_char(OSSL_PKEY_PARAM_RSA_E))?,
         ))?;
-        privkey.set_attr(attribute::from_bytes(
+        privkey.set_attr(Attribute::from_bytes(
             CKA_PRIVATE_EXPONENT,
             params.get_bn(name_as_char(OSSL_PKEY_PARAM_RSA_D))?,
         ))?;
-        privkey.set_attr(attribute::from_bytes(
+        privkey.set_attr(Attribute::from_bytes(
             CKA_PRIME_1,
             params.get_bn(name_as_char(OSSL_PKEY_PARAM_RSA_FACTOR1))?,
         ))?;
-        privkey.set_attr(attribute::from_bytes(
+        privkey.set_attr(Attribute::from_bytes(
             CKA_PRIME_2,
             params.get_bn(name_as_char(OSSL_PKEY_PARAM_RSA_FACTOR2))?,
         ))?;
-        privkey.set_attr(attribute::from_bytes(
+        privkey.set_attr(Attribute::from_bytes(
             CKA_EXPONENT_1,
             params.get_bn(name_as_char(OSSL_PKEY_PARAM_RSA_EXPONENT1))?,
         ))?;
-        privkey.set_attr(attribute::from_bytes(
+        privkey.set_attr(Attribute::from_bytes(
             CKA_EXPONENT_2,
             params.get_bn(name_as_char(OSSL_PKEY_PARAM_RSA_EXPONENT2))?,
         ))?;
-        privkey.set_attr(attribute::from_bytes(
+        privkey.set_attr(Attribute::from_bytes(
             CKA_COEFFICIENT,
             params.get_bn(name_as_char(OSSL_PKEY_PARAM_RSA_COEFFICIENT1))?,
         ))?;

--- a/src/ossl/sshkdf.rs
+++ b/src/ossl/sshkdf.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use crate::attribute::from_bytes;
+use crate::attribute::Attribute;
 use crate::error::Result;
 use crate::hash;
 use crate::interface::*;
@@ -139,7 +139,7 @@ impl Derive for SSHKDFOperation {
 
         self.fips_approved = check_kdf_fips_indicators(&mut kctx)?;
 
-        dobj.set_attr(from_bytes(CKA_VALUE, dkm))?;
+        dobj.set_attr(Attribute::from_bytes(CKA_VALUE, dkm))?;
         Ok(vec![dobj])
     }
 }

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -3,7 +3,7 @@
 
 use std::fmt::Debug;
 
-use crate::attribute::{from_bool, from_bytes, from_ulong, CkAttrs};
+use crate::attribute::{Attribute, CkAttrs};
 use crate::error::Result;
 use crate::hmac;
 use crate::interface::*;
@@ -44,14 +44,14 @@ impl PBKDF2Mechanism {
     fn mock_password_object(&self, key: Vec<u8>) -> Result<Object> {
         let mut obj = Object::new();
         obj.set_zeroize();
-        obj.set_attr(from_ulong(CKA_CLASS, CKO_SECRET_KEY))?;
-        obj.set_attr(from_ulong(CKA_KEY_TYPE, CKK_GENERIC_SECRET))?;
-        obj.set_attr(from_ulong(
+        obj.set_attr(Attribute::from_ulong(CKA_CLASS, CKO_SECRET_KEY))?;
+        obj.set_attr(Attribute::from_ulong(CKA_KEY_TYPE, CKK_GENERIC_SECRET))?;
+        obj.set_attr(Attribute::from_ulong(
             CKA_VALUE_LEN,
             CK_ULONG::try_from(key.len())?,
         ))?;
-        obj.set_attr(from_bytes(CKA_VALUE, key))?;
-        obj.set_attr(from_bool(CKA_DERIVE, true))?;
+        obj.set_attr(Attribute::from_bytes(CKA_VALUE, key))?;
+        obj.set_attr(Attribute::from_bool(CKA_DERIVE, true))?;
         Ok(obj)
     }
 }

--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -3,8 +3,7 @@
 
 use std::fmt::Debug;
 
-use crate::attribute;
-use crate::attribute::{from_bool, from_bytes, from_ulong};
+use crate::attribute::Attribute;
 use crate::error::Result;
 use crate::interface::*;
 use crate::kasn1::{DerEncBigUint, PrivateKeyInfo};
@@ -69,9 +68,15 @@ impl RSAPubFactory {
         data.attributes.append(&mut data.init_common_key_attrs());
         data.attributes
             .append(&mut data.init_common_public_key_attrs());
-        data.attributes.push(attr_element!(CKA_MODULUS; OAFlags::RequiredOnCreate | OAFlags::Unchangeable; from_bytes; val Vec::new()));
-        data.attributes.push(attr_element!(CKA_MODULUS_BITS; OAFlags::RequiredOnGenerate | OAFlags::Unchangeable; from_ulong; val 0));
-        data.attributes.push(attr_element!(CKA_PUBLIC_EXPONENT; OAFlags::RequiredOnCreate | OAFlags::Unchangeable; from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(
+            CKA_MODULUS; OAFlags::RequiredOnCreate | OAFlags::Unchangeable;
+            Attribute::from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(
+            CKA_MODULUS_BITS; OAFlags::RequiredOnGenerate
+            | OAFlags::Unchangeable; Attribute::from_ulong; val 0));
+        data.attributes.push(attr_element!(
+            CKA_PUBLIC_EXPONENT; OAFlags::RequiredOnCreate
+            | OAFlags::Unchangeable; Attribute::from_bytes; val Vec::new()));
         data
     }
 }
@@ -159,17 +164,36 @@ impl RSAPrivFactory {
         data.attributes.append(&mut data.init_common_key_attrs());
         data.attributes
             .append(&mut data.init_common_private_key_attrs());
-        data.attributes.push(attr_element!(CKA_MODULUS; OAFlags::RequiredOnCreate | OAFlags::Unchangeable; from_bytes; val Vec::new()));
-        data.attributes.push(attr_element!(CKA_PUBLIC_EXPONENT; OAFlags::RequiredOnCreate | OAFlags::Unchangeable; from_bytes; val Vec::new()));
-        data.attributes.push(attr_element!(CKA_PRIVATE_EXPONENT; OAFlags::Sensitive | OAFlags::RequiredOnCreate | OAFlags::SettableOnlyOnCreate | OAFlags::Unchangeable; from_bytes; val Vec::new()));
-        data.attributes.push(attr_element!(CKA_PRIME_1; OAFlags::Sensitive | OAFlags::SettableOnlyOnCreate | OAFlags::Unchangeable; from_bytes; val Vec::new()));
-        data.attributes.push(attr_element!(CKA_PRIME_2; OAFlags::Sensitive | OAFlags::SettableOnlyOnCreate | OAFlags::Unchangeable; from_bytes; val Vec::new()));
-        data.attributes.push(attr_element!(CKA_EXPONENT_1; OAFlags::Sensitive | OAFlags::SettableOnlyOnCreate | OAFlags::Unchangeable; from_bytes; val Vec::new()));
-        data.attributes.push(attr_element!(CKA_EXPONENT_2; OAFlags::Sensitive | OAFlags::SettableOnlyOnCreate | OAFlags::Unchangeable; from_bytes; val Vec::new()));
-        data.attributes.push(attr_element!(CKA_COEFFICIENT; OAFlags::Sensitive | OAFlags::SettableOnlyOnCreate | OAFlags::Unchangeable; from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(
+            CKA_MODULUS; OAFlags::RequiredOnCreate | OAFlags::Unchangeable;
+            Attribute::from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(
+            CKA_PUBLIC_EXPONENT; OAFlags::RequiredOnCreate
+            | OAFlags::Unchangeable; Attribute::from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(
+            CKA_PRIVATE_EXPONENT; OAFlags::Sensitive
+            | OAFlags::RequiredOnCreate | OAFlags::SettableOnlyOnCreate
+            | OAFlags::Unchangeable; Attribute::from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(
+            CKA_PRIME_1; OAFlags::Sensitive | OAFlags::SettableOnlyOnCreate
+            | OAFlags::Unchangeable; Attribute::from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(
+            CKA_PRIME_2; OAFlags::Sensitive | OAFlags::SettableOnlyOnCreate
+            | OAFlags::Unchangeable; Attribute::from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(
+            CKA_EXPONENT_1; OAFlags::Sensitive | OAFlags::SettableOnlyOnCreate
+            | OAFlags::Unchangeable; Attribute::from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(
+            CKA_EXPONENT_2; OAFlags::Sensitive | OAFlags::SettableOnlyOnCreate
+            | OAFlags::Unchangeable; Attribute::from_bytes; val Vec::new()));
+        data.attributes.push(attr_element!(
+            CKA_COEFFICIENT; OAFlags::Sensitive | OAFlags::SettableOnlyOnCreate
+            | OAFlags::Unchangeable; Attribute::from_bytes; val Vec::new()));
 
         /* default to private */
-        let private = attr_element!(CKA_PRIVATE; OAFlags::Defval | OAFlags::ChangeOnCopy; from_bool; val true);
+        let private = attr_element!(
+            CKA_PRIVATE; OAFlags::Defval | OAFlags::ChangeOnCopy;
+            Attribute::from_bool; val true);
         match data
             .attributes
             .iter()
@@ -244,14 +268,14 @@ impl PrivKeyFactory for RSAPrivFactory {
     ) -> Result<Object> {
         let mut key = self.default_object_unwrap(template)?;
 
-        if !key.check_or_set_attr(attribute::from_ulong(
+        if !key.check_or_set_attr(Attribute::from_ulong(
             CKA_CLASS,
             CKO_PRIVATE_KEY,
         ))? {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
         if !key
-            .check_or_set_attr(attribute::from_ulong(CKA_KEY_TYPE, CKK_RSA))?
+            .check_or_set_attr(Attribute::from_ulong(CKA_KEY_TYPE, CKK_RSA))?
         {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
@@ -278,49 +302,49 @@ impl PrivKeyFactory for RSAPrivFactory {
             Err(_) => return Err(CKR_WRAPPED_KEY_INVALID)?,
         };
 
-        if !key.check_or_set_attr(attribute::from_bytes(
+        if !key.check_or_set_attr(Attribute::from_bytes(
             CKA_MODULUS,
             rsapkey.modulus.as_nopad_bytes().to_vec(),
         ))? {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
-        if !key.check_or_set_attr(attribute::from_bytes(
+        if !key.check_or_set_attr(Attribute::from_bytes(
             CKA_PUBLIC_EXPONENT,
             rsapkey.public_exponent.as_nopad_bytes().to_vec(),
         ))? {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
-        if !key.check_or_set_attr(attribute::from_bytes(
+        if !key.check_or_set_attr(Attribute::from_bytes(
             CKA_PRIVATE_EXPONENT,
             rsapkey.private_exponent.as_nopad_bytes().to_vec(),
         ))? {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
-        if !key.check_or_set_attr(attribute::from_bytes(
+        if !key.check_or_set_attr(Attribute::from_bytes(
             CKA_PRIME_1,
             rsapkey.prime1.as_nopad_bytes().to_vec(),
         ))? {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
-        if !key.check_or_set_attr(attribute::from_bytes(
+        if !key.check_or_set_attr(Attribute::from_bytes(
             CKA_PRIME_2,
             rsapkey.prime2.as_nopad_bytes().to_vec(),
         ))? {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
-        if !key.check_or_set_attr(attribute::from_bytes(
+        if !key.check_or_set_attr(Attribute::from_bytes(
             CKA_EXPONENT_1,
             rsapkey.exponent1.as_nopad_bytes().to_vec(),
         ))? {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
-        if !key.check_or_set_attr(attribute::from_bytes(
+        if !key.check_or_set_attr(Attribute::from_bytes(
             CKA_EXPONENT_2,
             rsapkey.exponent2.as_nopad_bytes().to_vec(),
         ))? {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
-        if !key.check_or_set_attr(attribute::from_bytes(
+        if !key.check_or_set_attr(Attribute::from_bytes(
             CKA_COEFFICIENT,
             rsapkey.coefficient.as_nopad_bytes().to_vec(),
         ))? {
@@ -484,14 +508,14 @@ impl Mechanism for RsaPKCSMechanism {
     ) -> Result<(Object, Object)> {
         let mut pubkey =
             PUBLIC_KEY_FACTORY.default_object_generate(pubkey_template)?;
-        if !pubkey.check_or_set_attr(attribute::from_ulong(
+        if !pubkey.check_or_set_attr(Attribute::from_ulong(
             CKA_CLASS,
             CKO_PUBLIC_KEY,
         ))? {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
         if !pubkey
-            .check_or_set_attr(attribute::from_ulong(CKA_KEY_TYPE, CKK_RSA))?
+            .check_or_set_attr(Attribute::from_ulong(CKA_KEY_TYPE, CKK_RSA))?
         {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
@@ -501,7 +525,7 @@ impl Mechanism for RsaPKCSMechanism {
         let exponent: Vec<u8> = match pubkey.get_attr(CKA_PUBLIC_EXPONENT) {
             Some(a) => a.get_value().clone(),
             None => {
-                pubkey.set_attr(attribute::from_bytes(
+                pubkey.set_attr(Attribute::from_bytes(
                     CKA_PUBLIC_EXPONENT,
                     vec![0x01, 0x00, 0x01],
                 ))?;
@@ -511,14 +535,14 @@ impl Mechanism for RsaPKCSMechanism {
 
         let mut privkey =
             PRIVATE_KEY_FACTORY.default_object_generate(prikey_template)?;
-        if !privkey.check_or_set_attr(attribute::from_ulong(
+        if !privkey.check_or_set_attr(Attribute::from_ulong(
             CKA_CLASS,
             CKO_PRIVATE_KEY,
         ))? {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }
         if !privkey
-            .check_or_set_attr(attribute::from_ulong(CKA_KEY_TYPE, CKK_RSA))?
+            .check_or_set_attr(Attribute::from_ulong(CKA_KEY_TYPE, CKK_RSA))?
         {
             return Err(CKR_TEMPLATE_INCONSISTENT)?;
         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -3,18 +3,13 @@
 
 use std::vec::Vec;
 
-use super::error;
-use super::interface;
-use super::mechanism;
-use super::token;
-
-use error::Result;
-use interface::*;
-use mechanism::{Operation, SearchOperation};
-use token::Token;
+use crate::error::Result;
+use crate::interface::*;
+use crate::mechanism::{Operation, SearchOperation};
+use crate::token::Token;
 
 #[cfg(feature = "fips")]
-use super::fips;
+use crate::fips;
 
 #[derive(Debug)]
 pub struct SessionSearch {

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -4,13 +4,10 @@
 use std::collections::HashMap;
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-use super::error;
-use super::interface;
-use super::session::Session;
-use super::token::Token;
-
-use error::Result;
-use interface::*;
+use crate::error::Result;
+use crate::interface::*;
+use crate::session::Session;
+use crate::token::Token;
 
 static SLOT_DESCRIPTION: [CK_UTF8CHAR; 64usize] =
     *b"Kryoptic Slot                                                   ";

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,13 +1,9 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::error;
-use super::interface;
-use super::object;
-
-use error::Result;
-use interface::CK_ATTRIBUTE;
-use object::Object;
+use crate::error::Result;
+use crate::interface::CK_ATTRIBUTE;
+use crate::object::Object;
 
 use std::fmt::Debug;
 

--- a/src/storage/json.rs
+++ b/src/storage/json.rs
@@ -1,21 +1,15 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
+use crate::attribute::{string_to_ck_date, AttrType, Attribute};
+use crate::error::{Error, Result};
+use crate::interface::*;
+use crate::object::Object;
+use crate::storage::{memory, Storage};
+
 use data_encoding::BASE64;
 use serde::{Deserialize, Serialize};
 use serde_json::{from_reader, to_string_pretty, Map, Number, Value};
-
-use super::super::error;
-use super::super::interface;
-use super::super::object;
-use crate::attribute::{string_to_ck_date, AttrType, Attribute};
-
-use super::memory;
-use super::Storage;
-
-use error::Result;
-use interface::*;
-use object::Object;
 
 fn to_json_value(a: &Attribute) -> Value {
     match a.get_attrtype() {
@@ -41,11 +35,11 @@ fn to_json_value(a: &Attribute) -> Value {
     }
 }
 
-fn uninit(e: std::io::Error) -> error::Error {
+fn uninit(e: std::io::Error) -> Error {
     if e.kind() == std::io::ErrorKind::NotFound {
-        error::Error::ck_rv_from_error(CKR_CRYPTOKI_NOT_INITIALIZED, e)
+        Error::ck_rv_from_error(CKR_CRYPTOKI_NOT_INITIALIZED, e)
     } else {
-        error::Error::other_error(e)
+        Error::other_error(e)
     }
 }
 
@@ -163,11 +157,11 @@ impl JsonToken {
     pub fn save(&self, filename: &str) -> Result<()> {
         let jstr = match to_string_pretty(&self) {
             Ok(j) => j,
-            Err(e) => return Err(error::Error::other_error(e)),
+            Err(e) => return Err(Error::other_error(e)),
         };
         match std::fs::write(filename, jstr) {
             Ok(_) => Ok(()),
-            Err(e) => Err(error::Error::other_error(e)),
+            Err(e) => Err(Error::other_error(e)),
         }
     }
 }

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -1,18 +1,13 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::super::error;
-use super::super::interface;
-use super::super::object;
 use std::collections::HashMap;
-
-use super::Storage;
-
-use error::{Error, Result};
-use interface::*;
-use object::Object;
-
 use std::fmt::Debug;
+
+use crate::error::{Error, Result};
+use crate::interface::*;
+use crate::object::Object;
+use crate::storage::Storage;
 
 #[derive(Debug)]
 struct MemoryStorage {

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -1,26 +1,22 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use rusqlite::{params, types::Value, Connection, Rows, Transaction};
 use std::sync::{Arc, Mutex};
 
-use super::super::error;
-use super::super::interface;
-use super::super::object;
 use crate::attribute::{string_to_ck_date, AttrType, Attribute};
+use crate::error::{Error, Result};
+use crate::interface::*;
+use crate::object::Object;
+use crate::storage::Storage;
 
-use super::Storage;
+use rusqlite::{params, types::Value, Connection, Rows, Transaction};
 
-use error::{Error, Result};
-use interface::*;
-use object::Object;
-
-fn bad_code<E: std::error::Error + 'static>(error: E) -> error::Error {
-    error::Error::ck_rv_from_error(CKR_GENERAL_ERROR, error)
+fn bad_code<E: std::error::Error + 'static>(error: E) -> Error {
+    Error::ck_rv_from_error(CKR_GENERAL_ERROR, error)
 }
 
-fn bad_storage<E: std::error::Error + 'static>(error: E) -> error::Error {
-    error::Error::ck_rv_from_error(CKR_DEVICE_MEMORY, error)
+fn bad_storage<E: std::error::Error + 'static>(error: E) -> Error {
+    Error::ck_rv_from_error(CKR_DEVICE_MEMORY, error)
 }
 
 const IS_DB_INITIALIZED: &str =
@@ -246,7 +242,7 @@ impl SqliteStorage {
         Ok(objid)
     }
 
-    fn num_to_val(ulong: CK_ULONG) -> error::Result<Value> {
+    fn num_to_val(ulong: CK_ULONG) -> Result<Value> {
         /* CK_UNAVAILABLE_INFORMATION need to be special cased */
         /* for storage compatibility CK_ULONGs can only be stored as u32
          * values and PKCS#11 spec pay attentions to never allocate numbers
@@ -265,7 +261,7 @@ impl SqliteStorage {
         Ok(Value::from(val))
     }
 
-    fn val_to_ulong(val: i64) -> error::Result<CK_ULONG> {
+    fn val_to_ulong(val: i64) -> Result<CK_ULONG> {
         /* we need to map back CK_UNAVAILABLE_INFORMATION's special case */
         if val == -1 {
             Ok(CK_UNAVAILABLE_INFORMATION)

--- a/src/tests/aes.rs
+++ b/src/tests/aes.rs
@@ -1,8 +1,7 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
+use crate::tests::*;
 
 use serial_test::parallel;
 

--- a/src/tests/aes_kw_vectors.rs
+++ b/src/tests/aes_kw_vectors.rs
@@ -1,12 +1,12 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
-
-use serial_test::parallel;
 use std::io;
 use std::io::BufRead;
+
+use crate::tests::*;
+
+use serial_test::parallel;
 
 #[derive(Debug)]
 struct TestUnit {

--- a/src/tests/attrs.rs
+++ b/src/tests/attrs.rs
@@ -1,8 +1,7 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
+use crate::tests::*;
 
 use serial_test::parallel;
 

--- a/src/tests/ecc.rs
+++ b/src/tests/ecc.rs
@@ -1,8 +1,7 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
+use crate::tests::*;
 
 use serial_test::parallel;
 

--- a/src/tests/ecdh.rs
+++ b/src/tests/ecdh.rs
@@ -1,8 +1,7 @@
 // Copyright 2024 Jakub Jelen
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
+use crate::tests::*;
 
 use serial_test::parallel;
 

--- a/src/tests/ecdh_vectors.rs
+++ b/src/tests/ecdh_vectors.rs
@@ -1,13 +1,13 @@
 // Copyright 2024 Jakub Jelen
 // See LICENSE.txt file for terms
 
-use super::tests;
-use crate::ecc;
-use tests::*;
-
-use serial_test::parallel;
 use std::io;
 use std::io::BufRead;
+
+use crate::ecc;
+use crate::tests::*;
+
+use serial_test::parallel;
 
 #[derive(Debug)]
 struct EccKey {

--- a/src/tests/eddsa.rs
+++ b/src/tests/eddsa.rs
@@ -1,11 +1,10 @@
 // Copyright 2024 Simo Sorce, Jakub Jelen
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
-
 use std::io;
 use std::io::BufRead;
+
+use crate::tests::*;
 
 use serial_test::parallel;
 

--- a/src/tests/hashes.rs
+++ b/src/tests/hashes.rs
@@ -1,8 +1,7 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
+use crate::tests::*;
 
 use serial_test::parallel;
 

--- a/src/tests/init.rs
+++ b/src/tests/init.rs
@@ -1,13 +1,11 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
-
-use serial_test::{parallel, serial};
-
 #[cfg(feature = "fips")]
 use crate::fips::indicators::KRF_FIPS;
+use crate::tests::*;
+
+use serial_test::{parallel, serial};
 
 #[test]
 #[parallel]

--- a/src/tests/kdf_vectors.rs
+++ b/src/tests/kdf_vectors.rs
@@ -1,12 +1,12 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
-
-use serial_test::parallel;
 use std::io;
 use std::io::BufRead;
+
+use crate::tests::*;
+
+use serial_test::parallel;
 
 #[derive(Debug, PartialEq)]
 enum KdfCtrlLoc {

--- a/src/tests/kdfs.rs
+++ b/src/tests/kdfs.rs
@@ -1,10 +1,9 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use itertools::Itertools;
-use tests::*;
+use crate::tests::*;
 
+use itertools::Itertools;
 use serial_test::parallel;
 
 #[cfg(feature = "sp800_108")]

--- a/src/tests/keys.rs
+++ b/src/tests/keys.rs
@@ -1,8 +1,7 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
+use crate::tests::*;
 
 use serial_test::parallel;
 

--- a/src/tests/login.rs
+++ b/src/tests/login.rs
@@ -1,8 +1,7 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
+use crate::tests::*;
 
 use serial_test::parallel;
 

--- a/src/tests/mac_vectors.rs
+++ b/src/tests/mac_vectors.rs
@@ -1,12 +1,12 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
-
-use serial_test::parallel;
 use std::io;
 use std::io::BufRead;
+
+use crate::tests::*;
+
+use serial_test::parallel;
 
 #[derive(Debug)]
 struct TestUnit {

--- a/src/tests/mechs.rs
+++ b/src/tests/mechs.rs
@@ -1,8 +1,7 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
+use crate::tests::*;
 
 use serial_test::parallel;
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,10 +1,12 @@
 // Copyright 2023 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::*;
-use hex;
 use std::ffi::CString;
 use std::sync::Once;
+
+use crate::*;
+
+use hex;
 
 #[macro_use]
 mod util;

--- a/src/tests/objects.rs
+++ b/src/tests/objects.rs
@@ -1,8 +1,7 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
+use crate::tests::*;
 
 use serial_test::parallel;
 

--- a/src/tests/random.rs
+++ b/src/tests/random.rs
@@ -1,8 +1,7 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
+use crate::tests::*;
 
 use serial_test::parallel;
 

--- a/src/tests/rsa.rs
+++ b/src/tests/rsa.rs
@@ -1,8 +1,7 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
+use crate::tests::*;
 
 use serial_test::parallel;
 

--- a/src/tests/session.rs
+++ b/src/tests/session.rs
@@ -1,8 +1,7 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
+use crate::tests::*;
 
 use serial_test::parallel;
 

--- a/src/tests/signatures.rs
+++ b/src/tests/signatures.rs
@@ -1,8 +1,7 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
+use crate::tests::*;
 
 use serial_test::parallel;
 

--- a/src/tests/tls.rs
+++ b/src/tests/tls.rs
@@ -1,16 +1,16 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::attribute;
-use super::hmac;
-use super::object;
-use super::tests;
-use super::tlskdf;
-use tests::*;
-
-use serial_test::parallel;
 use std::io;
 use std::io::BufRead;
+
+use crate::attribute::Attribute;
+use crate::hmac;
+use crate::object;
+use crate::tests::*;
+use crate::tlskdf;
+
+use serial_test::parallel;
 
 #[test]
 #[parallel]
@@ -96,18 +96,18 @@ fn test_tlsprf_vectors() {
 
         /* mock key */
         let mut key = object::Object::new();
-        key.set_attr(attribute::from_ulong(CKA_CLASS, CKO_SECRET_KEY))
+        key.set_attr(Attribute::from_ulong(CKA_CLASS, CKO_SECRET_KEY))
             .unwrap();
-        key.set_attr(attribute::from_ulong(CKA_KEY_TYPE, CKK_GENERIC_SECRET))
+        key.set_attr(Attribute::from_ulong(CKA_KEY_TYPE, CKK_GENERIC_SECRET))
             .unwrap();
-        key.set_attr(attribute::from_bytes(CKA_VALUE, secret.clone()))
+        key.set_attr(Attribute::from_bytes(CKA_VALUE, secret.clone()))
             .unwrap();
-        key.set_attr(attribute::from_ulong(
+        key.set_attr(Attribute::from_ulong(
             CKA_VALUE_LEN,
             secret.len() as CK_ULONG,
         ))
         .unwrap();
-        key.set_attr(attribute::from_bool(CKA_DERIVE, true))
+        key.set_attr(Attribute::from_bool(CKA_DERIVE, true))
             .unwrap();
 
         let mech = hmac::test_get_hmac(mechtype);

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -1,11 +1,11 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
+use std::env;
+
+use crate::tests::*;
 
 use serial_test::{parallel, serial};
-use std::env;
 
 fn test_token(name: &str) {
     let mut testtokn = TestToken::new(name, true);

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -1,8 +1,7 @@
 // Copyright 2024 Simo Sorce
 // See LICENSE.txt file for terms
 
-use super::tests;
-use tests::*;
+use crate::tests::*;
 
 pub const CK_ULONG_SIZE: usize = std::mem::size_of::<CK_ULONG>();
 pub const CK_BBOOL_SIZE: usize = std::mem::size_of::<CK_BBOOL>();


### PR DESCRIPTION
Instead of using functions, implement methods on strcuts and enums. This looks more ergonomic and gives a better way to import the objects as well as a clear signal of what the output of the function actually is.