### PR TITLE
bindings: Create 32b compatible bindings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -162,6 +162,7 @@ fn main() {
         .blocklist_type("CK_FUNCTION_LIST_PTR")
         .blocklist_type("CK_FUNCTION_LIST_3_0_PTR")
         .blocklist_type("CK_INTERFACE")
+        .blocklist_var("CK_UNAVAILABLE_INFORMATION")
         .parse_callbacks(Box::new(Pkcs11Callbacks))
         .generate()
         .expect("Unable to generate bindings")

--- a/src/pkcs11/interface.rs
+++ b/src/pkcs11/interface.rs
@@ -6,6 +6,9 @@ include!("bindings.rs");
 // types that need different mutability than bindgen provides
 pub type CK_FUNCTION_LIST_PTR = *const CK_FUNCTION_LIST;
 pub type CK_FUNCTION_LIST_3_0_PTR = *const CK_FUNCTION_LIST_3_0;
+// this is wrongly converted on 32b architecture to too large value
+// which can not be represented in CK_ULONG.
+pub const CK_UNAVAILABLE_INFORMATION: CK_ULONG = CK_ULONG::MAX;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CK_INTERFACE {


### PR DESCRIPTION
It turns out the bindgen assumes 64b architecture by default when converting constants, which causes warnings like
```
warning: literal out of range for `u32`
 --> src/pkcs11/bindings.rs:7:50
  |
7 | pub const CK_UNAVAILABLE_INFORMATION: CK_ULONG = 18446744073709551615;
  |                                                  ^^^^^^^^^^^^^^^^^^^^
  |
  = note: the literal `18446744073709551615` does not fit into the type `u32` whose range is `0..=4294967295`
  = note: `#[warn(overflowing_literals)]` on by default
```
but more important, most of the tests keep failing as the comparisons around this value wont work.

Rather than inventing a way to convert the constant to c-type ulong, I thought setting specific value known as to be the MAX would be more obvious.

Builds run in rawhide now:

https://copr.fedorainfracloud.org/coprs/jjelen/kryoptic/build/8186035/

Unfortunately, this did not fix it and we are still getting error during intialization with:
```
---- tests::token::test_token_sql stdout ----
thread 'tests::token::test_token_sql' panicked at src/tests/mod.rs:97:43:
called `Result::unwrap()` on an `Err` value: Error { kind: CkError, origin: None, errmsg: None, reqsize: 0, ckrv: 19 }
```
(`CKR_ATTRIBUTE_VALUE_INVALID`), which sounds like some attributes pulled from DB have different bit size than expected by the 32b build. Not sure if there is something in #106, which might fix it -- I will try after it will get merged.

The Fedora 41 builds seems to be failing for unrelated reasons. Sounds like the bindings were not generated correctly and the types with blocklisted prefixes are not generated as they should on the Fedora 41 version of bindgen? -- still investigating.