### PR TITLE
Fix memory leaks in unsafe code

### DIFF
--- a/src/ossl/common.rs
+++ b/src/ossl/common.rs
@@ -468,14 +468,18 @@ impl<'a> OsslParam<'a> {
             size += 1;
         }
         let mut container = vec![0u8; size];
-        if unsafe {
+        let ret = unsafe {
             BN_bn2nativepad(
                 bn,
                 container.as_mut_ptr(),
                 c_int::try_from(container.len())?,
             )
-        } < 1
-        {
+        };
+        unsafe {
+            BN_free(bn);
+        }
+        drop(bn);
+        if ret < 1 {
             return Err(CKR_DEVICE_ERROR)?;
         }
         let param = unsafe {

--- a/src/ossl/ecdsa.rs
+++ b/src/ossl/ecdsa.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 - 2024 Simo Sorce, Jakub Jelen
 // See LICENSE.txt file for terms
 
-use core::ffi::{c_char, c_int};
+use core::ffi::c_char;
 
 use crate::attribute::Attribute;
 use crate::ec::ecdsa::*;
@@ -235,19 +235,8 @@ impl EccOperation {
         params.finalize();
 
         let evp_pkey = EvpPkey::generate(name_as_char(EC_NAME), &params)?;
+        let params = evp_pkey.todata(EVP_PKEY_KEYPAIR)?;
 
-        let mut params: *mut OSSL_PARAM = std::ptr::null_mut();
-        let res = unsafe {
-            EVP_PKEY_todata(
-                evp_pkey.as_ptr(),
-                c_int::try_from(EVP_PKEY_KEYPAIR)?,
-                &mut params,
-            )
-        };
-        if res != 1 {
-            return Err(CKR_DEVICE_ERROR)?;
-        }
-        let params = OsslParam::from_ptr(params)?;
         /* Public Key */
         let point_encoded = match asn1::write_single(
             &params.get_octet_string(name_as_char(OSSL_PKEY_PARAM_PUB_KEY))?,

--- a/src/ossl/rsa.rs
+++ b/src/ossl/rsa.rs
@@ -373,19 +373,8 @@ impl RsaPKCSOperation {
         params.finalize();
 
         let evp_pkey = EvpPkey::generate(name_as_char(RSA_NAME), &params)?;
+        let params = evp_pkey.todata(EVP_PKEY_KEYPAIR)?;
 
-        let mut params: *mut OSSL_PARAM = std::ptr::null_mut();
-        let res = unsafe {
-            EVP_PKEY_todata(
-                evp_pkey.as_ptr(),
-                EVP_PKEY_KEYPAIR as std::os::raw::c_int,
-                &mut params,
-            )
-        };
-        if res != 1 {
-            return Err(CKR_DEVICE_ERROR)?;
-        }
-        let params = OsslParam::from_ptr(params)?;
         /* Public Key (has E already set) */
         pubkey.set_attr(Attribute::from_bytes(
             CKA_MODULUS,


### PR DESCRIPTION
These were found while working on pkcs11-provider's address sanitizer tests.