### PR TITLE
Silly way to generate cscope database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /*.sql
 cscope.*
 tags
+.generated_files

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,22 @@ tests: build
 docs:
 	cargo doc --features standard,nssdb,jsondb,fips --document-private-items
 
-tags:
+.ONESHELL:
+SHELL = /bin/bash
+scope:
+	@if [ -x "$$(command -v scope)" ]; then
+		PKCSFILES=$$(find ./ -name pkcs11_bindings.rs)
+		if [[ -n "$$PKCSFILES" ]]; then
+			read PKCSFILE < <(ls -t $$PKCSFILES)
+		fi
+		OSSLFILES=$$(find ./ -name pkcs11_bindings.rs)
+		if [[ -n "$$OSSLFILES" ]]; then
+			read OSSLFILE < <(ls -t $$OSSLFILES)
+		fi
+		scope -- src $$PKCSFILE $$OSSLFILE
+	fi
+
+tags: scope
 	ctags -R src/
 
 clean:


### PR DESCRIPTION
As we have to use OUT_DIR, there is no simple way to index the generated files as they are stored in a location that changes freuently due to the hash in the target directory.

At build time store the file names of the generate files so that if the file is present they can be indexed.