### PR TITLE
Improve output length checking for FIPS indicators in AES/HMAC code

### DIFF
--- a/src/fips/indicators.rs
+++ b/src/fips/indicators.rs
@@ -510,6 +510,8 @@ const FIPS_CHECKS: FipsChecks = FipsChecks {
             restrictions: [restrict!(CKK_AES), restrict!()],
             genflags: CKF_ENCRYPT
                 | CKF_DECRYPT
+                | CKF_SIGN // for CMAC
+                | CKF_VERIFY
                 | CKF_WRAP
                 | CKF_UNWRAP
                 | CKF_DERIVE,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,7 +374,7 @@ fn init_fips_approval(
     session.set_fips_indicator(key_ok);
 }
 
-/* final assemssment on FIPS indicator, after the operation is complete */
+/* final assessment on FIPS indicator, after the operation is complete */
 #[cfg(feature = "fips")]
 fn finalize_fips_approval(
     mut session: RwLockWriteGuard<'_, Session>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -478,14 +478,14 @@ fn force_load_config() -> CK_RV {
     return CKR_OK;
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "eddsa"))]
 fn get_ec_point_encoding(save: &mut config::EcPointEncoding) -> CK_RV {
     let gconf = global_rlock!(noinitcheck CONFIG);
     *save = gconf.conf.ec_point_encoding;
     CKR_OK
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "eddsa"))]
 fn set_ec_point_encoding(val: config::EcPointEncoding) -> CK_RV {
     let mut gconf = global_wlock!(noinitcheck CONFIG);
     gconf.conf.ec_point_encoding = val;

--- a/src/ossl/hmac.rs
+++ b/src/ossl/hmac.rs
@@ -120,6 +120,9 @@ impl HMACOperation {
         output.copy_from_slice(&buf[..output.len()]);
         zeromem(buf.as_mut_slice());
 
+        /* The OpenSSL implementation verifies the truncation is > 112b according to the
+         * FIPS 140-3 IG, C.D Use of a Truncated HMAC
+         */
         self.fips_approved = check_mac_fips_indicators(&mut self.ctx)?;
         Ok(())
     }


### PR DESCRIPTION
There were several issues:
 * The `check_mac_fips_indicators()` won't do anything for the CMACs, as the cmac implementation in FIPS provider does not implement the fips indicator OSSL_PARAM.
* The AES key with SIGN/VERIFY flags was also not marked correctly as FIPS valid so any CMAC operation on that given key caused the FIPS indicator failure.
* Adding explicit tag/mac length checks for CMAC and GCM
* Ignoring CCM and KMAC as I think we do not certify these

I am still not sure about the GCM as the specs are vague. Putting 64b for now.