### PR TITLE
build.rs: fix Cargo calls

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -82,7 +82,7 @@ fn build_ossl() {
             providers_path.to_string_lossy()
         );
         println!("cargo:rustc-link-lib=static=fips");
-        println!("cargo::rerun-if-changed={}", libfips);
+        println!("cargo:rerun-if-changed={}", libfips);
 
         (libfips, buildargs, "fips.h")
     };
@@ -94,7 +94,7 @@ fn build_ossl() {
 
         println!("cargo:rustc-link-search={}", openssl_path.to_str().unwrap());
         println!("cargo:rustc-link-lib=static=crypto");
-        println!("cargo::rerun-if-changed={}", libcrypto);
+        println!("cargo:rerun-if-changed={}", libcrypto);
 
         (libcrypto, ["--debug"], "ossl.h")
     };
@@ -154,7 +154,7 @@ fn main() {
 
     /* PKCS11 Headers */
     let pkcs11_header = "pkcs11_headers/3.1/pkcs11.h";
-    println!("cargo::rerun-if-changed={}", pkcs11_header);
+    println!("cargo:rerun-if-changed={}", pkcs11_header);
     bindgen::Builder::default()
         .header(pkcs11_header)
         .derive_default(true)
@@ -174,10 +174,10 @@ fn main() {
     use_system_ossl();
 
     #[cfg(not(feature = "dynamic"))]
-    println!("cargo::rerun-if-changed={}", ".git/modules/openssl/HEAD");
+    println!("cargo:rerun-if-changed={}", ".git/modules/openssl/HEAD");
 
     #[cfg(not(feature = "dynamic"))]
     build_ossl();
 
-    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=build.rs");
 }


### PR DESCRIPTION
Fixed following compilation error

root@evk:~/kryoptic# CONFDIR=/etc cargo build
   Compiling kryoptic v0.1.0 (/root/kryoptic)
error: unsupported output in build script of `kryoptic v0.1.0 (/root/kryoptic)`: `cargo::rerun-if-changed=pkcs11_headers/3.1/pkcs11.h` Found a `cargo::key=value` build directive which is reserved for future use. Either change the directive to `cargo:key=value` syntax (note the single `:`) or upgrade your version of Rust. See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script for more information about build script outputs.