### PR TITLE
Fix storing and reading default DATE attributes

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -414,6 +414,14 @@ const ASCII_DASH: u8 = 0x2D;
 const MIN_ASCII_DIGIT: u8 = 0x30;
 const MAX_ASCII_DIGIT: u8 = 0x39;
 
+fn empty_date() -> CK_DATE {
+    CK_DATE {
+        year: [0x30, 0x30, 0x30, 0x30],
+        month: [0x30, 0x30],
+        day: [0x30, 0x30],
+    }
+}
+
 fn vec_to_date_validate(val: Vec<u8>) -> Result<CK_DATE> {
     if val.len() != 8 {
         return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;
@@ -522,11 +530,7 @@ impl CK_ATTRIBUTE {
     pub fn to_date(&self) -> Result<CK_DATE> {
         if self.ulValueLen == 0 {
             /* set 0000-00-00 */
-            return Ok(CK_DATE {
-                year: [0x30, 0x30, 0x30, 0x30],
-                month: [0x30, 0x30],
-                day: [0x30, 0x30],
-            });
+            return Ok(empty_date());
         }
         if self.pValue.is_null() {
             return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -250,6 +250,9 @@ impl Attribute {
     }
 
     pub fn to_date_string(&self) -> Result<String> {
+        if self.value.len() == 0 {
+            return Ok(String::new()); /* empty default value */
+        }
         if self.value.len() != 8 {
             return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;
         }

--- a/src/object.rs
+++ b/src/object.rs
@@ -844,10 +844,10 @@ pub trait CertFactory {
                 CKA_CHECK_VALUE; OAFlags::Ignored; Attribute::from_ignore;
                 val None),
             attr_element!(
-                CKA_START_DATE; OAFlags::empty(); Attribute::from_date_bytes;
+                CKA_START_DATE; OAFlags::Defval; Attribute::from_date_bytes;
                 val Vec::new()),
             attr_element!(
-                CKA_END_DATE; OAFlags::empty(); Attribute::from_date_bytes;
+                CKA_END_DATE; OAFlags::Defval; Attribute::from_date_bytes;
                 val Vec::new()),
             attr_element!(
                 CKA_PUBLIC_KEY_INFO; OAFlags::empty(); Attribute::from_bytes;
@@ -1010,10 +1010,10 @@ pub trait CommonKeyFactory {
                 CKA_ID; OAFlags::empty(); Attribute::from_bytes;
                 val Vec::new()),
             attr_element!(
-                CKA_START_DATE; OAFlags::empty(); Attribute::from_date_bytes;
+                CKA_START_DATE; OAFlags::Defval; Attribute::from_date_bytes;
                 val Vec::new()),
             attr_element!(
-                CKA_END_DATE; OAFlags::empty(); Attribute::from_date_bytes;
+                CKA_END_DATE; OAFlags::Defval; Attribute::from_date_bytes;
                 val Vec::new()),
             attr_element!(
                 CKA_DERIVE; OAFlags::Defval; Attribute::from_bool; val false),

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -113,10 +113,20 @@ impl SqliteStorage {
                         }
                         AttrType::DateType => {
                             match val.as_str_or_null().map_err(bad_storage)? {
-                                Some(s) => Attribute::from_date(
-                                    atype,
-                                    string_to_ck_date(s)?,
-                                ),
+                                Some(s) => {
+                                    if s.len() == 0 {
+                                        /* special case for default empty value */
+                                        Attribute::from_date_bytes(
+                                            atype,
+                                            Vec::new(),
+                                        )
+                                    } else {
+                                        Attribute::from_date(
+                                            atype,
+                                            string_to_ck_date(s)?,
+                                        )
+                                    }
+                                }
                                 None => {
                                     return Err(CKR_ATTRIBUTE_VALUE_INVALID)?
                                 }


### PR DESCRIPTION
#### Description

Turned out the START_DATE and END_DATE attributes had default value defined, but the flag was missing, which lead to not storing the default attributes in DB.

Throughout the chain of storing and reading DATE type, there were several checks for valid dates (which empty string is not) so there were some changes needed to loosen these checks.

Fixes: #182

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [X] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [X] Documentation was updated
- [~] This is not a code change

#### Reviewer's checklist:

- [x] Any issues marked for closing are fully addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible text
