### PR TITLE
Add Key wrapping support and tests for all EC keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,28 @@ All notable changes to this project should be documented in this file.
 * Added support for ML-DSA signature scheme
 
 * Added support for SignatureVerify APIs with all algorithms
-  [Support SignatureVerify APIs with all algorithms](https://github.com/latchset/kryoptic/pull/216)
+  - [Support SignatureVerify APIs with all
+     algorithms](https://github.com/latchset/kryoptic/pull/216)
 
 * Fixed a database format bug that would affect cross-platform portability
-  [Add better support for array of attributes](https://github.com/latchset/kryoptic/pull/219)
+  - [Add better support for array of
+     attributes](https://github.com/latchset/kryoptic/pull/219)
 
 * Added doc string with Gemini's help to most files
-  [Add more documentation strings and cleanup changes](https://github.com/latchset/kryoptic/pull/229)
+  - [Add more documentation strings and cleanup
+     changes](https://github.com/latchset/kryoptic/pull/229)
 
 * Made Token Info more spec compliant and added relevant information like the
   software release version.
-  [Make token info a little more useful](https://github.com/latchset/kryoptic/pull/237)
+  - [Make token info a little more
+     useful](https://github.com/latchset/kryoptic/pull/237)
 
-* Fix Asymmetric keys export format for Key Wrapping
-  [Fix PrivateKeyInfo ASN.1 structure](https://github.com/latchset/kryoptic/pull/238)
+* Fix Asymmetric keys export format for Key Wrapping and extend it to all EC key
+  types
+  - [Fix PrivateKeyInfo ASN.1
+     structure](https://github.com/latchset/kryoptic/pull/238)
+  - [Add Key wrapping support and tests for all EC
+     keys](https://github.com/latchset/kryoptic/pull/239)
 
 # [1.1.0]
 ## 2025-04-14
@@ -37,24 +45,32 @@ both enabled by passing --feature mlkem at build time.
 ### What Changed
 
 * Added support for PKCS#11 3.2 interfaces
-  [Pkcs11 3.2 Draft](https://github.com/latchset/kryoptic/pull/149)
+  - [Pkcs11 3.2 Draft](https://github.com/latchset/kryoptic/pull/149)
 
 * Added support for Key Encapdulation/Decapsulation and ML-KEM Support
-  [Add Encapsulation/Decapsulation and ML-KEM support](https://github.com/latchset/kryoptic/pull/197)
+  - [Add Encapsulation/Decapsulation and ML-KEM
+     support](https://github.com/latchset/kryoptic/pull/197)
 
 * Sundry fixes that result in minor, but visible, behavior changes:
-  [Deal with length query issues](https://github.com/latchset/kryoptic/pull/185)
-  [aes: Restrict AES-GCM to at least 1B tag length](https://github.com/latchset/kryoptic/pull/189)
-  [Fix incorrect error returned on un-initialized operations](https://github.com/latchset/kryoptic/pull/192)
-  [Ensure token store objects can be extracted if the right booleans are
-set](https://github.com/latchset/kryoptic/pull/194)
-  [Fix check for object sensitivity as per spec](https://github.com/latchset/kryoptic/pull/198)
-  [ecdh: Fix max ECDH output size](https://github.com/latchset/kryoptic/pull/203)
-  [Fix C_WrapKey size query](https://github.com/latchset/kryoptic/pull/202)
+  - [Deal with length query
+     issues](https://github.com/latchset/kryoptic/pull/185)
+  - [aes: Restrict AES-GCM to at least 1B tag
+     length](https://github.com/latchset/kryoptic/pull/189)
+  - [Fix incorrect error returned on un-initialized
+     operations](https://github.com/latchset/kryoptic/pull/192)
+  - [Ensure token store objects can be extracted if the right booleans are
+     set](https://github.com/latchset/kryoptic/pull/194)
+  - [Fix check for object sensitivity as per
+     spec](https://github.com/latchset/kryoptic/pull/198)
+  - [ecdh: Fix max ECDH output
+     size](https://github.com/latchset/kryoptic/pull/203)
+  - [Fix C_WrapKey size query](https://github.com/latchset/kryoptic/pull/202)
 
 * Minor enhancements:
-  [Add Stricter FIPS options to configuration](https://github.com/latchset/kryoptic/pull/199)
-  [Allow digesting AES keys and add test coverage.](https://github.com/latchset/kryoptic/pull/204)
+  - [Add Stricter FIPS options to
+     configuration](https://github.com/latchset/kryoptic/pull/199)
+  - [Allow digesting AES keys and add test
+     coverage.](https://github.com/latchset/kryoptic/pull/204)
 
 
 # [1.0.0]

--- a/src/ec/eddsa.rs
+++ b/src/ec/eddsa.rs
@@ -215,7 +215,23 @@ impl ObjectFactory for EDDSAPrivFactory {
 
 impl CommonKeyFactory for EDDSAPrivFactory {}
 
-impl PrivKeyFactory for EDDSAPrivFactory {}
+impl PrivKeyFactory for EDDSAPrivFactory {
+    fn export_for_wrapping(&self, key: &Object) -> Result<Vec<u8>> {
+        export_for_wrapping(key)
+    }
+
+    fn import_from_wrapped(
+        &self,
+        data: Vec<u8>,
+        template: &[CK_ATTRIBUTE],
+    ) -> Result<Object> {
+        import_from_wrapped(
+            CKK_EC_EDWARDS,
+            data,
+            self.default_object_unwrap(template)?,
+        )
+    }
+}
 
 /// The static Public Key factory
 ///

--- a/src/ec/montgomery.rs
+++ b/src/ec/montgomery.rs
@@ -215,7 +215,23 @@ impl ObjectFactory for ECMontgomeryPrivFactory {
 
 impl CommonKeyFactory for ECMontgomeryPrivFactory {}
 
-impl PrivKeyFactory for ECMontgomeryPrivFactory {}
+impl PrivKeyFactory for ECMontgomeryPrivFactory {
+    fn export_for_wrapping(&self, key: &Object) -> Result<Vec<u8>> {
+        export_for_wrapping(key)
+    }
+
+    fn import_from_wrapped(
+        &self,
+        data: Vec<u8>,
+        template: &[CK_ATTRIBUTE],
+    ) -> Result<Object> {
+        import_from_wrapped(
+            CKK_EC_MONTGOMERY,
+            data,
+            self.default_object_unwrap(template)?,
+        )
+    }
+}
 
 /// The static Public Key factory
 ///

--- a/src/kasn1/pkcs.rs
+++ b/src/kasn1/pkcs.rs
@@ -124,3 +124,31 @@ pub const EC_SECP521R1_ALG: AlgorithmIdentifier<'_> = AlgorithmIdentifier {
         oid::EC_SECP521R1,
     )),
 };
+
+/// Ed25519 Algorithm Identifier, typically used for Identifying a private or
+/// public key (for example in PrivateKeyInfo)
+pub const ED25519_ALG: AlgorithmIdentifier<'_> = AlgorithmIdentifier {
+    oid: asn1::DefinedByMarker::marker(),
+    params: AlgorithmParameters::Ed25519,
+};
+
+/// Ed448 Algorithm Identifier, typically used for Identifying a private or
+/// public key (for example in PrivateKeyInfo)
+pub const ED448_ALG: AlgorithmIdentifier<'_> = AlgorithmIdentifier {
+    oid: asn1::DefinedByMarker::marker(),
+    params: AlgorithmParameters::Ed448,
+};
+
+/// X25519 Algorithm Identifier, typically used for Identifying a private or
+/// public key (for example in PrivateKeyInfo)
+pub const X25519_ALG: AlgorithmIdentifier<'_> = AlgorithmIdentifier {
+    oid: asn1::DefinedByMarker::marker(),
+    params: AlgorithmParameters::X25519,
+};
+
+/// X448  Algorithm Identifier, typically used for Identifying a private or
+/// public key (for example in PrivateKeyInfo
+pub const X448_ALG: AlgorithmIdentifier<'_> = AlgorithmIdentifier {
+    oid: asn1::DefinedByMarker::marker(),
+    params: AlgorithmParameters::X448,
+};

--- a/src/tests/keys.rs
+++ b/src/tests/keys.rs
@@ -354,69 +354,64 @@ fn test_rsa_key() {
     testtokn.finalize();
 }
 
-#[cfg(feature = "ecdsa")]
+#[cfg(any(feature = "ecdsa", feature = "eddsa", feature = "ec_montgomery"))]
 #[test]
 #[parallel]
-fn test_ecc_key() {
-    let mut testtokn = TestToken::initialized("test_ecc_key", None);
+fn test_ec_keys() {
+    let mut testtokn = TestToken::initialized("test_ec_keys", None);
     let session = testtokn.get_session(true);
 
     /* login */
     testtokn.login();
 
-    /* EC key pair */
-    let ec_params = hex::decode(
-        "06052B81040022", // secp384r1
-    )
-    .expect("Failed to decode hex ec_params");
+    struct TestData {
+        ec_params: Vec<u8>,
+        key_type: CK_KEY_TYPE,
+        key_gen: CK_MECHANISM_TYPE,
+        op_flags: (CK_ATTRIBUTE_TYPE, CK_ATTRIBUTE_TYPE),
+        op_alg: CK_MECHANISM_TYPE,
+        out_size: usize,
+    }
 
-    let (pubkey, prikey) = ret_or_panic!(generate_key_pair(
-        session,
-        CKM_EC_KEY_PAIR_GEN,
-        &[(CKA_CLASS, CKO_PUBLIC_KEY), (CKA_KEY_TYPE, CKK_EC),],
-        &[(CKA_EC_PARAMS, ec_params.as_slice())],
-        &[(CKA_VERIFY, true)],
-        &[(CKA_CLASS, CKO_PRIVATE_KEY), (CKA_KEY_TYPE, CKK_EC),],
-        &[],
-        &[
-            (CKA_PRIVATE, true),
-            (CKA_SENSITIVE, true),
-            (CKA_TOKEN, true),
-            (CKA_SIGN, true),
-            (CKA_EXTRACTABLE, true),
-        ],
-    ));
-
-    let data = "plaintext";
-    let sig = ret_or_panic!(sig_gen(
-        session,
-        prikey,
-        data.as_bytes(),
-        &CK_MECHANISM {
-            mechanism: CKM_ECDSA_SHA256,
-            pParameter: std::ptr::null_mut(),
-            ulParameterLen: 0,
-        },
-    ));
-    assert_eq!(sig.len(), 96);
-
-    assert_eq!(
-        CKR_OK,
-        sig_verify(
-            session,
-            pubkey,
-            data.as_bytes(),
-            sig.as_slice(),
-            &CK_MECHANISM {
-                mechanism: CKM_ECDSA_SHA256,
-                pParameter: std::ptr::null_mut(),
-                ulParameterLen: 0,
-            },
+    let mut testdata = Vec::<TestData>::new();
+    #[cfg(feature = "ecdsa")]
+    testdata.push(TestData {
+        ec_params: hex::decode(
+            "06052B81040022", // secp384r1
         )
-    );
+        .expect("Failed to decode hex ec_params"),
+        key_type: CKK_EC,
+        key_gen: CKM_EC_KEY_PAIR_GEN,
+        op_flags: (CKA_VERIFY, CKA_SIGN),
+        op_alg: CKM_ECDSA_SHA256,
+        out_size: 96,
+    });
+    #[cfg(feature = "eddsa")]
+    testdata.push(TestData {
+        ec_params: hex::decode(
+            "130c656477617264733235353139", // edwards25519
+        )
+        .expect("Failed to decode hex ec_params"),
+        key_type: CKK_EC_EDWARDS,
+        key_gen: CKM_EC_EDWARDS_KEY_PAIR_GEN,
+        op_flags: (CKA_VERIFY, CKA_SIGN),
+        op_alg: CKM_EDDSA,
+        out_size: 64,
+    });
+    #[cfg(feature = "ec_montgomery")]
+    testdata.push(TestData {
+        ec_params: hex::decode("130a63757276653235353139")
+            .expect("Failed to decode hex ec_params"),
+        key_type: CKK_EC_MONTGOMERY,
+        key_gen: CKM_EC_MONTGOMERY_KEY_PAIR_GEN,
+        op_flags: (CKA_DERIVE, CKA_DERIVE),
+        op_alg: CK_UNAVAILABLE_INFORMATION,
+        out_size: 0,
+    });
+    let data = "plaintext";
 
-    /* Wrap EC key in AES */
-    let handle = ret_or_panic!(generate_key(
+    /* Key for wrapping tests */
+    let wk_handle = ret_or_panic!(generate_key(
         session,
         CKM_AES_KEY_GEN,
         std::ptr::null_mut(),
@@ -431,87 +426,143 @@ fn test_ecc_key() {
         ],
     ));
 
-    let iv = [0xCCu8; 4];
-    let mut mechanism: CK_MECHANISM = CK_MECHANISM {
-        mechanism: CKM_AES_KEY_WRAP_KWP,
-        pParameter: void_ptr!(&iv),
-        ulParameterLen: iv.len() as CK_ULONG,
-    };
-
-    let mut wrapped = vec![0u8; 65536];
-    let mut wrapped_len = wrapped.len() as CK_ULONG;
-
-    let mut ret = fn_wrap_key(
-        session,
-        &mut mechanism,
-        handle,
-        prikey,
-        wrapped.as_mut_ptr(),
-        &mut wrapped_len,
-    );
-    assert_eq!(ret, CKR_OK);
-
-    assert_eq!(check_validation(session, 1), true);
-
-    let mut pri_template = make_attr_template(
-        &[(CKA_CLASS, CKO_PRIVATE_KEY), (CKA_KEY_TYPE, CKK_EC)],
-        &[],
-        &[
-            (CKA_PRIVATE, true),
-            (CKA_SENSITIVE, true),
-            (CKA_TOKEN, true),
-            (CKA_SIGN, true),
-            (CKA_EXTRACTABLE, true),
-        ],
-    );
-
-    let mut prikey2 = CK_INVALID_HANDLE;
-    ret = fn_unwrap_key(
-        session,
-        &mut mechanism,
-        handle,
-        wrapped.as_mut_ptr(),
-        wrapped_len,
-        pri_template.as_mut_ptr(),
-        pri_template.len() as CK_ULONG,
-        &mut prikey2,
-    );
-    assert_eq!(ret, CKR_OK);
-
-    assert_eq!(check_validation(session, 1), true);
-
-    /* Test the unwrapped key can be used */
-    let data = "plaintext";
-    let sig = ret_or_panic!(sig_gen(
-        session,
-        prikey2,
-        data.as_bytes(),
-        &CK_MECHANISM {
-            mechanism: CKM_ECDSA_SHA256,
-            pParameter: std::ptr::null_mut(),
-            ulParameterLen: 0,
-        },
-    ));
-    assert_eq!(sig.len(), 96);
-
-    /* And signature verified by the original public key */
-    assert_eq!(
-        CKR_OK,
-        sig_verify(
+    for t in &testdata {
+        let (pubkey, prikey) = ret_or_panic!(generate_key_pair(
             session,
-            pubkey,
-            data.as_bytes(),
-            sig.as_slice(),
-            &CK_MECHANISM {
-                mechanism: CKM_ECDSA_SHA256,
-                pParameter: std::ptr::null_mut(),
-                ulParameterLen: 0,
-            },
-        )
-    );
+            t.key_gen,
+            &[(CKA_CLASS, CKO_PUBLIC_KEY), (CKA_KEY_TYPE, t.key_type),],
+            &[(CKA_EC_PARAMS, t.ec_params.as_slice())],
+            &[(t.op_flags.0, true)],
+            &[(CKA_CLASS, CKO_PRIVATE_KEY), (CKA_KEY_TYPE, t.key_type),],
+            &[],
+            &[
+                (CKA_PRIVATE, true),
+                (CKA_SENSITIVE, true),
+                (CKA_TOKEN, true),
+                (t.op_flags.1, true),
+                (CKA_EXTRACTABLE, true),
+            ],
+        ));
+
+        if t.op_flags.1 == CKA_SIGN {
+            let sig = ret_or_panic!(sig_gen(
+                session,
+                prikey,
+                data.as_bytes(),
+                &CK_MECHANISM {
+                    mechanism: t.op_alg,
+                    pParameter: std::ptr::null_mut(),
+                    ulParameterLen: 0,
+                },
+            ));
+            assert_eq!(sig.len(), t.out_size);
+
+            assert_eq!(
+                CKR_OK,
+                sig_verify(
+                    session,
+                    pubkey,
+                    data.as_bytes(),
+                    sig.as_slice(),
+                    &CK_MECHANISM {
+                        mechanism: t.op_alg,
+                        pParameter: std::ptr::null_mut(),
+                        ulParameterLen: 0,
+                    },
+                )
+            );
+        }
+
+        /* Wrap EC keys in AES */
+        let iv = [0xCCu8; 4];
+        let mut mechanism: CK_MECHANISM = CK_MECHANISM {
+            mechanism: CKM_AES_KEY_WRAP_KWP,
+            pParameter: void_ptr!(&iv),
+            ulParameterLen: iv.len() as CK_ULONG,
+        };
+
+        let mut wrapped = vec![0u8; 65536];
+        let mut wrapped_len = wrapped.len() as CK_ULONG;
+
+        let mut ret = fn_wrap_key(
+            session,
+            &mut mechanism,
+            wk_handle,
+            prikey,
+            wrapped.as_mut_ptr(),
+            &mut wrapped_len,
+        );
+        assert_eq!(ret, CKR_OK);
+
+        assert_eq!(check_validation(session, 1), true);
+
+        let mut pri_template = make_attr_template(
+            &[(CKA_CLASS, CKO_PRIVATE_KEY), (CKA_KEY_TYPE, t.key_type)],
+            &[],
+            &[
+                (CKA_PRIVATE, true),
+                (CKA_SENSITIVE, true),
+                (CKA_TOKEN, true),
+                (t.op_flags.1, true),
+                (CKA_EXTRACTABLE, true),
+            ],
+        );
+
+        let mut prikey2 = CK_INVALID_HANDLE;
+        ret = fn_unwrap_key(
+            session,
+            &mut mechanism,
+            wk_handle,
+            wrapped.as_mut_ptr(),
+            wrapped_len,
+            pri_template.as_mut_ptr(),
+            pri_template.len() as CK_ULONG,
+            &mut prikey2,
+        );
+        assert_eq!(ret, CKR_OK);
+
+        assert_eq!(check_validation(session, 1), true);
+
+        if t.op_flags.1 == CKA_SIGN {
+            /* Test the unwrapped key can be used */
+            let sig = ret_or_panic!(sig_gen(
+                session,
+                prikey2,
+                data.as_bytes(),
+                &CK_MECHANISM {
+                    mechanism: t.op_alg,
+                    pParameter: std::ptr::null_mut(),
+                    ulParameterLen: 0,
+                },
+            ));
+            assert_eq!(sig.len(), t.out_size);
+
+            /* And signature verified by the original public key */
+            assert_eq!(
+                CKR_OK,
+                sig_verify(
+                    session,
+                    pubkey,
+                    data.as_bytes(),
+                    sig.as_slice(),
+                    &CK_MECHANISM {
+                        mechanism: t.op_alg,
+                        pParameter: std::ptr::null_mut(),
+                        ulParameterLen: 0,
+                    },
+                )
+            );
+        }
+    }
+
+    /* the rest is done only for "ecdsa" */
+    #[cfg(not(feature = "ecdsa"))]
+    {
+        testtokn.finalize();
+        return;
+    }
 
     /* Test CKA_ALWAYS_AUTHENTICATE */
-
     let ec_params = hex::decode(
         "06052B81040022", // secp384r1
     )
@@ -623,70 +674,6 @@ fn test_ecc_key() {
         &mut siglen,
     );
     assert_eq!(ret, CKR_OK);
-
-    testtokn.finalize();
-}
-
-#[cfg(all(feature = "eddsa", not(feature = "fips")))]
-#[test]
-#[parallel]
-fn test_eddsa_key() {
-    let mut testtokn = TestToken::initialized("test_eddsa_key", None);
-    let session = testtokn.get_session(true);
-
-    /* login */
-    testtokn.login();
-
-    /* Ed25519 key pair */
-    let ec_params = hex::decode(
-        "130c656477617264733235353139", // edwards25519
-    )
-    .expect("Failed to decode hex ec_params");
-
-    let (pubkey, prikey) = ret_or_panic!(generate_key_pair(
-        session,
-        CKM_EC_EDWARDS_KEY_PAIR_GEN,
-        &[(CKA_CLASS, CKO_PUBLIC_KEY), (CKA_KEY_TYPE, CKK_EC_EDWARDS),],
-        &[(CKA_EC_PARAMS, ec_params.as_slice())],
-        &[(CKA_VERIFY, true)],
-        &[(CKA_CLASS, CKO_PRIVATE_KEY), (CKA_KEY_TYPE, CKK_EC_EDWARDS),],
-        &[],
-        &[
-            (CKA_PRIVATE, true),
-            (CKA_SENSITIVE, true),
-            (CKA_TOKEN, true),
-            (CKA_SIGN, true),
-            (CKA_EXTRACTABLE, true),
-        ],
-    ));
-
-    let data = "plaintext";
-    let sig = ret_or_panic!(sig_gen(
-        session,
-        prikey,
-        data.as_bytes(),
-        &CK_MECHANISM {
-            mechanism: CKM_EDDSA,
-            pParameter: std::ptr::null_mut(),
-            ulParameterLen: 0,
-        },
-    ));
-    assert_eq!(sig.len(), 64);
-
-    assert_eq!(
-        CKR_OK,
-        sig_verify(
-            session,
-            pubkey,
-            data.as_bytes(),
-            sig.as_slice(),
-            &CK_MECHANISM {
-                mechanism: CKM_EDDSA,
-                pParameter: std::ptr::null_mut(),
-                ulParameterLen: 0,
-            },
-        )
-    );
 
     testtokn.finalize();
 }


### PR DESCRIPTION
#### Description

Edwards and Montgomery keys were lacking encoding/decoding functions for import/export

Add missing code by creating common handlers and test key generating and wrapping/unwrapping for all there key types

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [x] Documentation was updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] A changelog entry is added if the change is significant
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible text
