### PR TITLE
Ensure token store objects can be extracted if the right booleans are set

### DIFF
--- a/src/storage/format.rs
+++ b/src/storage/format.rs
@@ -227,6 +227,11 @@ impl Storage for StdStorageFormat {
              * not be returned in that case */
             attrs.add_missing_ulong(CKA_KEY_TYPE, &dnm);
             attrs.add_missing_ulong(CKA_CERTIFICATE_TYPE, &dnm);
+            /* We also need to know whether the object is sensible/extractable
+             * so that the token code can decide whether it is ok to return
+             * some attributes or not */
+            attrs.add_missing_ulong(CKA_SENSITIVE, &dnm);
+            attrs.add_missing_ulong(CKA_EXTRACTABLE, &dnm);
         }
 
         let mut obj = self.store.fetch_by_uid(&uid, attrs.as_slice())?;


### PR DESCRIPTION
#### Description

The database optimized code was not sourcing the CKA_SENSITIVE/CKA_EXTRACTABLE attributes for token objects, this would cause subsequent checks on these attributes to use the object defaults rather than what was actually stored.
Session objects did not suffer from this issue because all attributes are always available for those.

Fixes: #193

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite updated with functionality tests
- [x] Test suite updated with negative tests
- ~[ ] Documentation was updated~
- ~[ ] This is not a code change~

#### Reviewer's checklist:

- [x] Any issues marked for closing are fully addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible text
