### PR TITLE
Allow digesting AES keys and add test coverage.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1716,9 +1716,10 @@ extern "C" fn fn_digest_key(
     if res_or_ret!(key.get_attr_as_ulong(CKA_CLASS)) != CKO_SECRET_KEY {
         return CKR_KEY_HANDLE_INVALID;
     }
-    if res_or_ret!(key.get_attr_as_ulong(CKA_KEY_TYPE)) != CKK_GENERIC_SECRET {
-        return CKR_KEY_INDIGESTIBLE;
-    }
+    match res_or_ret!(key.get_attr_as_ulong(CKA_KEY_TYPE)) {
+        CKK_GENERIC_SECRET | CKK_AES => (),
+        _ => return CKR_KEY_INDIGESTIBLE,
+    };
 
     let data = res_or_ret!(key.get_attr_as_bytes(CKA_VALUE));
     res_or_ret!(operation.digest_update(data));


### PR DESCRIPTION
#### Description

Currently, only the generic secret keys were allowed to be digested. This allows also AES keys (as I did not find any limitation specified in specs) and adds test coverage as there was really none for this code path.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [X] Test suite updated with functionality tests
- [X] Test suite updated with negative tests
~- [ ] Documentation was updated~
~- [ ] This is not a code change~

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
