### PR TITLE
tests: Avoid failures when configuration file is present in default path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,10 @@ jobs:
             FEATURES="${FEATURES},standard,pqc"
           fi
 
+          # create a bugus configuration file to make sure it is not used during tests
+          mkdir -p ~/.config/kryoptic/
+          cp testdata/test.conf ~/.config/kryoptic/token.conf
+
           cargo build -vv $OPTS --features "$FEATURES"
           cargo test -vv $OPTS --features "$FEATURES"
 

--- a/.github/workflows/openssl_versions.yml
+++ b/.github/workflows/openssl_versions.yml
@@ -163,6 +163,10 @@ jobs:
             FEATURES="$FEATURES,dynamic"
           fi
 
+          # create a bugus configuration file to make sure it is not used during tests
+          mkdir -p ~/.config/kryoptic/
+          cp testdata/test.conf ~/.config/kryoptic/token.conf
+
           cargo build -vv $OPTS --features "$FEATURES"
           cargo test -vv $OPTS --features "$FEATURES"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -499,15 +499,18 @@ struct GlobalConfig {
 
 /// Global, lazily initialized, read-write locked configuration instance.
 static CONFIG: Lazy<RwLock<GlobalConfig>> = Lazy::new(|| {
+    #[cfg(test)]
+    let conf = Config::new();
+
+    #[cfg(not(test))]
+    let conf = match Config::default_config() {
+        Ok(conf) => conf,
+        Err(_) => Config::new(),
+    };
     /* if there is no config file or the configuration is malformed,
      * set an empty config, an error will be returned later at
      * fn_initialize() time */
-    let mut global_conf = GlobalConfig {
-        conf: match Config::default_config() {
-            Ok(conf) => conf,
-            Err(_) => Config::new(),
-        },
-    };
+    let mut global_conf = GlobalConfig { conf: conf };
     global_conf.conf.load_env_vars_overrides();
     RwLock::new(global_conf)
 });

--- a/testdata/test.conf
+++ b/testdata/test.conf
@@ -1,0 +1,4 @@
+[[slots]]
+slot = 1
+dbtype = "sqlite"
+dbargs = "/tmp/kryoptic/token.sql"


### PR DESCRIPTION
#### Description

This worked for me, but:
 * I did not add a reproducer yet -- not sure if there is a good way to do that except for introducing some bash script that would run `cargo test`
 * I am not much happy to have the `#[cfg(test))` throughout the code as this means the we can not test the code in the `#[cfg(not(test))]` branch.

So opening as a draft.

Fixes: #226

#### Checklist

- [x] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation was updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [x] Any issues marked for closing are fully addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible text
