### PR TITLE
Fix C_WrapKey size query

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2430,12 +2430,6 @@ extern "C" fn fn_wrap_key(
     wrapped_key: CK_BYTE_PTR,
     pul_wrapped_key_len: CK_ULONG_PTR,
 ) -> CK_RV {
-    if wrapped_key.is_null() {
-        /* FIXME: Stop gap measure to avoid crashing,
-         * needs to be addressed with an extension to
-         * ask mechanisms for the size */
-        return CKR_GENERAL_ERROR;
-    }
     let rstate = global_rlock!(STATE);
     #[cfg(not(feature = "fips"))]
     let session = res_or_ret!(rstate.get_session(s_handle));
@@ -2474,9 +2468,12 @@ extern "C" fn fn_wrap_key(
     }
 
     let pwraplen = unsafe { *pul_wrapped_key_len as CK_ULONG };
-    let wraplen = cast_or_ret!(usize from pwraplen => CKR_ARGUMENTS_BAD);
-    let wrapped: &mut [u8] =
-        unsafe { std::slice::from_raw_parts_mut(wrapped_key, wraplen) };
+    let wrapped: &mut [u8] = if wrapped_key.is_null() {
+        &mut [] /* empty buffer will be always too small */
+    } else {
+        let wraplen = cast_or_ret!(usize from pwraplen => CKR_ARGUMENTS_BAD);
+        unsafe { std::slice::from_raw_parts_mut(wrapped_key, wraplen) }
+    };
     let outlen = match mech.wrap_key(mechanism, &wkey, &key, wrapped, factory) {
         Ok(len) => {
             #[cfg(feature = "fips")]

--- a/src/ossl/rsa.rs
+++ b/src/ossl/rsa.rs
@@ -431,6 +431,15 @@ impl RsaPKCSOperation {
                 return Err(e);
             }
         };
+        let needed_len = op.encryption_len(keydata.len(), true)?;
+        if output.len() == 0 {
+            zeromem(keydata.as_mut_slice());
+            return Ok(needed_len);
+        }
+        if output.len() < needed_len {
+            zeromem(keydata.as_mut_slice());
+            return Err(Error::buf_too_small(needed_len));
+        }
         let result = op.encrypt(&keydata, output);
         zeromem(keydata.as_mut_slice());
         result

--- a/src/tests/aes.rs
+++ b/src/tests/aes.rs
@@ -740,7 +740,6 @@ fn test_aes_operations() {
         };
 
         let mut wrapped = [0u8; AES_BLOCK_SIZE * 2];
-        let mut wraplen = wrapped.len() as CK_ULONG;
         let mut mechanism = CK_MECHANISM {
             mechanism: mech,
             pParameter: void_ptr!(&iv),
@@ -755,6 +754,18 @@ fn test_aes_operations() {
             &[(CKA_VALUE, &data)],
             &[(CKA_EXTRACTABLE, true)],
         ));
+
+        /* get length */
+        let mut wraplen = 0;
+        let ret = fn_wrap_key(
+            session,
+            &mut mechanism,
+            handle,
+            wp_handle,
+            std::ptr::null_mut(),
+            &mut wraplen,
+        );
+        assert_eq!(ret, CKR_OK);
         let ret = fn_wrap_key(
             session,
             &mut mechanism,

--- a/src/tests/keys.rs
+++ b/src/tests/keys.rs
@@ -161,9 +161,20 @@ fn test_rsa_key() {
     };
 
     let mut wrapped = vec![0u8; 65536];
-    let mut wrapped_len = wrapped.len() as CK_ULONG;
 
-    let mut ret = fn_wrap_key(
+    /* Get length */
+    let mut wrapped_len = 0;
+    let ret = fn_wrap_key(
+        session,
+        &mut mechanism,
+        handle,
+        prikey,
+        std::ptr::null_mut(),
+        &mut wrapped_len,
+    );
+    assert_eq!(ret, CKR_OK);
+
+    let ret = fn_wrap_key(
         session,
         &mut mechanism,
         handle,
@@ -188,7 +199,7 @@ fn test_rsa_key() {
     );
 
     let mut prikey2 = CK_INVALID_HANDLE;
-    ret = fn_unwrap_key(
+    let ret = fn_unwrap_key(
         session,
         &mut mechanism,
         handle,
@@ -240,7 +251,7 @@ fn test_rsa_key() {
         };
         let mut wrapped_len = wrapped.len() as CK_ULONG;
 
-        ret = fn_wrap_key(
+        let ret = fn_wrap_key(
             session,
             &mut mechanism,
             pubkey,
@@ -263,7 +274,7 @@ fn test_rsa_key() {
         );
 
         let mut handle2 = CK_INVALID_HANDLE;
-        ret = fn_unwrap_key(
+        let ret = fn_unwrap_key(
             session,
             &mut mechanism,
             prikey,
@@ -282,12 +293,12 @@ fn test_rsa_key() {
             ulParameterLen: 0,
         };
 
-        ret = fn_encrypt_init(session, &mut mechanism, handle2);
+        let ret = fn_encrypt_init(session, &mut mechanism, handle2);
         assert_eq!(ret, CKR_OK);
 
         /* init is sufficient to ensure the key is well formed,
          * terminate current operation */
-        ret = fn_encrypt_init(session, std::ptr::null_mut(), handle2);
+        let ret = fn_encrypt_init(session, std::ptr::null_mut(), handle2);
         assert_eq!(ret, CKR_OK);
     }
 

--- a/testdata/test_rsa_operations.json
+++ b/testdata/test_rsa_operations.json
@@ -158,7 +158,8 @@
         "CKA_PRIVATE": false,
         "CKA_PUBLIC_EXPONENT": "AQAB",
         "CKA_TOKEN": true,
-        "CKA_ENCRYPT": true
+        "CKA_ENCRYPT": true,
+        "CKA_WRAP": true
     }
 }, {
     "attributes": {


### PR DESCRIPTION
#### Description

Fixes `C_WrapKey` size queries that previously crashed kryoptic (#184). 

This is a naive approach, which involves creating 0-length buffer for the size query, doing the export of the key and if the buffer is not large enough, returning.

Better approach would be to store the intermediate state of the operation and continue from there once we will have large enough buffer, but it would involve much more changes.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [X] Test suite updated with functionality tests
~- [ ] Test suite updated with negative tests~
~- [ ] Documentation was updated~
~- [ ] This is not a code change~

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
