### PR TITLE
 nssdb: Add missing attrs for getting skipped attributes 

### DIFF
--- a/src/storage/nssdb/mod.rs
+++ b/src/storage/nssdb/mod.rs
@@ -842,6 +842,7 @@ impl Storage for NSSStorage {
              * is not a key, the attribute will simply not be returned
              * in that case */
             attrs.add_missing_ulong(CKA_KEY_TYPE, &dnm);
+            attrs.add_missing_ulong(CKA_CERTIFICATE_TYPE, &dnm);
             attrs.add_missing_ulong(CKA_EXTRACTABLE, &dnm);
             attrs.add_missing_ulong(CKA_SENSITIVE, &dnm);
             /* we can not query a DB for these */


### PR DESCRIPTION
Fixes up the dfb480a384be9762ef01487a355a80d9e47e2b55 which
started checking the certificate type on the certificates for
pulling default attributes that can not be stored in the NSS DB.