### PR TITLE
Add TLS PRF selftests in FIPS mode

### DIFF
--- a/src/fips/indicators.rs
+++ b/src/fips/indicators.rs
@@ -245,7 +245,7 @@ struct FipsMechanism {
 
 struct FipsChecks {
     keys: [FipsKeyType; 15],
-    mechs: [FipsMechanism; 67],
+    mechs: [FipsMechanism; 71],
 }
 
 /* TODO: double check the values, this is just an initial
@@ -782,6 +782,15 @@ const FIPS_CHECKS: FipsChecks = FipsChecks {
             ],
             genflags: 0,
         },
+        FipsMechanism {
+            mechanism: CKM_TLS_MAC,
+            operations: CKF_SIGN | CKF_VERIFY,
+            restrictions: [
+                restrict!(CKK_GENERIC_SECRET, range!(112, 512)),
+                restrict!(),
+            ],
+            genflags: 0,
+        },
         /* Key gen, gen/derive */
         FipsMechanism {
             mechanism: CKM_PKCS5_PBKD2,
@@ -796,10 +805,10 @@ const FIPS_CHECKS: FipsChecks = FipsChecks {
             mechanism: CKM_GENERIC_SECRET_KEY_GEN,
             operations: CKF_GENERATE,
             restrictions: [
-                restrict!(CKK_GENERIC_SECRET, range!(112, 256)),
+                restrict!(CKK_GENERIC_SECRET, range!(112, 255 * 64 * 8)),
                 restrict!(),
             ],
-            genflags: CKF_DERIVE,
+            genflags: CKF_SIGN | CKF_VERIFY | CKF_DERIVE,
         },
         FipsMechanism {
             mechanism: CKM_HKDF_KEY_GEN,
@@ -839,6 +848,45 @@ const FIPS_CHECKS: FipsChecks = FipsChecks {
                 | CKF_DECRYPT
                 | CKF_WRAP
                 | CKF_UNWRAP
+                | CKF_DERIVE,
+        },
+        FipsMechanism {
+            mechanism: CKM_TLS12_MASTER_KEY_DERIVE,
+            operations: CKF_DERIVE,
+            restrictions: [
+                restrict!(CKK_GENERIC_SECRET, step!(48 * 8)),
+                restrict!(),
+            ],
+            genflags: CKF_SIGN
+                | CKF_VERIFY
+                | CKF_ENCRYPT
+                | CKF_DECRYPT
+                | CKF_DERIVE,
+        },
+        FipsMechanism {
+            mechanism: CKM_TLS12_KEY_AND_MAC_DERIVE,
+            operations: CKF_DERIVE,
+            restrictions: [
+                restrict!(CKK_GENERIC_SECRET, range!(112, 255 * 64 * 8)),
+                restrict!(),
+            ],
+            genflags: CKF_SIGN
+                | CKF_VERIFY
+                | CKF_ENCRYPT
+                | CKF_DECRYPT
+                | CKF_DERIVE,
+        },
+        FipsMechanism {
+            mechanism: CKM_TLS12_KEY_SAFE_DERIVE,
+            operations: CKF_DERIVE,
+            restrictions: [
+                restrict!(CKK_GENERIC_SECRET, range!(112, 255 * 64 * 8)),
+                restrict!(),
+            ],
+            genflags: CKF_SIGN
+                | CKF_VERIFY
+                | CKF_ENCRYPT
+                | CKF_DECRYPT
                 | CKF_DERIVE,
         },
         FipsMechanism {
@@ -1104,5 +1152,6 @@ pub fn is_approved(
         }
     }
 
+    /* mechanism not found in the indicators table -- not allowed */
     false
 }

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -250,7 +250,7 @@ pub fn register(mechs: &mut Mechanisms, ot: &mut ObjectFactories) {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(feature = "fips", test))]
 pub fn test_get_hmac(mech: CK_MECHANISM_TYPE) -> Box<dyn Mechanism> {
     for hs in &hash::HASH_MECH_SET {
         if hs.mac == mech {

--- a/src/tests/tls.rs
+++ b/src/tests/tls.rs
@@ -500,6 +500,7 @@ fn test_tls_mechanisms() {
         }
     ));
     assert_eq!(mac.len(), 64);
+    assert_eq!(check_validation(session, 1), true);
     assert_eq!(
         CKR_OK,
         sig_verify(
@@ -514,6 +515,7 @@ fn test_tls_mechanisms() {
             }
         )
     );
+    assert_eq!(check_validation(session, 1), true);
 
     /* Test CKM_TLS12_KEY_SAFE_DERIVE */
     let derive_template = make_attr_template(
@@ -569,6 +571,7 @@ fn test_tls_mechanisms() {
         std::ptr::null_mut(),
     );
     assert_eq!(ret, CKR_OK);
+    assert_eq!(check_validation(session, 1), true);
 
     /* ensure IVs were ignored */
     assert_eq!(cliiv.as_slice(), &[0u8; 10]);
@@ -609,6 +612,7 @@ fn test_tls_mechanisms() {
         &mut dk_handle,
     );
     assert_eq!(ret, CKR_OK);
+    assert_eq!(check_validation(session, 0), true);
 
     /* The End */
     testtokn.finalize();

--- a/src/tlskdf.rs
+++ b/src/tlskdf.rs
@@ -276,10 +276,12 @@ impl TLSKDFOperation {
     fn new(mech: &CK_MECHANISM) -> Result<TLSKDFOperation> {
         match mech.mechanism {
             CKM_TLS12_MASTER_KEY_DERIVE => Self::new_tls12_mk_derive(mech),
-            CKM_TLS12_KEY_AND_MAC_DERIVE => Self::new_tls12_keymac_derive(mech),
-            CKM_TLS12_KEY_SAFE_DERIVE => Self::new_tls12_keymac_derive(mech),
-            CKM_TLS12_KDF => Self::new_tls_generic_key_derive(mech),
-            CKM_TLS_KDF => Self::new_tls_generic_key_derive(mech),
+            CKM_TLS12_KEY_AND_MAC_DERIVE | CKM_TLS12_KEY_SAFE_DERIVE => {
+                Self::new_tls12_keymac_derive(mech)
+            }
+            CKM_TLS12_KDF | CKM_TLS_KDF => {
+                Self::new_tls_generic_key_derive(mech)
+            }
             _ => return Err(CKR_MECHANISM_INVALID)?,
         }
     }
@@ -770,10 +772,7 @@ impl Derive for TLSKDFOperation {
             CKM_TLS12_MASTER_KEY_DERIVE => {
                 self.derive_master_key(key, template, mechanisms, objfactories)
             }
-            CKM_TLS12_KEY_AND_MAC_DERIVE => {
-                self.derive_mac_key(key, template, mechanisms, objfactories)
-            }
-            CKM_TLS12_KEY_SAFE_DERIVE => {
+            CKM_TLS12_KEY_AND_MAC_DERIVE | CKM_TLS12_KEY_SAFE_DERIVE => {
                 self.derive_mac_key(key, template, mechanisms, objfactories)
             }
             CKM_TLS12_KDF | CKM_TLS_KDF => {


### PR DESCRIPTION
Second version does only the TLS PRF test with @simo5's suggested approach, that will invoke dynamically (and only once using the Lazy construct), as well as for the `CKM_TLS_MAC` mechanisms, that internally use TLS PRF.