### PR TITLE
Fix check for object sensitivity as per spec

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -1698,7 +1698,7 @@ impl ObjectFactories {
         obj: &Object,
         template: &mut [CK_ATTRIBUTE],
     ) -> Result<()> {
-        let sensitive = obj.is_sensitive() & !obj.is_extractable();
+        let sensitive = obj.is_sensitive() || !obj.is_extractable();
         let mut result = match self
             .get_object_factory(obj)?
             .check_get_attributes(template, sensitive)

--- a/src/tests/aes.rs
+++ b/src/tests/aes.rs
@@ -783,7 +783,7 @@ fn test_aes_operations() {
                 (CKA_VALUE_LEN, 16),
             ],
             &[],
-            &[(CKA_EXTRACTABLE, true)],
+            &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
         );
 
         let mut wp_handle2 = CK_INVALID_HANDLE;

--- a/src/tests/ec_montgomery.rs
+++ b/src/tests/ec_montgomery.rs
@@ -184,6 +184,7 @@ fn test_ec_montgomery_derive(t: TestUnit) {
         &[
             (CKA_ENCRYPT, true),
             (CKA_DECRYPT, true),
+            (CKA_SENSITIVE, false),
             (CKA_EXTRACTABLE, true),
         ],
     );
@@ -332,7 +333,7 @@ fn test_ec_montgomery_derive(t: TestUnit) {
     let derive_template = make_attr_template(
         &[(CKA_CLASS, CKO_SECRET_KEY), (CKA_KEY_TYPE, CKK_AES)],
         &[],
-        &[(CKA_EXTRACTABLE, true)],
+        &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
     );
     let mut s_handle = CK_INVALID_HANDLE;
     let ret = fn_derive_key(
@@ -369,7 +370,7 @@ fn test_ec_montgomery_derive(t: TestUnit) {
             (CKA_VALUE_LEN, ref_value.len() as CK_ULONG + 1),
         ],
         &[],
-        &[(CKA_EXTRACTABLE, true)],
+        &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
     );
     let mut s_handle = CK_INVALID_HANDLE;
     let ret = fn_derive_key(

--- a/src/tests/ecdh.rs
+++ b/src/tests/ecdh.rs
@@ -71,6 +71,7 @@ fn test_ecc_derive_plain() {
         &[
             (CKA_ENCRYPT, true),
             (CKA_DECRYPT, true),
+            (CKA_SENSITIVE, false),
             (CKA_EXTRACTABLE, true),
         ],
     );
@@ -191,7 +192,7 @@ fn test_ecc_derive_plain() {
     let derive_template = make_attr_template(
         &[(CKA_CLASS, CKO_SECRET_KEY), (CKA_KEY_TYPE, CKK_AES)],
         &[],
-        &[(CKA_EXTRACTABLE, true)],
+        &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
     );
     let mut s_handle = CK_INVALID_HANDLE;
     let ret = fn_derive_key(
@@ -228,7 +229,7 @@ fn test_ecc_derive_plain() {
             (CKA_VALUE_LEN, 33),
         ],
         &[],
-        &[(CKA_EXTRACTABLE, true)],
+        &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
     );
     let mut s_handle = CK_INVALID_HANDLE;
     let ret = fn_derive_key(
@@ -265,7 +266,7 @@ fn test_ecc_derive_plain() {
             (CKA_VALUE_LEN, 16),
         ],
         &[],
-        &[(CKA_EXTRACTABLE, true)],
+        &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
     );
     let mut s_handle = CK_INVALID_HANDLE;
     let ret = fn_derive_key(
@@ -345,7 +346,7 @@ fn test_ecc_derive_x963() {
             (CKA_VALUE_LEN, 32),
         ],
         &[],
-        &[(CKA_EXTRACTABLE, true)],
+        &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
     );
 
     let mut s_handle = CK_INVALID_HANDLE;
@@ -426,7 +427,7 @@ fn test_ecc_derive_nist() {
             (CKA_VALUE_LEN, 32),
         ],
         &[],
-        &[(CKA_EXTRACTABLE, true)],
+        &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
     );
 
     let mut s_handle = CK_INVALID_HANDLE;

--- a/src/tests/ecdh_vectors.rs
+++ b/src/tests/ecdh_vectors.rs
@@ -269,7 +269,7 @@ fn test_ecdh_units(session: CK_SESSION_HANDLE, test_data: Vec<EcdhTestUnit>) {
                 (CKA_VALUE_LEN, unit.z.len() as CK_ULONG),
             ],
             &[],
-            &[(CKA_EXTRACTABLE, true)],
+            &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
         );
 
         let mut dk_handle = CK_INVALID_HANDLE;

--- a/src/tests/kdf_vectors.rs
+++ b/src/tests/kdf_vectors.rs
@@ -342,7 +342,7 @@ fn test_kdf_units(session: CK_SESSION_HANDLE, test_data: Vec<KdfTestSection>) {
                     (CKA_VALUE_LEN, unit.ko.len() as CK_ULONG),
                 ],
                 &[],
-                &[(CKA_EXTRACTABLE, true)],
+                &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
             );
 
             let mut dk_handle = CK_INVALID_HANDLE;

--- a/src/tests/kdfs.rs
+++ b/src/tests/kdfs.rs
@@ -329,7 +329,7 @@ fn test_hash_kdf() {
             let derive_template = make_attr_template(
                 &[(CKA_CLASS, CKO_SECRET_KEY)],
                 &[],
-                &[(CKA_EXTRACTABLE, true)],
+                &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
             );
 
             let mut derive_mech = CK_MECHANISM {
@@ -368,7 +368,7 @@ fn test_hash_kdf() {
             let derive_template = make_attr_template(
                 &[(CKA_CLASS, CKO_SECRET_KEY), (CKA_VALUE_LEN, hopt.1 + 10)],
                 &[],
-                &[(CKA_EXTRACTABLE, true)],
+                &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
             );
 
             let mut hashkey2 = CK_INVALID_HANDLE;
@@ -386,7 +386,7 @@ fn test_hash_kdf() {
             let derive_template = make_attr_template(
                 &[(CKA_CLASS, CKO_SECRET_KEY), (CKA_VALUE_LEN, hopt.1 - 10)],
                 &[],
-                &[(CKA_EXTRACTABLE, true)],
+                &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
             );
             let mut hashkey2 = CK_INVALID_HANDLE;
             let ret = fn_derive_key(
@@ -414,7 +414,7 @@ fn test_hash_kdf() {
             let derive_template = make_attr_template(
                 &[(CKA_CLASS, CKO_SECRET_KEY), (CKA_KEY_TYPE, CKK_AES)],
                 &[],
-                &[(CKA_EXTRACTABLE, true)],
+                &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
             );
             let mut hashkey3 = CK_INVALID_HANDLE;
             let ret = fn_derive_key(
@@ -459,7 +459,7 @@ fn test_hash_kdf() {
                 (CKA_VALUE_LEN, 42),
             ],
             &[],
-            &[(CKA_EXTRACTABLE, true)],
+            &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
         );
 
         let mut hashkey4 = CK_INVALID_HANDLE;
@@ -481,7 +481,7 @@ fn test_hash_kdf() {
                 (CKA_VALUE_LEN, 32),
             ],
             &[],
-            &[(CKA_EXTRACTABLE, true)],
+            &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
         );
         let mut hashkey4 = CK_INVALID_HANDLE;
         let ret = fn_derive_key(
@@ -580,7 +580,7 @@ fn test_hkdf() {
                             (CKA_KEY_TYPE, CKK_GENERIC_SECRET),
                         ],
                         &[],
-                        &[(CKA_EXTRACTABLE, true)],
+                        &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
                     ),
                 ),
                 CKM_HKDF_DATA => (
@@ -880,6 +880,7 @@ fn test_pbkdf2() {
             &[
                 (CKA_WRAP, true),
                 (CKA_UNWRAP, true),
+                (CKA_SENSITIVE, false),
                 (CKA_EXTRACTABLE, true),
             ],
         ));
@@ -1137,7 +1138,7 @@ fn test_sshkdf() {
                         (CKA_VALUE_LEN, kt.1.len() as CK_ULONG),
                     ],
                     &[],
-                    &[(CKA_EXTRACTABLE, true)],
+                    &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
                 ),
                 _ => panic!("What?"),
             };

--- a/src/tests/keys.rs
+++ b/src/tests/keys.rs
@@ -25,6 +25,7 @@ fn test_secret_key() {
         &[
             (CKA_WRAP, true),
             (CKA_UNWRAP, true),
+            (CKA_SENSITIVE, false),
             (CKA_EXTRACTABLE, true),
         ],
     ));
@@ -148,6 +149,7 @@ fn test_rsa_key() {
         &[
             (CKA_WRAP, true),
             (CKA_UNWRAP, true),
+            (CKA_SENSITIVE, false),
             (CKA_EXTRACTABLE, true),
         ],
     ));
@@ -412,6 +414,7 @@ fn test_ecc_key() {
         &[
             (CKA_WRAP, true),
             (CKA_UNWRAP, true),
+            (CKA_SENSITIVE, false),
             (CKA_EXTRACTABLE, true),
         ],
     ));

--- a/src/tests/mlkem.rs
+++ b/src/tests/mlkem.rs
@@ -142,6 +142,7 @@ fn test_mlkem_operations() {
         &[
             (CKA_ENCRYPT, true),
             (CKA_DECRYPT, true),
+            (CKA_SENSITIVE, false),
             (CKA_EXTRACTABLE, true),
         ],
     );
@@ -323,7 +324,7 @@ fn test_groups(session: CK_SESSION_HANDLE, data: Value) {
             (CKA_KEY_TYPE, CKK_GENERIC_SECRET),
         ],
         &[],
-        &[(CKA_EXTRACTABLE, true)],
+        &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
     );
 
     let test_groups: &Vec<Value> = match data["testGroups"].as_array() {

--- a/src/tests/tls.rs
+++ b/src/tests/tls.rs
@@ -294,7 +294,7 @@ fn test_tlskdf_units(
                     (CKA_VALUE_LEN, unit.ms.len() as CK_ULONG),
                 ],
                 &[],
-                &[(CKA_EXTRACTABLE, true)],
+                &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
             );
 
             let (params, paramslen) = match section.kdf {
@@ -360,7 +360,7 @@ fn test_tlskdf_units(
                     (CKA_VALUE_LEN, keylen as CK_ULONG),
                 ],
                 &[],
-                &[(CKA_EXTRACTABLE, true)],
+                &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
             );
 
             let mut cliiv = vec![0u8; ivlen];


### PR DESCRIPTION
#### Description

The spec says:
"If the CKA_SENSITIVE attribute is CK_TRUE, or if the CKA_EXTRACTABLE attribute is CK_FALSE, then certain attributes of the private key cannot be revealed in plaintext"

However the code was performing a logical "and" instead of an "or". Correct the code and the tests to properly check/set the CKA_SENSITIVE value.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite updated with functionality tests
- [x] Test suite updated with negative tests
- ~[ ] Documentation was updated~
- ~[ ] This is not a code change~

#### Reviewer's checklist:

- ~[ ] Any issues marked for closing are fully addressed~
- [x] There is a test suite reasonably covering new functionality or modifications
- ~[ ] This feature/change has adequate documentation added~
- ~[ ] A changelog entry is added if the change is significant~
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible text
