### PR TITLE
ci: Cache DNF downloads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            /var/cache/dnf
+            /var/cache/libdnf5
           key: ${{ runner.os }}-dnf-${{ steps.get-date.outputs.date }}
 
       - name: Install Dependencies


### PR DESCRIPTION
Sounds like the latest fedora changed the location of metadata and package downloads.