### PR TITLE
Rebase openssl submodule to 3.5 (prerelease)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "openssl"]
 	path = openssl
 	url = https://github.com/simo5/openssl
-	branch = kryoptic
+	branch = kryoptic_ossl35

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ kdf_all = ["hkdf", "pbkdf2", "sp800_108", "sshkdf", "tlskdf"]
 standard = ["sqlitedb", "ecc_all", "hash_all", "kdf_all", "rsa"]
 
 ecc_fips = ["ecdsa", "ecdh"]
-fips = ["rusqlite/bundled", "aes", "ecc_fips", "hash_all", "kdf_all", "rsa"]
+fips = ["sqlitedb", "rusqlite/bundled", "aes", "ecc_fips", "hash_all", "kdf_all", "rsa"]
 
 dynamic = [] # Builds against system libcrypto.so
 

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,17 @@ build:
 fips:
 	cargo build --no-default-features --features fips,sqlitedb,nssdb
 
+static:
+	cargo build --no-default-features --features standard
+
 check:
 	cargo test --features nssdb
 
 check-fips:
 	cargo test --no-default-features --features fips,sqlitedb,nssdb
+
+check-static:
+	cargo test --no-default-features --features standard
 
 check-format:
 	@find ./src build.rs -name '*.rs' | xargs rustfmt --check --color auto
@@ -35,7 +41,7 @@ scope:
 		if [[ -n "$$PKCSFILES" ]]; then
 			read PKCSFILE < <(ls -t $$PKCSFILES)
 		fi
-		OSSLFILES=$$(find ./ -name pkcs11_bindings.rs)
+		OSSLFILES=$$(find ./ -name ossl_bindings.rs)
 		if [[ -n "$$OSSLFILES" ]]; then
 			read OSSLFILE < <(ls -t $$OSSLFILES)
 		fi

--- a/build.rs
+++ b/build.rs
@@ -77,7 +77,10 @@ fn build_ossl(out_file: &Path) {
             "no-ec2m",
             "no-sm2",
             "no-sm4",
-            "-DREDHAT_FIPS_VERSION=\\\"0.0.1-test\\\"",
+            "no-des",
+            "no-dsa",
+            "no-atexit",
+            "-DDEVRANDOM=\\\"/dev/urandom\\\" -DOPENSSL_PEDANTIC_ZEROIZATION -DFIPS_VENDOR=\\\"Kryoptic\\\" -DKRYOPTIC_FIPS_VERSION=\\\"1.0.0-test\\\"",
         ];
 
         println!(
@@ -94,12 +97,21 @@ fn build_ossl(out_file: &Path) {
     let (libpath, bldargs, header) = {
         let libcrypto =
             format!("{}/libcrypto.a", openssl_path.to_string_lossy());
+        let buildargs = [
+            "--debug",
+            "no-mdc2",
+            "no-ec2m",
+            "no-sm2",
+            "no-sm4",
+            "no-des",
+            "-DDEVRANDOM=\\\"/dev/urandom\\\"",
+        ];
 
         println!("cargo:rustc-link-search={}", openssl_path.to_str().unwrap());
         println!("cargo:rustc-link-lib=static=crypto");
         println!("cargo:rerun-if-changed={}", libcrypto);
 
-        (libcrypto, ["--debug"], "ossl.h")
+        (libcrypto, buildargs, "ossl.h")
     };
 
     match std::path::Path::new(&libpath).try_exists() {

--- a/fips.h
+++ b/fips.h
@@ -9,6 +9,7 @@
 #include "../crypto/evp/evp_local.h"
 #include "../providers/common/include/prov/providercommon.h"
 #include "openssl/self_test.h"
+#include "openssl/indicator.h"
 
 OSSL_LIB_CTX *ossl_prov_ctx_get0_libctx(OSSL_PROVIDER *ctx);
 int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,

--- a/src/ossl/hkdf.rs
+++ b/src/ossl/hkdf.rs
@@ -265,6 +265,9 @@ impl Derive for HKDFOperation {
         }
         params.finalize();
 
+        #[cfg(feature = "fips")]
+        fips_approval_prep_check();
+
         let mut kctx = EvpKdfCtx::new(name_as_char(OSSL_KDF_NAME_HKDF))?;
         let mut dkm = vec![0u8; keysize];
         let res = unsafe {
@@ -280,9 +283,7 @@ impl Derive for HKDFOperation {
         }
 
         #[cfg(feature = "fips")]
-        {
-            self.fips_approved = check_kdf_fips_indicators(&mut kctx)?;
-        }
+        fips_approval_finalize(&mut self.fips_approved);
 
         obj.set_attr(Attribute::from_bytes(CKA_VALUE, dkm))?;
 

--- a/src/tests/aes.rs
+++ b/src/tests/aes.rs
@@ -456,7 +456,7 @@ fn test_aes_operations() {
         assert_eq!(enc_len, tag_len as CK_ULONG);
 
         /* test that we can get correct indicators based on inputs */
-        assert_eq!(check_validation(session, 0), true);
+        assert_eq!(check_validation(session, 1), true);
 
         let dec = ret_or_panic!(decrypt(
             session,
@@ -478,7 +478,7 @@ fn test_aes_operations() {
         assert_eq!(&enc[..12], enc2.as_slice());
 
         /* test that we can get correct indicators based on inputs */
-        assert_eq!(check_validation(session, 0), true);
+        assert_eq!(check_validation(session, 1), true);
 
         /* GCM without TAG should fail */
         let iv = "BA0987654321";

--- a/src/tests/rsa.rs
+++ b/src/tests/rsa.rs
@@ -415,7 +415,9 @@ fn test_rsa_operations() {
     );
     assert_eq!(ret, CKR_OK);
 
-    #[cfg(not(feature = "fips"))]
+    /* Raw sig is disabled in the openssl submodule */
+
+    #[cfg(feature = "dynamic")]
     {
         /* RSA PKCS Sig */
         let pri_key_handle = match get_test_key_handle(

--- a/src/tests/signatures.rs
+++ b/src/tests/signatures.rs
@@ -130,6 +130,7 @@ fn test_rsa_signatures() {
 
     /* get test data */
     let mut testcase = get_test_case_data("CKM_RSA_PKCS");
+    #[allow(unused_variables)]
     let pri_key_handle =
         match get_test_key_handle(session, "SigGen15_186-2", CKO_PRIVATE_KEY) {
             Ok(k) => k,

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -234,6 +234,7 @@ pub fn sig_gen(
     Ok(signature)
 }
 
+#[allow(dead_code)]
 pub fn sig_gen_multipart(
     session: CK_SESSION_HANDLE,
     key: CK_OBJECT_HANDLE,


### PR DESCRIPTION
Rebases the openssl submodule from a version based on Openssl 3.2 to a pre-release of the code that will go in Openssl 3.5.0 with additional patches from Red Hat for fips compliance nd sha1 hardening.

The fips indicator stuff had to be overhauled.

Note:
Two test do not correctly report unapproved fips indicators and will need more investigation.
It may be due to incomplete patching on the openssl side wrt indicators we used to check previously. Keeping PR as draft until openssl branches upstream and thse two test are investigated.