### PR TITLE
tests: Drop pkcs11-tool dependency of migrate test

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -32,7 +32,11 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          dnf -y install git cargo clang-devel openssl-devel sqlite-devel opensc
+          dnf -y install git cargo clang-devel openssl-devel sqlite-devel
+          if [ "${{ matrix.name }}" = "i686" ]; then
+            dnf -y install rust-std-static.i686 openssl-devel.i686 \
+              sqlite-devel.i686
+          fi
 
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -46,7 +46,7 @@ jobs:
             dnf -y install rustc rpm-build openssl-devel cargo rust-toolset sqlite-devel clang git
           else
             dnf -y install rustc rpm-build cargo-rpm-macros openssl-devel git \
-                'crate(asn1/default)' 'crate(bimap/default)' \
+                'crate(asn1/default)' 'crate(bimap/default)' 'crate(bindgen/default) >= 0.69.0' \
                 'crate(bindgen/default)' 'crate(bitflags/default)' 'crate(cfg-if/default)' \
                 'crate(clap)' 'crate(clap/cargo)' 'crate(clap/derive)' 'crate(clap/help)' \
                 'crate(clap/std)' 'crate(clap/usage)' 'crate(constant_time_eq/default)' \
@@ -56,7 +56,7 @@ jobs:
                 'crate(paste/default)' 'crate(pkg-config/default)' 'crate(rusqlite/default)' \
                 'crate(serde/default)' 'crate(serde/derive)' 'crate(serde_json/default)' \
                 'crate(serial_test/default)' 'crate(toml)' 'crate(toml/display)' 'crate(toml/parse)' \
-                'crate(uuid/default)' 'crate(uuid/v4)'
+                'crate(uuid/default)' 'crate(uuid/v4)' 'crate(cryptoki/default)'
           fi
 
       - name: Checkout Repository

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,16 @@ name = "softhsm_migrate"
 path = "src/tools/softhsm/migrate.rs"
 test = false
 
+[[bin]]
+name = "kryoptic_init"
+path = "src/tools/softhsm/test_init.rs"
+test = false
+
+[[bin]]
+name = "test_signature"
+path = "src/tools/softhsm/test_signature.rs"
+test = false
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
@@ -39,6 +49,7 @@ bitflags = "2.4.1"
 cfg-if = "1.0.0"
 clap = { version = "4.5.26", default-features = false, features = ["cargo", "derive", "help", "std", "usage"] }
 constant_time_eq = "0.3.0"
+cryptoki = "0.6.2"
 data-encoding = "2.4.0"
 getrandom = "0.3"
 hex = "0.4.3"

--- a/packaging/kryoptic.spec
+++ b/packaging/kryoptic.spec
@@ -102,7 +102,7 @@ export CONFDIR=%{_sysconfdir}
 %install
 %cargo_install -f dynamic,nssdb,standard
 install -Dp target/rpm/%{soname}.so $RPM_BUILD_ROOT%{_libdir}/pkcs11/%{soname}.so
-rm -f $RPM_BUILD_ROOT%{_bindir}/conformance
+rm -f $RPM_BUILD_ROOT%{_bindir}/{conformance,kryoptic_init,test_signature}
 
 mkdir -p $RPM_BUILD_ROOT%{_datadir}/p11-kit/modules/
 echo "module: %{soname}.so" > $RPM_BUILD_ROOT%{_datadir}/p11-kit/modules/kryoptic.module

--- a/src/tools/softhsm/test_init.rs
+++ b/src/tools/softhsm/test_init.rs
@@ -1,0 +1,48 @@
+use std::process::ExitCode;
+
+use clap::Parser;
+use cryptoki::context::{CInitializeArgs, Pkcs11};
+use cryptoki::session::UserType;
+use cryptoki::types::AuthPin;
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Arguments {
+    #[arg(short = 'm', long)]
+    pkcs11_module: String,
+
+    #[arg(short = 'p', long)]
+    pin: String,
+
+    #[arg(short = 's', long)]
+    so_pin: String,
+
+    #[arg(short = 'l', long)]
+    token_label: String,
+}
+
+fn main() -> ExitCode {
+    let args = Arguments::parse();
+
+    let pkcs11 = Pkcs11::new(args.pkcs11_module).unwrap();
+
+    // initialize the library
+    pkcs11.initialize(CInitializeArgs::OsThreads).unwrap();
+
+    // find a slot, get the first one
+    let slot = pkcs11.get_slots_with_token().unwrap().remove(0);
+
+    let so_pin = AuthPin::new(args.so_pin.into());
+    pkcs11.init_token(slot, &so_pin, &args.token_label).unwrap();
+
+    // open a SO session
+    let session = pkcs11.open_rw_session(slot).unwrap();
+    // log in the session
+    session.login(UserType::So, Some(&so_pin)).unwrap();
+
+    // Initialize the User Pin
+    let pin = AuthPin::new(args.pin.into());
+    session.init_pin(&pin).unwrap();
+
+    ExitCode::from(0)
+}

--- a/src/tools/softhsm/test_signature.rs
+++ b/src/tools/softhsm/test_signature.rs
@@ -1,0 +1,75 @@
+use std::process::ExitCode;
+
+use clap::Parser;
+use cryptoki::context::{CInitializeArgs, Pkcs11};
+use cryptoki::mechanism::Mechanism;
+use cryptoki::object::{Attribute, ObjectClass};
+use cryptoki::session::UserType;
+use cryptoki::types::AuthPin;
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Arguments {
+    #[arg(short = 'm', long)]
+    pkcs11_module: String,
+
+    #[arg(short = 'p', long)]
+    pin: String,
+}
+
+fn main() -> ExitCode {
+    let args = Arguments::parse();
+
+    let pkcs11 = Pkcs11::new(args.pkcs11_module).unwrap();
+
+    // initialize the library
+    pkcs11.initialize(CInitializeArgs::OsThreads).unwrap();
+
+    // find a slot, get the first one
+    let slot = pkcs11.get_slots_with_token().unwrap().remove(0);
+
+    // open a session
+    let session = pkcs11.open_rw_session(slot).unwrap();
+    // log in the session
+    let pin = AuthPin::new(args.pin.into());
+    session.login(UserType::User, Some(&pin)).unwrap();
+
+    // Find the certificate with testCert label
+    let id = vec![0x00, 0x01];
+    let template = vec![
+        Attribute::Token(true),
+        Attribute::Id(id.clone()),
+        Attribute::Class(ObjectClass::CERTIFICATE),
+        Attribute::Label("testCert".into()),
+    ];
+
+    let found_keys = session.find_objects(&template).unwrap();
+    if found_keys.len() != 1 {
+        eprintln!(
+            "Failed to find the test certificate. Found {} objects.",
+            found_keys.len()
+        );
+        return ExitCode::from(0xFF);
+    }
+
+    // find the private key and make a signature
+    let mut template = vec![
+        Attribute::Token(true),
+        Attribute::Id(id),
+        Attribute::Class(ObjectClass::PRIVATE_KEY),
+    ];
+    let priv_handle = session.find_objects(&template).unwrap().remove(0);
+
+    let data = "Signature Test";
+    let signature = session
+        .sign(&Mechanism::RsaPkcs, priv_handle, data.as_bytes())
+        .unwrap();
+
+    template[2] = Attribute::Class(ObjectClass::PUBLIC_KEY);
+    let pub_handle = session.find_objects(&template).unwrap().remove(0);
+    session
+        .verify(&Mechanism::RsaPkcs, pub_handle, data.as_bytes(), &signature)
+        .unwrap();
+
+    ExitCode::from(0)
+}


### PR DESCRIPTION
#### Description

The Fedora 42 splits opensc to libs and tools, but only libs are
multilib. This means the 64b pkcs11-tool can not work with the 32b
kryoptic in the tests.
    
This is attempt to get rid of the opensc dependency by using the
rust-cryptoki API in the migrate test.

#### Checklist

- [X] Test suite updated with functionality tests
~- [ ] Test suite updated with negative tests~
~- [ ] Documentation was updated~
- [X] This is not a code change

#### Reviewer's checklist:

- [x] Any issues marked for closing are fully addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible text
