### PR TITLE
Add missing FIPS checks for Key creation functions

### DIFF
--- a/src/fips/indicators.rs
+++ b/src/fips/indicators.rs
@@ -567,14 +567,26 @@ const FIPS_CHECKS: FipsChecks = FipsChecks {
         FipsMechanism {
             mechanism: CKM_AES_KEY_WRAP,
             operations: CKF_ENCRYPT | CKF_DECRYPT | CKF_WRAP | CKF_UNWRAP,
-            restrictions: [restrict!(CKK_AES), restrict!()],
-            genflags: 0,
+            restrictions: [restrict!(KRY_UNSPEC), restrict!()],
+            genflags: CKF_SIGN
+                | CKF_VERIFY
+                | CKF_ENCRYPT
+                | CKF_DECRYPT
+                | CKF_WRAP
+                | CKF_UNWRAP
+                | CKF_DERIVE,
         },
         FipsMechanism {
             mechanism: CKM_AES_KEY_WRAP_KWP,
             operations: CKF_ENCRYPT | CKF_DECRYPT | CKF_WRAP | CKF_UNWRAP,
-            restrictions: [restrict!(CKK_AES), restrict!()],
-            genflags: 0,
+            restrictions: [restrict!(KRY_UNSPEC), restrict!()],
+            genflags: CKF_SIGN
+                | CKF_VERIFY
+                | CKF_ENCRYPT
+                | CKF_DECRYPT
+                | CKF_WRAP
+                | CKF_UNWRAP
+                | CKF_DERIVE,
         },
         /* SHA */
         FipsMechanism {
@@ -904,7 +916,7 @@ fn check_key(
         },
         CKK_EC | CKK_EC_EDWARDS => match get_oid_from_obj(obj) {
             Ok(oid) => match oid_to_bits(oid) {
-                Ok(l) => l,
+                Ok(l) => btb!(l),
                 Err(_) => return false,
             },
             Err(_) => return false,

--- a/src/fips/indicators.rs
+++ b/src/fips/indicators.rs
@@ -1048,7 +1048,7 @@ pub fn is_approved(
         if checks & 1 == 1 {
             let mut valid_key = false;
             if let Some(obj) = iobj {
-                if let Ok(f) = obj.get_attr_as_ulong(CKA_VALIDATION_FLAG) {
+                if let Ok(f) = obj.get_attr_as_ulong(CKA_VALIDATION_FLAGS) {
                     if (f & KRF_FIPS) == KRF_FIPS {
                         valid_key = true;
                     } else if let Ok(class) = obj.get_attr_as_ulong(CKA_CLASS) {
@@ -1084,7 +1084,7 @@ pub fn is_approved(
                         Err(_) => 0,
                     } | KRF_FIPS;
                     let _ = obj.set_attr(Attribute::from_ulong(
-                        CKA_VALIDATION_FLAG,
+                        CKA_VALIDATION_FLAGS,
                         flag,
                     ));
                     return true;

--- a/src/storage/nssdb/attrs.rs
+++ b/src/storage/nssdb/attrs.rs
@@ -262,8 +262,12 @@ pub fn is_db_attribute(attr: CK_ATTRIBUTE_TYPE) -> bool {
     NSS_KNOWN_ATTRIBUTES.contains(&attr)
 }
 
-pub static NSS_SKIP_ATTRIBUTES: [CK_ATTRIBUTE_TYPE; 3] =
-    [CKA_UNIQUE_ID, CKA_COPYABLE, CKA_DESTROYABLE];
+pub static NSS_SKIP_ATTRIBUTES: [CK_ATTRIBUTE_TYPE; 4] = [
+    CKA_UNIQUE_ID,
+    CKA_COPYABLE,
+    CKA_DESTROYABLE,
+    CKA_VALIDATION_FLAGS,
+];
 
 pub fn is_skippable_attribute(attr: CK_ATTRIBUTE_TYPE) -> bool {
     NSS_SKIP_ATTRIBUTES.contains(&attr)

--- a/src/tests/rsa.rs
+++ b/src/tests/rsa.rs
@@ -363,6 +363,8 @@ fn test_rsa_operations() {
         ],
     ));
 
+    assert_eq!(check_validation(session, 1), true);
+
     let label = "Public Key test 1";
     let mut template = make_ptrs_template(&[(
         CKA_LABEL,


### PR DESCRIPTION
C_GenerateKeyPair / C_WrapKey / C_UnWrapKey were missing invocations to fips indicators checks.

Added checks and added tests to ensure they work