### PR TITLE
Switch to 2024 edition

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2983,7 +2983,7 @@ extern "C" fn fn_get_info(info: CK_INFO_PTR) -> CK_RV {
 ///
 /// Version 3.1 Specification: [https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/os/pkcs11-spec-v3.1-os.html#_Toc111203258](https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/os/pkcs11-spec-v3.1-os.html#_Toc111203258)
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn C_GetFunctionList(fnlist: CK_FUNCTION_LIST_PTR_PTR) -> CK_RV {
     unsafe {
         *fnlist = &FNLIST_240 as *const _ as *mut _;
@@ -3821,7 +3821,7 @@ static INTERFACE_SET: Lazy<Vec<InterfaceData>> = Lazy::new(|| {
 ///
 /// Version 3.1 Specification: [https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/os/pkcs11-spec-v3.1-os.html#_Toc111203259](https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/os/pkcs11-spec-v3.1-os.html#_Toc111203259)
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn C_GetInterfaceList(
     interfaces_list: CK_INTERFACE_PTR,
     count: CK_ULONG_PTR,
@@ -3864,7 +3864,7 @@ pub extern "C" fn C_GetInterfaceList(
 ///
 /// Version 3.1 Specification: [https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/os/pkcs11-spec-v3.1-os.html#_Toc111203260](https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/os/pkcs11-spec-v3.1-os.html#_Toc111203260)
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn C_GetInterface(
     interface_name: CK_UTF8CHAR_PTR,
     version: CK_VERSION_PTR,

--- a/src/object.rs
+++ b/src/object.rs
@@ -1441,16 +1441,14 @@ pub fn default_key_attributes(
     key.set_attr(Attribute::from_bool(CKA_LOCAL, true))?;
     key.set_attr(Attribute::from_ulong(CKA_KEY_GEN_MECHANISM, mech))?;
 
-    let extractable = if let Ok(b) = key.get_attr_as_bool(CKA_EXTRACTABLE) {
-        b
-    } else {
-        true
+    let extractable = match key.get_attr_as_bool(CKA_EXTRACTABLE) {
+        Ok(b) => b,
+        _ => true,
     };
     key.set_attr(Attribute::from_bool(CKA_NEVER_EXTRACTABLE, !extractable))?;
-    let sensitive = if let Ok(b) = key.get_attr_as_bool(CKA_SENSITIVE) {
-        b
-    } else {
-        false
+    let sensitive = match key.get_attr_as_bool(CKA_SENSITIVE) {
+        Ok(b) => b,
+        _ => false,
     };
     key.set_attr(Attribute::from_bool(CKA_ALWAYS_SENSITIVE, sensitive))?;
 

--- a/src/storage/sqlite_common.rs
+++ b/src/storage/sqlite_common.rs
@@ -70,14 +70,15 @@ pub fn check_table(
     };
     let mut stmt = conn.prepare(&sql)?;
     let mut rows = stmt.query(rusqlite::params![])?;
-    if let Some(row) = rows.next()? {
-        match row.get(0)? {
+    match rows.next()? {
+        Some(row) => match row.get(0)? {
             1 => (),
             0 => return Err(CKR_CRYPTOKI_NOT_INITIALIZED)?,
             _ => return Err(CKR_DEVICE_ERROR)?,
+        },
+        _ => {
+            return Err(CKR_CRYPTOKI_NOT_INITIALIZED)?;
         }
-    } else {
-        return Err(CKR_CRYPTOKI_NOT_INITIALIZED)?;
     }
     match rows.next() {
         Ok(None) => Ok(()),

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -376,11 +376,13 @@ fn test_config_multiple_tokens() {
     /* try to init this token now */
     let mut args = TestToken::make_init_args(None);
     let args_ptr = &mut args as *mut CK_C_INITIALIZE_ARGS;
-    env::set_var("KRYOPTIC_CONF", confname);
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { env::set_var("KRYOPTIC_CONF", confname) };
     let ret = force_load_config();
     assert_eq!(ret, CKR_OK);
     let ret = fn_initialize(args_ptr as *mut std::ffi::c_void);
-    env::remove_var("KRYOPTIC_CONF");
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { env::remove_var("KRYOPTIC_CONF") };
     assert_eq!(ret, CKR_OK);
 
     /* check slots and tokens */


### PR DESCRIPTION
The migration tool automatically changed some of thcode causing some churn. I manually changed some of the things, like removing expr_2021 from macros as it was not necessary and changing the renaming of the now reserved word gen from r#gen to generator.

A bunch of let Some() {} else () expressions were changed to matches, I let that be, sometime smatch turns out to be idiomatic, sometimes it is about the same readability.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] ~Test suite updated with functionality tests~
- [ ] ~Test suite updated with negative tests~
- [ ] ~Documentation was updated~
- [ ] ~This is not a code change~

#### Reviewer's checklist:

- [x] Any issues marked for closing are fully addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] A changelog entry is added if the change is significant
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible text
