### PR TITLE
Change default feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,7 @@ jobs:
           OPTS=""
 
           if [ "${{ matrix.name }}" = "fips" ]; then
+            OPTS="--no-default-features"
             FEATURES="${FEATURES},fips"
           elif [ "${{ matrix.name }}" = "ossl3" ]; then
             FEATURES="${FEATURES},standard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,20 +69,20 @@ tlskdf = []
 # Databases
 jsondb = ["memorydb"]
 memorydb = ["aes", "hkdf", "pbkdf2"] # for encryption
-sqlitedb = [ "dep:rusqlite", "aes", "hkdf", "pbkdf2" ]
-nssdb = [ "dep:rusqlite", "aes", "hmac", "pbkdf2" ]
+sqlitedb = ["dep:rusqlite", "aes", "hkdf", "pbkdf2"]
+nssdb = ["dep:rusqlite", "aes", "hmac", "pbkdf2"]
 
-default = [ "sqlitedb" ]
+default = ["standard"]
 
 ecc_all = ["ecdsa", "ec_montgomery", "eddsa", "ecdh"]
 hash_all = ["hash", "hmac"]
-kdf_all = [ "hkdf", "pbkdf2", "sp800_108", "sshkdf", "tlskdf" ]
+kdf_all = ["hkdf", "pbkdf2", "sp800_108", "sshkdf", "tlskdf"]
 
-standard = [ "ecc_all", "hash_all", "kdf_all", "rsa"]
+standard = ["sqlitedb", "ecc_all", "hash_all", "kdf_all", "rsa"]
 
 ecc_fips = ["ecdsa", "ecdh"]
-fips = [ "rusqlite/bundled", "aes", "ecc_fips", "hash_all", "kdf_all", "rsa"]
+fips = ["rusqlite/bundled", "aes", "ecc_fips", "hash_all", "kdf_all", "rsa"]
 
-dynamic = [ ] # Builds against system libcrypto.so
+dynamic = [] # Builds against system libcrypto.so
 
 slow = [] # Enables slow tests

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 all: build
 
 build:
-	cargo build --features standard,nssdb
+	cargo build --features nssdb
 
 fips:
-	cargo build --features fips
+	cargo build --no-default-features --features fips,sqlitedb,nssdb
 
 check:
-	cargo test --features standard,nssdb
+	cargo test --features nssdb
 
 check-fips:
-	cargo test --features fips
+	cargo test --no-default-features --features fips,sqlitedb,nssdb
 
 check-format:
 	@find . -not \( -path ./target -prune \) -type f -name '*.rs' | xargs rustfmt --check --color auto

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ First after cloning, we need to pull and update openssl submodule:
     $ git submodule init
     $ git submodule update
 
+# Build
+
 Build the rust project:
 
     $ CONFDIR=/etc cargo build
@@ -20,6 +22,16 @@ Build the rust project:
 For FIPS module, you need to generate hmac checksum:
 
     $ ./hmacify.sh target/release/libkryoptic_pkcs11.so
+
+The default build specifies "standard" as the default feature for
+ease of use. "Standard" pulls in all the standard algorithms and the
+sqlitedb storage backend.
+
+In order to make a different selection you need to use the cargo
+switch to disable default features (--no-default-features) and then
+specify the features you want to build with:
+
+eg: cargo build --no-default-features --features fips,sqlitedb,nssdb
 
 # Tests
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,6 +363,7 @@ macro_rules! global_wlock {
     }};
 }
 
+/// tests helper
 #[cfg(test)]
 pub fn check_test_slot_busy(slot: CK_SLOT_ID) -> bool {
     let state = match STATE.read() {
@@ -430,6 +431,7 @@ static CONFIG: Lazy<RwLock<GlobalConfig>> = Lazy::new(|| {
     RwLock::new(global_conf)
 });
 
+/// tests helper
 #[cfg(test)]
 pub fn add_slot(slot: config::Slot) -> CK_RV {
     let mut gconf = global_wlock!(noinitcheck CONFIG);


### PR DESCRIPTION
The README.md was not updated when we last change defaults.

This commit restores the default build to point to the "standard" feature. This makes it slightly harder to build non standard configurations, but makes it easier for new-comers.

Fixes #162 