### PR TITLE
Increase test coverage of ALLOWED_MECHANISMS usage

### DIFF
--- a/src/ossl/rsa.rs
+++ b/src/ossl/rsa.rs
@@ -25,7 +25,7 @@ pub const MIN_RSA_SIZE_BITS: usize = 1024;
 #[cfg(feature = "fips")]
 pub const MIN_RSA_SIZE_BITS: usize = 2048;
 
-pub const MAX_RSA_SIZE_BITS: usize = 16536;
+pub const MAX_RSA_SIZE_BITS: usize = 16384;
 pub const MIN_RSA_SIZE_BYTES: usize = MIN_RSA_SIZE_BITS / 8;
 
 static RSA_NAME: &[u8; 4] = b"RSA\0";

--- a/src/storage/nssdb/attrs.rs
+++ b/src/storage/nssdb/attrs.rs
@@ -262,11 +262,12 @@ pub fn is_db_attribute(attr: CK_ATTRIBUTE_TYPE) -> bool {
     NSS_KNOWN_ATTRIBUTES.contains(&attr)
 }
 
-pub static NSS_SKIP_ATTRIBUTES: [CK_ATTRIBUTE_TYPE; 4] = [
+pub static NSS_SKIP_ATTRIBUTES: [CK_ATTRIBUTE_TYPE; 5] = [
     CKA_UNIQUE_ID,
     CKA_COPYABLE,
     CKA_DESTROYABLE,
     CKA_VALIDATION_FLAGS,
+    CKA_ALLOWED_MECHANISMS,
 ];
 
 pub fn is_skippable_attribute(attr: CK_ATTRIBUTE_TYPE) -> bool {

--- a/testdata/test_rsa_operations.json
+++ b/testdata/test_rsa_operations.json
@@ -96,6 +96,7 @@
         "CKA_LABEL": "SigVerPSS_186-3.rsp [mod = 3072]",
         "CKA_MODIFIABLE": false,
         "CKA_MODULUS": "pfPaCq9UtF+ZpdcIXyE8NyHL5+g7Pmw/4PWoTH44e6UTOSwoqQENO2GMA4R+axG7u+TV5H/JfqaWJQaZ6W7NkRQE97gGlXA4pou1mlIPLZAYLRg+A1IEqRTmrAPCvG0/nXhWsl+QQbVt8xDeP+swqkaKBmih5dqc2xhZVsql114c3KwtuCMXNJVhkQU2cjG38t51KKinnsn9u6tgEXiiBKWqThl1nrFupLq4e/SLsXkPn8brTVZ00/vBG5IlWNTlaORUsmpxePPhR76wyMpuz/XlKvJIrAfWoYk5PhcjKt/y90I/VrlLmn1h/eI6lVisejvHwGdIpdoRdZ+SuvTjhrsCElZbW+7PMdBjz6txr4lrPXNHUNm8oHNDv7PChkUibp2tMHD8JHxxwHjpdJNJQQAKedAaurFNIfXmCMTk0T3uwa7ymOEkfFC0e/7mFi81L0HNuoYo0dYohIyHbPsQLazOf6FgwE06q8hmehQqcQt/SV/TUMSGKmU9FcM9kmb9",
+        "CKA_ALLOWED_MECHANISMS": "RAAAAAAAAAA=",
         "CKA_PRIVATE": true,
         "CKA_SENSITIVE": true,
         "CKA_EXTRACTABLE": false,


### PR DESCRIPTION
Currently, `ALLOWED_MECHANISMS` were tested only with AES keys. This add test with RSA keys to make sure they are effective also with different key types.