### PR TITLE
Really update to edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kryoptic"
 version = "1.0.0"
-edition = "2021"
+edition = "2024"
 description = "A PKCS #11 software token written in Rust"
 homepage = "https://github.com/latchset/kryoptic"
 repository = "https://github.com/latchset/kryoptic"
@@ -28,7 +28,7 @@ path = "src/tools/softhsm/migrate.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-bindgen = "0.69"
+bindgen = "0.71"
 pkg-config = "0.3"
 
 [dependencies]


### PR DESCRIPTION
Requires updating bindgen to 0.71 as well.

#### Description

Somehow the previous PR ended up missing the critical change to Cargo.toml that actually really switched editions, even though the migration preparation work was all done.

#### Checklist

- [ ] ~Test suite updated with functionality tests~
- [ ] ~Test suite updated with negative tests~
- [ ] ~Documentation was updated~
- [x] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
