### PR TITLE
Logout when last session is closed on given token

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,10 @@ impl State {
         };
         self.get_slot_mut(slot_id)?.drop_session(handle);
         self.sessionmap.remove(&handle);
+        /* The specs requires the last session to logout the token */
+        if !self.has_sessions(slot_id)? {
+            self.get_token_from_slot_mut(slot_id)?.logout();
+        }
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -731,6 +731,8 @@ extern "C" fn fn_close_all_sessions(slot_id: CK_SLOT_ID) -> CK_RV {
     for handle in dropped_sessions {
         token.drop_session_objects(handle);
     }
+    /* The spec requires the token to logout once the last session is closed */
+    token.logout();
     CKR_OK
 }
 

--- a/src/tests/login.rs
+++ b/src/tests/login.rs
@@ -176,3 +176,58 @@ fn test_login_close() {
         testtokn.close_session();
     }
 }
+
+#[test]
+#[parallel]
+fn test_login_close_all() {
+    let mut testtokn = TestToken::initialized("test_login_close_all", None);
+
+    let mut session = CK_INVALID_HANDLE;
+    let ret = fn_open_session(
+        testtokn.get_slot(),
+        CKF_SERIAL_SESSION | CKF_RW_SESSION,
+        std::ptr::null_mut(),
+        None,
+        &mut session,
+    );
+    assert_eq!(ret, CKR_OK);
+
+    let mut info = CK_SESSION_INFO {
+        slotID: CK_UNAVAILABLE_INFORMATION,
+        state: CK_UNAVAILABLE_INFORMATION,
+        flags: 0,
+        ulDeviceError: 0,
+    };
+    let ret = fn_get_session_info(session, &mut info);
+    assert_eq!(ret, CKR_OK);
+    assert_eq!(info.state, CKS_RW_PUBLIC_SESSION);
+
+    /* login */
+    let pin = "12345678";
+    let ret = fn_login(
+        session,
+        CKU_USER,
+        pin.as_ptr() as *mut _,
+        pin.len() as CK_ULONG,
+    );
+    assert_eq!(ret, CKR_OK);
+
+    let ret = fn_get_session_info(session, &mut info);
+    assert_eq!(ret, CKR_OK);
+    assert_eq!(info.state, CKS_RW_USER_FUNCTIONS);
+
+    /* close session should reset the login state */
+    let ret = fn_close_all_sessions(testtokn.get_slot());
+    assert_eq!(ret, CKR_OK);
+
+    let session = testtokn.get_session(true);
+    let mut info = CK_SESSION_INFO {
+        slotID: CK_UNAVAILABLE_INFORMATION,
+        state: CK_UNAVAILABLE_INFORMATION,
+        flags: 0,
+        ulDeviceError: 0,
+    };
+    let ret = fn_get_session_info(session, &mut info);
+    assert_eq!(ret, CKR_OK);
+    assert_eq!(info.state, CKS_RW_PUBLIC_SESSION);
+}

--- a/src/tests/login.rs
+++ b/src/tests/login.rs
@@ -138,3 +138,41 @@ fn test_login() {
 
     testtokn.finalize();
 }
+
+#[test]
+#[parallel]
+fn test_login_close() {
+    let mut testtokn = TestToken::initialized("test_login_close", None);
+
+    /* Run this twice and make sure the second call does not return ALREADY_LOGGED_IN */
+    for _ in 0..2 {
+        let session = testtokn.get_session(true);
+
+        let mut info = CK_SESSION_INFO {
+            slotID: CK_UNAVAILABLE_INFORMATION,
+            state: CK_UNAVAILABLE_INFORMATION,
+            flags: 0,
+            ulDeviceError: 0,
+        };
+        let ret = fn_get_session_info(session, &mut info);
+        assert_eq!(ret, CKR_OK);
+        assert_eq!(info.state, CKS_RW_PUBLIC_SESSION);
+
+        /* login */
+        let pin = "12345678";
+        let ret = fn_login(
+            session,
+            CKU_USER,
+            pin.as_ptr() as *mut _,
+            pin.len() as CK_ULONG,
+        );
+        assert_eq!(ret, CKR_OK);
+
+        let ret = fn_get_session_info(session, &mut info);
+        assert_eq!(ret, CKR_OK);
+        assert_eq!(info.state, CKS_RW_USER_FUNCTIONS);
+
+        /* close session should reset the login state */
+        testtokn.close_session();
+    }
+}


### PR DESCRIPTION
> If this function is successful and it closes the last session between
> the application and the token, the login state of the token for
> the application returns to public sessions. Any new sessions to the token
> opened by the application will be either R/O Public or R/W Public sessions.

https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/os/pkcs11-spec-v3.1-os.html#_Toc111203273

Fixes: #163