### PR TITLE
Fix handing of public objects with nssdb

### DIFF
--- a/src/storage/nssdb/mod.rs
+++ b/src/storage/nssdb/mod.rs
@@ -845,14 +845,16 @@ impl Storage for NSSStorage {
         let mut obj =
             self.fetch_by_nssid(&table, nssobjid, attrs.as_slice())?;
         if let Some(ref enckey) = self.enckey {
-            for typ in NSS_SENSITIVE_ATTRIBUTES {
-                let encval = match obj.get_attr(typ) {
-                    Some(attr) => attr.get_value(),
-                    None => continue,
-                };
-                let plain =
-                    decrypt_data(facilities, enckey.as_slice(), encval)?;
-                obj.set_attr(Attribute::from_bytes(typ, plain))?;
+            if table == NSS_PRIVATE_TABLE {
+                for typ in NSS_SENSITIVE_ATTRIBUTES {
+                    let encval = match obj.get_attr(typ) {
+                        Some(attr) => attr.get_value(),
+                        None => continue,
+                    };
+                    let plain =
+                        decrypt_data(facilities, enckey.as_slice(), encval)?;
+                    obj.set_attr(Attribute::from_bytes(typ, plain))?;
+                }
             }
 
             for typ in AUTHENTICATED_ATTRIBUTES {

--- a/src/tests/nssdb.rs
+++ b/src/tests/nssdb.rs
@@ -403,6 +403,20 @@ fn test_nssdb_init_token() {
     );
     assert_eq!(ret, CKR_OK);
 
+    /* add a public object to ensure attributes are handled correctly
+     * CKA_VALUE is encrypted only for private objects */
+    let _ = ret_or_panic!(import_object(
+        session,
+        CKO_CERTIFICATE,
+        &[(CKA_CERTIFICATE_TYPE, CKC_X_509)],
+        &[
+            (CKA_CHECK_VALUE, "ignored".as_bytes()),
+            (CKA_SUBJECT, "subject".as_bytes()),
+            (CKA_VALUE, "value".as_bytes())
+        ],
+        &[(CKA_TOKEN, true), (CKA_TRUSTED, false)],
+    ));
+
     let ret = fn_logout(session);
     assert_eq!(ret, CKR_OK);
 


### PR DESCRIPTION
The fetch side was unconditionally applying sensitivity object parsing which meant it would try to decrypt any CKA_VALUE attribute regardless of object type. However the store() function would encrypt it only for the private database objects.

Fix the asymmetry and add a test to ensure writing public object works as expected.