### PR TITLE
Improve documentation for using a static build of OpenSSL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ Example:
 
     export KRYOPTIC_OPENSSL_SOURCES=/path/to/src/openssl
 
+When building, you'll need to disable the dynamic feature.  Since
+features are additive in `Cargo`, you'll need to disable the default
+features and then select the features that you need.  For instance, if
+you want the standard features, you can do:
+
+    cargo build --no-default-features --features standard
+
 # Build
 
 Build the rust project:


### PR DESCRIPTION
To use a static build of OpenSSL, it is not enough to set KRYOPTIC_OPENSSL_SOURCES, the `dynamic` feature also needs to be disabled.

Mention this in `README.md` and provide an example.

#### Description

<!--  The description should give a general overview of the goal of the PR.

Individual commit message should highlight important changes that people may
want to know about when looking at the commit years later
-->

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] ~Test suite updated with functionality tests~
- [ ] ~Test suite updated with negative tests~
- [ ] ~Documentation was updated~
- [x] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
