### PR TITLE
Cargo: Bump cryptoki version to match version in Fedora

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ bitflags = "2.4.1"
 cfg-if = "1.0.0"
 clap = { version = "4.5.26", default-features = false, features = ["cargo", "derive", "help", "std", "usage"] }
 constant_time_eq = "0.3.0"
-cryptoki = "0.6.2"
+cryptoki = "0.9.0"
 data-encoding = "2.4.0"
 getrandom = "0.3"
 hex = "0.4.3"


### PR DESCRIPTION
#### Description

The cryptoki was updated in Fedora to 0.9.0 so follow the suit here to keep the Fedora RPM builds working.

https://src.fedoraproject.org/rpms/rust-cryptoki/pull-request/2

#### Checklist

~- [ ] Test suite updated with functionality tests~
~- [ ] Test suite updated with negative tests~
~- [ ] Rustdoc string were added or updated~
~- [ ] CHANGELOG and/or other documentation added or updated~
- [X] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
