### PR TITLE
Add a caching layer for NSSDB per-attribute keys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
           cargo build -vv $OPTS --features "$FEATURES"
           cargo test -vv $OPTS --features "$FEATURES"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Build logs ${{ matrix.name }}

--- a/src/error.rs
+++ b/src/error.rs
@@ -204,6 +204,13 @@ impl From<Vec<u8>> for Error {
     }
 }
 
+use std::array::TryFromSliceError;
+impl From<TryFromSliceError> for Error {
+    fn from(error: TryFromSliceError) -> Error {
+        Error::other_error(error)
+    }
+}
+
 #[macro_export]
 macro_rules! some_or_err {
     ($action:expr) => {

--- a/src/storage/nssdb/ci.rs
+++ b/src/storage/nssdb/ci.rs
@@ -84,11 +84,17 @@ impl KeysWithCaching {
     }
 
     pub fn set_key(&mut self, key: Vec<u8>) {
+        if let Some(ref mut oldkey) = &mut self.enckey {
+            oldkey.zeroize();
+        }
         self.enckey = Some(key);
     }
 
     pub fn unset_key(&mut self) {
-        self.enckey = None;
+        if let Some(ref mut key) = &mut self.enckey {
+            key.zeroize();
+            self.enckey = None;
+        }
     }
 
     fn get_cached_key(&self, id: &[u8; SHA256_LEN]) -> Option<LockedKey> {


### PR DESCRIPTION
Adds a caching layer to NSSDB to reduce the performance impact of the key derivation operations.
NSSDB uses a particularly costly operation (pbkdf2) to derive a key for each of the attributes being encrypted.

This PR also adds a test to demonstrate the issue.
This test takes a relatively long time to execute without the cache:
```
$ time cargo test --features standard,nssdb test_nssdb_key_cache
   Compiling kryoptic v0.1.0 (/home/remote/ssorce/devel/git/kryoptic)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 4.96s
     Running unittests src/lib.rs (target/debug/deps/kryoptic_pkcs11-0639a8933718ff9b)

running 1 test
test tests::nssdb::test_nssdb_key_cache has been running for over 60 seconds
test tests::nssdb::test_nssdb_key_cache ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 186 filtered out; finished in 110.29s


real	1m55.282s
user	1m57.233s
sys	0m0.649s

```

It is much faster with the cache:
```
$ time cargo test --features standard,nssdb test_nssdb_key_cache
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running unittests src/lib.rs (target/debug/deps/kryoptic_pkcs11-0639a8933718ff9b)

running 1 test
test tests::nssdb::test_nssdb_key_cache ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 186 filtered out; finished in 0.11s


real	0m0.166s
user	0m0.144s
sys	0m0.020s

```

Fixes #130 