### PR TITLE
More performance improvements with nssdb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ serde_json = "1.0.104"
 serial_test = "3.1.1"
 toml = { version = "0.8.19", default-features = false, features = ["display", "parse"] }
 uuid = { version = "1.4.1", features = ["v4"] }
-zeroize = "1.6.0"
 
 [features]
 aes = []

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -7,13 +7,12 @@ use crate::attribute::Attribute;
 use crate::error::Result;
 use crate::interface::*;
 use crate::mechanism::*;
+use crate::misc::zeromem;
 use crate::object::*;
 use crate::ossl::aes::*;
 use crate::{attr_element, cast_params};
 
 use once_cell::sync::Lazy;
-
-use zeroize::Zeroize;
 
 pub const MIN_AES_SIZE_BYTES: usize = 16; /* 128 bits */
 pub const MID_AES_SIZE_BYTES: usize = 24; /* 192 bits */
@@ -100,7 +99,7 @@ impl ObjectFactory for AesKeyFactory {
             Some(idx) => {
                 let len = usize::try_from(template[idx].to_ulong()?)?;
                 if len > data.len() {
-                    data.zeroize();
+                    zeromem(data.as_mut_slice());
                     return Err(CKR_KEY_SIZE_RANGE)?;
                 }
                 if len < data.len() {
@@ -112,7 +111,7 @@ impl ObjectFactory for AesKeyFactory {
         match check_key_len(data.len()) {
             Ok(_) => (),
             Err(e) => {
-                data.zeroize();
+                zeromem(data.as_mut_slice());
                 return Err(e);
             }
         }

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -5,9 +5,8 @@ use std::borrow::Cow;
 
 use crate::error::{Error, Result};
 use crate::interface::*;
+use crate::misc::zeromem;
 use crate::{bytes_to_vec, sizeof, void_ptr};
-
-use zeroize::Zeroize;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AttrType {
@@ -271,7 +270,7 @@ impl Attribute {
     }
 
     pub fn zeroize(&mut self) {
-        self.value.zeroize();
+        zeromem(self.value.as_mut_slice());
     }
 
     pub fn from_date_bytes(t: CK_ULONG, val: Vec<u8>) -> Attribute {
@@ -559,7 +558,7 @@ impl Drop for CkAttrs<'_> {
     fn drop(&mut self) {
         if self.zeroize {
             while let Some(mut elem) = self.v.pop() {
-                elem.zeroize();
+                zeromem(elem.as_mut_slice());
             }
         }
     }

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -7,11 +7,11 @@ use crate::error::{Error, Result};
 use crate::hash;
 use crate::interface::*;
 use crate::mechanism::*;
+use crate::misc::zeromem;
 use crate::object::*;
 use crate::sizeof;
 
 use once_cell::sync::Lazy;
-use zeroize::Zeroize;
 
 #[cfg(not(feature = "fips"))]
 use crate::native::hmac::HMACOperation;
@@ -26,7 +26,7 @@ pub struct HmacKey {
 
 impl Drop for HmacKey {
     fn drop(&mut self) {
-        self.raw.zeroize()
+        zeromem(self.raw.as_mut_slice())
     }
 }
 

--- a/src/kasn1/mod.rs
+++ b/src/kasn1/mod.rs
@@ -5,9 +5,9 @@ use std::borrow::Cow;
 
 use crate::error::Result;
 use crate::interface::*;
+use crate::misc::zeromem;
 
 use asn1;
-use zeroize::Zeroize;
 
 /* Helper routines to use with rust/asn1 */
 
@@ -68,7 +68,7 @@ impl<'a> DerEncBigUint<'a> {
 impl Drop for DerEncBigUint<'_> {
     fn drop(&mut self) {
         match &self.data {
-            Cow::Owned(_) => self.data.to_mut().zeroize(),
+            Cow::Owned(_) => zeromem(self.data.to_mut()),
             _ => (),
         }
     }
@@ -111,7 +111,7 @@ impl<'a> DerEncOctetString<'a> {
 impl Drop for DerEncOctetString<'_> {
     fn drop(&mut self) {
         match &self.data {
-            Cow::Owned(_) => self.data.to_mut().zeroize(),
+            Cow::Owned(_) => zeromem(self.data.to_mut()),
             _ => (),
         }
     }

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -6,7 +6,7 @@ use crate::attribute::{Attribute, CkAttrs};
 use crate::error::Result;
 use crate::interface::*;
 use crate::object::{Object, ObjectFactories, ObjectType};
-
+use crate::ossl::common::zeromem as ossl_zeromem;
 pub const CK_ULONG_SIZE: usize = std::mem::size_of::<CK_ULONG>();
 
 #[macro_export]
@@ -190,4 +190,8 @@ pub fn copy_sized_string(s: &[u8], d: &mut [u8]) {
         d[..slen].copy_from_slice(&s[..slen]);
         d[slen..].fill(0x20); /* space in ASCII/UTF8 */
     }
+}
+
+pub fn zeromem(mem: &mut [u8]) {
+    ossl_zeromem(mem);
 }

--- a/src/native/hmac.rs
+++ b/src/native/hmac.rs
@@ -8,9 +8,9 @@ use crate::hash;
 use crate::hmac::*;
 use crate::interface::*;
 use crate::mechanism::*;
+use crate::misc::zeromem;
 
 use constant_time_eq::constant_time_eq;
-use zeroize::Zeroize;
 
 /* HMAC spec From FIPS 198-1 */
 
@@ -32,9 +32,9 @@ pub struct HMACOperation {
 
 impl Drop for HMACOperation {
     fn drop(&mut self) {
-        self.state.zeroize();
-        self.ipad.zeroize();
-        self.opad.zeroize();
+        zeromem(self.state.as_mut_slice());
+        zeromem(self.ipad.as_mut_slice());
+        zeromem(self.opad.as_mut_slice());
     }
 }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -8,12 +8,12 @@ use crate::attribute::{AttrType, Attribute};
 use crate::error::{Error, Result};
 use crate::interface::*;
 use crate::mechanism::{Mechanism, Mechanisms};
+use crate::misc::zeromem;
 use crate::CSPRNG;
 
 use bitflags::bitflags;
 use once_cell::sync::Lazy;
 use uuid::Uuid;
-use zeroize::Zeroize;
 
 macro_rules! create_bool_checker {
     (make $name:ident; from $id:expr; def $def:expr) => {
@@ -1032,7 +1032,7 @@ macro_rules! ok_or_clear {
         match $exp {
             Ok(x) => x,
             Err(e) => {
-                $clear.zeroize();
+                zeromem($clear.as_mut_slice());
                 return Err(e);
             }
         }

--- a/src/ossl/fips.rs
+++ b/src/ossl/fips.rs
@@ -18,7 +18,6 @@ use crate::ossl::common::*;
 use getrandom;
 use libc;
 use once_cell::sync::Lazy;
-use zeroize::Zeroize;
 
 /* Entropy Stuff */
 
@@ -434,7 +433,7 @@ unsafe fn fips_cleanse(
     let slice: &mut [u8] =
         slice::from_raw_parts_mut(addr as *mut u8, pos + len);
     let (_, clear) = slice.split_at_mut(pos);
-    clear.zeroize()
+    zeromem(clear);
 }
 
 unsafe extern "C" fn fips_malloc(

--- a/src/ossl/hmac.rs
+++ b/src/ossl/hmac.rs
@@ -7,12 +7,12 @@ use crate::error::Result;
 use crate::hmac::*;
 use crate::interface::*;
 use crate::mechanism::*;
+use crate::misc::zeromem;
 use crate::ossl::bindings::*;
 use crate::ossl::common::*;
 use crate::ossl::fips::*;
 
 use constant_time_eq::constant_time_eq;
-use zeroize::Zeroize;
 
 #[derive(Debug)]
 pub struct HMACOperation {
@@ -113,12 +113,12 @@ impl HMACOperation {
             return Err(CKR_DEVICE_ERROR)?;
         }
         if outlen != self.maclen {
-            buf.zeroize();
+            zeromem(buf.as_mut_slice());
             return Err(CKR_GENERAL_ERROR)?;
         }
 
         output.copy_from_slice(&buf[..output.len()]);
-        buf.zeroize();
+        zeromem(buf.as_mut_slice());
 
         self.fips_approved = check_mac_fips_indicators(&mut self.ctx)?;
         Ok(())

--- a/src/ossl/rsa.rs
+++ b/src/ossl/rsa.rs
@@ -8,6 +8,7 @@ use crate::error::{Error, Result};
 use crate::hash::{hash_size, INVALID_HASH_SIZE};
 use crate::interface::*;
 use crate::mechanism::*;
+use crate::misc::zeromem;
 use crate::object::Object;
 use crate::ossl::bindings::*;
 use crate::ossl::common::*;
@@ -18,8 +19,6 @@ use crate::ossl::get_libctx;
 
 #[cfg(feature = "fips")]
 use crate::ossl::fips::*;
-
-use zeroize::Zeroize;
 
 #[cfg(not(feature = "fips"))]
 pub const MIN_RSA_SIZE_BITS: usize = 1024;
@@ -439,12 +438,12 @@ impl RsaPKCSOperation {
         let mut op = match Self::encrypt_new(mech, wrapping_key, info) {
             Ok(o) => o,
             Err(e) => {
-                keydata.zeroize();
+                zeromem(keydata.as_mut_slice());
                 return Err(e);
             }
         };
         let result = op.encrypt(&keydata, output);
-        keydata.zeroize();
+        zeromem(keydata.as_mut_slice());
         result
     }
 

--- a/src/storage/aci.rs
+++ b/src/storage/aci.rs
@@ -8,6 +8,7 @@ use crate::attribute::CkAttrs;
 use crate::error::Result;
 use crate::interface::*;
 use crate::kasn1::*;
+use crate::misc::zeromem;
 use crate::object::Object;
 use crate::token::TokenFacilities;
 use crate::Operation;
@@ -15,7 +16,6 @@ use crate::CSPRNG;
 use crate::{byte_ptr, sizeof, void_ptr};
 
 use asn1;
-use zeroize::Zeroize;
 
 pub fn pbkdf2_derive(
     facilities: &TokenFacilities,
@@ -412,7 +412,7 @@ impl Default for StorageAuthInfo {
 impl Drop for StorageAuthInfo {
     fn drop(&mut self) {
         if let Some(ref mut data) = self.user_data {
-            data.zeroize();
+            zeromem(data.as_mut_slice());
         }
     }
 }

--- a/src/storage/nssdb/ci.rs
+++ b/src/storage/nssdb/ci.rs
@@ -20,13 +20,13 @@ use zeroize::Zeroize;
 const SHA256_LEN: usize = 32;
 const MAX_KEY_CACHE_SIZE: usize = 128;
 
-enum KeyOp {
+pub enum KeyOp {
     Encryption,
     Signature,
 }
 
 #[derive(Debug)]
-struct LockedKey<'a> {
+pub struct LockedKey<'a> {
     id: [u8; SHA256_LEN],
     l: RwLockReadGuard<'a, BTreeMap<[u8; SHA256_LEN], Object>>,
 }
@@ -313,6 +313,16 @@ fn derive_key_internal<'a>(
     }
 
     return Err(CKR_GENERAL_ERROR)?;
+}
+
+#[cfg(test)]
+pub fn derive_key_test<'a>(
+    facilities: &TokenFacilities,
+    keys: &'a KeysWithCaching,
+    params: &PBKDF2Params,
+    operation: KeyOp,
+) -> Result<LockedKey<'a>> {
+    derive_key_internal(facilities, keys, params, operation)
 }
 
 pub fn decrypt_data(

--- a/src/storage/nssdb/ci.rs
+++ b/src/storage/nssdb/ci.rs
@@ -9,13 +9,12 @@ use crate::error::Result;
 use crate::interface::*;
 use crate::kasn1::oid::*;
 use crate::kasn1::pkcs::*;
+use crate::misc::zeromem;
 use crate::object::Object;
 use crate::storage::aci::pbkdf2_derive;
 use crate::token::TokenFacilities;
 use crate::CSPRNG;
 use crate::{sizeof, void_ptr};
-
-use zeroize::Zeroize;
 
 const SHA256_LEN: usize = 32;
 const MAX_KEY_CACHE_SIZE: usize = 128;
@@ -59,7 +58,7 @@ impl Default for KeysWithCaching {
 impl Drop for KeysWithCaching {
     fn drop(&mut self) {
         if let Some(ref mut key) = &mut self.enckey {
-            key.zeroize();
+            zeromem(key.as_mut_slice());
         }
     }
 }
@@ -85,14 +84,14 @@ impl KeysWithCaching {
 
     pub fn set_key(&mut self, key: Vec<u8>) {
         if let Some(ref mut oldkey) = &mut self.enckey {
-            oldkey.zeroize();
+            zeromem(oldkey.as_mut_slice());
         }
         self.enckey = Some(key);
     }
 
     pub fn unset_key(&mut self) {
         if let Some(ref mut key) = &mut self.enckey {
-            key.zeroize();
+            zeromem(key.as_mut_slice());
             self.enckey = None;
         }
     }

--- a/src/storage/nssdb/mod.rs
+++ b/src/storage/nssdb/mod.rs
@@ -23,7 +23,7 @@ use zeroize::Zeroize;
 
 mod attrs;
 use attrs::*;
-mod ci;
+pub mod ci;
 mod config;
 use ci::*;
 use config::*;

--- a/src/storage/nssdb/mod.rs
+++ b/src/storage/nssdb/mod.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use crate::attribute::{AttrType, Attribute, CkAttrs};
 use crate::error::{Error, Result};
 use crate::interface::*;
-use crate::misc::copy_sized_string;
+use crate::misc::{copy_sized_string, zeromem};
 use crate::object::Object;
 use crate::storage;
 use crate::storage::sqlite_common::check_table;
@@ -19,7 +19,6 @@ use crate::CSPRNG;
 use itertools::Itertools;
 use rusqlite::types::{FromSqlError, Value, ValueRef};
 use rusqlite::{params, Connection, OpenFlags, Rows, Transaction};
-use zeroize::Zeroize;
 
 mod attrs;
 use attrs::*;
@@ -1208,7 +1207,7 @@ impl Storage for NSSStorage {
         self.keys.unset_key();
 
         let result = self.save_password(&salt, encdata.as_slice());
-        encdata.zeroize();
+        zeromem(encdata.as_mut_slice());
         result
     }
 }


### PR DESCRIPTION
Using valgrind's callgrind tool I am analyzing the behavior of with the nssdb storage backend which shows particularly bad performance in pkcs11-provider's CI.

The first easy pick was to remove the Zeroize crate, which single-handedly accounted for a 50% of the time spent in pbkdf2 operations.

The second easy pick was to rewrite the HAM initialization to use fixed slices instead of vectors for the internal state.

The nssdb is still much slower than the others, due to higher use of the pbkdf2 function, yet nssdb uses the same and it is much faster.

Some playing around shows the "native" version is about 20/30 % slower than the OpenSSL one we use in fips mode ... but there is definitely more work to do to improve performance here.