### PR TITLE
Minor cleanups in tests and rust warning fixes

### DIFF
--- a/src/mechanism.rs
+++ b/src/mechanism.rs
@@ -108,6 +108,7 @@ pub trait Mechanism: Debug + Send + Sync {
         Err(CKR_MECHANISM_INVALID)?
     }
 
+    #[cfg(feature = "pkcs11_3_2")]
     fn encapsulate(
         &self,
         _: &CK_MECHANISM,
@@ -119,6 +120,7 @@ pub trait Mechanism: Debug + Send + Sync {
         Err(CKR_MECHANISM_INVALID)?
     }
 
+    #[cfg(feature = "pkcs11_3_2")]
     fn decapsulate(
         &self,
         _: &CK_MECHANISM,

--- a/src/tests/ecdh.rs
+++ b/src/tests/ecdh.rs
@@ -249,7 +249,6 @@ fn test_ecc_derive_plain() {
         extract_template.len() as CK_ULONG,
     );
     assert_eq!(ret, CKR_OK);
-    assert_eq!(value.len(), ref_value_full.len());
     assert_eq!(value, ref_value_full);
 
     /* With GENERIC_SECRET and explicit CKA_VALUE_LEN larger than field size we should fail */

--- a/src/tests/ecdh.rs
+++ b/src/tests/ecdh.rs
@@ -219,7 +219,7 @@ fn test_ecc_derive_plain() {
         extract_template.len() as CK_ULONG,
     );
     assert_eq!(ret, CKR_OK);
-    assert_eq!(value, ref_value_full[(ref_value_full.len() - 32)..]);
+    assert_eq!(value, ref_value_full);
 
     /* With GENERIC_SECRET without explicit CKA_VALUE_LEN should
      * create keys of ECDH derive output (ec group size = 32B) */


### PR DESCRIPTION
#### Description

* The ECDH test had needless slicing as discussed in #203. Removed
* The ECDH test had also needless check of lengths before comparing buffers
* The warnings when built without PQC started to annoy me so I fixed them :)

#### Checklist

- ~[ ] Test suite updated with functionality tests~
- ~[ ] Test suite updated with negative tests~
- ~[ ] Documentation was updated~
- [x] This is not a code change

#### Reviewer's checklist:

- ~[ ] Any issues marked for closing are fully addressed~
- ~[ ] There is a test suite reasonably covering new functionality or modifications~
- ~[ ] This feature/change has adequate documentation added~
- ~[ ] A changelog entry is added if the change is significant~
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible text
