### PR TITLE
Add better support for array of attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project should be documented in this file.
 
 * Added support for ML-DSA signature scheme
 
+* Added support for SignatureVerify APIs with all algorithms
+  [Support SignatureVerify APIs with all algorithms](https://github.com/latchset/kryoptic/pull/216)
+
+* Fixed a database format bug that would affect cross-platform portability
+  [Add better support for array of attributes](https://github.com/latchset/kryoptic/pull/219)
+
 
 # [1.1.0]
 ## 2025-04-14

--- a/src/storage/nssdb/mod.rs
+++ b/src/storage/nssdb/mod.rs
@@ -349,6 +349,10 @@ impl NSSStorage {
                     AttrType::DenyType => {
                         return Err(CKR_ATTRIBUTE_TYPE_INVALID)?
                     }
+                    AttrType::UlongArrayType => {
+                        /* currently unsupported */
+                        return Err(CKR_ATTRIBUTE_TYPE_INVALID)?;
+                    }
                 };
                 obj.set_attr(attr)?;
             }

--- a/testdata/test_rsa_operations.json
+++ b/testdata/test_rsa_operations.json
@@ -96,7 +96,7 @@
         "CKA_LABEL": "SigVerPSS_186-3.rsp [mod = 3072]",
         "CKA_MODIFIABLE": false,
         "CKA_MODULUS": "pfPaCq9UtF+ZpdcIXyE8NyHL5+g7Pmw/4PWoTH44e6UTOSwoqQENO2GMA4R+axG7u+TV5H/JfqaWJQaZ6W7NkRQE97gGlXA4pou1mlIPLZAYLRg+A1IEqRTmrAPCvG0/nXhWsl+QQbVt8xDeP+swqkaKBmih5dqc2xhZVsql114c3KwtuCMXNJVhkQU2cjG38t51KKinnsn9u6tgEXiiBKWqThl1nrFupLq4e/SLsXkPn8brTVZ00/vBG5IlWNTlaORUsmpxePPhR76wyMpuz/XlKvJIrAfWoYk5PhcjKt/y90I/VrlLmn1h/eI6lVisejvHwGdIpdoRdZ+SuvTjhrsCElZbW+7PMdBjz6txr4lrPXNHUNm8oHNDv7PChkUibp2tMHD8JHxxwHjpdJNJQQAKedAaurFNIfXmCMTk0T3uwa7ymOEkfFC0e/7mFi81L0HNuoYo0dYohIyHbPsQLazOf6FgwE06q8hmehQqcQt/SV/TUMSGKmU9FcM9kmb9",
-        "CKA_ALLOWED_MECHANISMS": "RAAAAAAAAAA=",
+        "CKA_ALLOWED_MECHANISMS": [68],
         "CKA_PRIVATE": true,
         "CKA_SENSITIVE": true,
         "CKA_EXTRACTABLE": false,


### PR DESCRIPTION
#### Description

Some attributes are actually well defined arrays of other attributes.

The two array types are arrays of CK_ULONGs and arrays of CK_ATTRIBUTEs

The latter is used for "TEMPLATE" attributes.

This PR implements support for more correctly storing and parsing arrays of CK_ULONG attributes.

At the same time we prevent trying to store TEMPLATE attributes.
This is because it is not entirely clear how to deal with the memory pointers referenced by the CK_ATTRIBUTE structure, and currently storing these attributes simply results in a broken attribute referencing arbitrary memory.

Fixes #217

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite updated with functionality tests
- [ ] ~Test suite updated with negative tests~
- [ ] ~Documentation was updated~
- [ ] ~This is not a code change~

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
