### PR TITLE
Bump bindgen dependency version to follow rawhide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ test = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-bindgen = "0.69"
+bindgen = "0.71"
 pkg-config = "0.3"
 
 [dependencies]


### PR DESCRIPTION
#### Description

The bindgen was updated in rawhide to 0.71

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

~- [ ] Test suite updated with functionality tests~
~- [ ] Test suite updated with negative tests~
~- [ ] Documentation was updated~
- [X] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible text
