### PR TITLE
ecdh: Fix max ECDH output size

### DIFF
--- a/src/ossl/ecdh.rs
+++ b/src/ossl/ecdh.rs
@@ -131,7 +131,7 @@ impl Derive for ECDHOperation {
         let factory =
             objfactories.get_obj_factory_from_key_template(template)?;
 
-        let raw_max = 2 * ((pkey.get_bits()? + 7) / 8);
+        let raw_max = (pkey.get_bits()? + 7) / 8;
         /* the raw ECDH results have length of bit field length */
         let keylen = match template.iter().find(|x| x.type_ == CKA_VALUE_LEN) {
             Some(a) => {
@@ -195,7 +195,7 @@ impl Derive for ECDHOperation {
         }
 
         let ec_point = {
-            if self.public.len() > raw_max + 1 {
+            if self.public.len() > (2 * raw_max) + 1 {
                 /* try to see if it is a DER encoded point */
                 match asn1::parse_single::<&[u8]>(self.public.as_slice()) {
                     Ok(pt) => Cow::Owned(pt.to_vec()),


### PR DESCRIPTION
#### Description

For some reason, I set the output length to the 2 * field sizes initially. This does not have any effect on deriving AES keys as they can not be that large, but this could explode for secret keys that could get larger.

#### Checklist

- [x] Test suite updated with functionality tests
~- [ ] Test suite updated with negative tests~
~- [ ] Documentation was updated~
~- [ ] This is not a code change~

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible text
