### PR TITLE
Fix parsing NSSDB configuration

### DIFF
--- a/src/storage/nssdb/mod.rs
+++ b/src/storage/nssdb/mod.rs
@@ -149,7 +149,7 @@ impl NSSStorage {
             &mut info.manufacturer,
         );
         if self.config.password_required {
-            info.flags = CKF_LOGIN_REQUIRED;
+            info.flags |= CKF_LOGIN_REQUIRED;
         }
         Ok(info)
     }


### PR DESCRIPTION
Parsing of the NSS configuration string was working just for the first key=value and exploded for anything after that. This fixes couple issues found while parsing different key=value inputs, quoting. Most of the inputs are unused in the code so there is no way to test them for now.