### PR TITLE
Add pragma to ensure secure delete is on

### DIFF
--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -10,7 +10,7 @@ use crate::misc::copy_sized_string;
 use crate::object::Object;
 use crate::storage::aci::{StorageACI, StorageAuthInfo};
 use crate::storage::format::{StdStorageFormat, StorageRaw};
-use crate::storage::sqlite_common::check_table;
+use crate::storage::sqlite_common::{check_table, set_secure_delete};
 use crate::storage::{Storage, StorageDBInfo, StorageTokenInfo};
 
 use itertools::Itertools;
@@ -279,7 +279,9 @@ impl StorageRaw for SqliteStorage {
             Ok(c) => Arc::new(Mutex::from(c)),
             Err(_) => return Err(CKR_TOKEN_NOT_PRESENT)?,
         };
-        Ok(())
+        /* Ensure secure delete is always set on the db */
+        let conn = self.conn.lock()?;
+        set_secure_delete(&conn)
     }
 
     fn flush(&mut self) -> Result<()> {

--- a/src/storage/sqlite_common.rs
+++ b/src/storage/sqlite_common.rs
@@ -85,3 +85,9 @@ pub fn check_table(
         Err(e) => Err(e)?,
     }
 }
+
+pub fn set_secure_delete(
+    conn: &MutexGuard<'_, rusqlite::Connection>,
+) -> Result<()> {
+    Ok(conn.execute_batch("PRAGMA secure_delete = ON")?)
+}


### PR DESCRIPTION
In many distributions this seem to be on by default already, although the official sqlite documentations ays it is off by default.

Also by experimentation it seem this setting is not saved to the db file, so ensure secure_delete is turned on whenever we open the database.