### PR TITLE
Change some build time variables and configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,6 @@ Build the rust project:
 
     $ CONFDIR=/etc cargo build
 
-For the FIPS build, you need to generate the hmac checksum:
-
-    $ ./misc/hmacify.sh target/release/libkryoptic_pkcs11.so
-
 The default build specifies "standard" as the default feature for
 ease of use. "Standard" pulls in all the standard algorithms and the
 sqlitedb storage backend.
@@ -51,6 +47,32 @@ switch to disable default features (`--no-default-features`) and then
 specify the features you want to build with, eg:
 
     $ cargo build --no-default-features --features fips,sqlitedb,nssdb
+
+# FIPS Builds
+
+The `--feature fips` builds create a token linking just to OpenSSL libfips.a
+and enable FIPS behavior, restricting how algorithms behave and reporting
+FIPS indicators for (non)approved algorithms and operations. It forces the
+presence of the PKCS#11 3.2 interfaces as well as the PQC algorithms.
+
+The FIPS build allows to specify the name, version, and additional build
+information returned by the embedded OpenSSL FIPS provider by setting the
+following environment variables (requires custom patches to the OpenSSL
+code base to take effect):
+- KRYOPTIC_FIPS_VENDOR
+- KRYOPTIC_FIPS_VERSION
+- KRYOPTIC_FIPS_BUILD
+
+If these variables are not set build defaults respectively to:
+- CARGO_PKG_NAME
+- CARGO_PKG_VERSION
+- "test"
+
+For the FIPS build, you need to generate the hmac checksum:
+
+    $ ./misc/hmacify.sh target/release/libkryoptic_pkcs11.so
+
+Without this step the token will panic at initialization.
 
 # Tests
 

--- a/build.rs
+++ b/build.rs
@@ -171,13 +171,32 @@ fn build_ossl(features: &Features, out_file: &Path) {
         buildargs.push("enable-fips");
 
         defines.push_str(" -DOPENSSL_PEDANTIC_ZEROIZATION");
+
+        let fips_name = match std::env::var("KRYOPTIC_FIPS_VENDOR") {
+            Ok(name) => name,
+            Err(_) => env!("CARGO_PKG_NAME").to_string(),
+        };
         defines.push_str(&format!(
-            " -DFIPS_VENDOR=\\\"{}\\\"",
-            env!("CARGO_PKG_NAME")
+            " -DKRYOPTIC_FIPS_VENDOR=\\\"{}\\\"",
+            fips_name,
         ));
+
+        let fips_ver = match std::env::var("KRYOPTIC_FIPS_VERSION") {
+            Ok(ver) => ver,
+            Err(_) => env!("CARGO_PKG_VERSION").to_string(),
+        };
         defines.push_str(&format!(
-            " -DKRYOPTIC_FIPS_VERSION=\\\"{}-test\\\"",
-            env!("CARGO_PKG_VERSION")
+            " -DKRYOPTIC_FIPS_VERSION=\\\"{}\\\"",
+            fips_ver,
+        ));
+
+        let fips_build = match std::env::var("KRYOPTIC_FIPS_BUILD") {
+            Ok(bd) => bd,
+            Err(_) => "test".to_string(),
+        };
+        defines.push_str(&format!(
+            " -DKRYOPTIC_FIPS_BUILD=\\\"{}\\\"",
+            fips_build,
         ));
 
         ar_name = "fips";

--- a/src/fips/mod.rs
+++ b/src/fips/mod.rs
@@ -38,7 +38,7 @@ pub fn register(_: &mut Mechanisms, ot: &mut ObjectFactories) {
 /// checks whether the CKA_SENSITIVE attribute contains an appropriate value
 pub fn check_key_template(
     template: &[CK_ATTRIBUTE],
-    fips_opts: FipsBehavior,
+    fips_opts: &FipsBehavior,
 ) -> Result<()> {
     if !fips_opts.keys_always_sensitive {
         return Ok(());

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -25,6 +25,8 @@ pub struct Slot {
     token: RwLock<Token>,
     /// Map of active sessions associated with this slot, keyed by session handle.
     sessions: HashMap<CK_SESSION_HANDLE, RwLock<Session>>,
+    #[cfg(feature = "fips")]
+    fips_behavior: config::FipsBehavior,
 }
 
 impl Slot {
@@ -54,6 +56,8 @@ impl Slot {
             },
             token: RwLock::new(Token::new(dbtype, dbargs)?),
             sessions: HashMap::new(),
+            #[cfg(feature = "fips")]
+            fips_behavior: config.fips_behavior.clone(),
         };
 
         /* fill strings */
@@ -223,5 +227,15 @@ impl Slot {
     pub fn finalize(&mut self) -> Result<()> {
         self.drop_all_sessions();
         self.token.write().unwrap().save()
+    }
+
+    #[cfg(feature = "fips")]
+    pub fn get_fips_behavior(&self) -> &config::FipsBehavior {
+        &self.fips_behavior
+    }
+
+    #[cfg(feature = "fips")]
+    pub fn set_fips_behavior(&mut self, behavior: config::FipsBehavior) {
+        self.fips_behavior = behavior;
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -221,9 +221,12 @@ impl TestToken<'_> {
         /* By default we force relaxed behavior so tests can access
          * data to check results */
         #[cfg(feature = "fips")]
-        set_fips_behavior(config::FipsBehavior {
-            keys_always_sensitive: false,
-        });
+        set_fips_behavior(
+            td.get_slot(),
+            config::FipsBehavior {
+                keys_always_sensitive: false,
+            },
+        );
 
         td
     }

--- a/src/tests/nssdb.rs
+++ b/src/tests/nssdb.rs
@@ -166,12 +166,16 @@ fn test_nssdb_init_token() {
     #[cfg(feature = "fips")]
     /* Set default NSSDB Behavior for this test */
     let saved_config = {
+        let slot_id = testtokn.get_slot();
         let mut save = config::FipsBehavior::default();
-        let ret = get_fips_behavior(&mut save);
+        let ret = get_fips_behavior(slot_id, &mut save);
         assert_eq!(ret, CKR_OK);
-        let ret = set_fips_behavior(config::FipsBehavior {
-            keys_always_sensitive: true,
-        });
+        let ret = set_fips_behavior(
+            slot_id,
+            config::FipsBehavior {
+                keys_always_sensitive: true,
+            },
+        );
         assert_eq!(ret, CKR_OK);
         save
     };
@@ -246,7 +250,7 @@ fn test_nssdb_init_token() {
     #[cfg(feature = "fips")]
     {
         /* Restore default FIPS  Behavior */
-        let ret = set_fips_behavior(saved_config);
+        let ret = set_fips_behavior(testtokn.get_slot(), saved_config);
         assert_eq!(ret, CKR_OK);
     }
 


### PR DESCRIPTION
#### Description

Add the ability to set a series of env vars at build time to control the FIPS token name/version/build info

Additionally make FIPS tunables per token instead of being global

Fixes #240 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [x] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
