### PR TITLE
Implement TLS 1.2 EMS derive

### DIFF
--- a/src/fips/indicators.rs
+++ b/src/fips/indicators.rs
@@ -282,7 +282,7 @@ struct FipsMechanism {
 /// Struct that holds FIPS properties for keys and mechanisms
 struct FipsChecks {
     keys: [FipsKeyType; 17],
-    mechs: [FipsMechanism; 86],
+    mechs: [FipsMechanism; 87],
 }
 
 /// A constant instantiation of FIPS properties with a list
@@ -917,7 +917,20 @@ const FIPS_CHECKS: FipsChecks = FipsChecks {
                 | CKF_DERIVE,
         },
         FipsMechanism {
-            mechanism: CKM_TLS12_MASTER_KEY_DERIVE,
+            mechanism: CKM_TLS12_EXTENDED_MASTER_KEY_DERIVE_DH,
+            operations: CKF_DERIVE,
+            restrictions: [
+                restrict!(CKK_GENERIC_SECRET, step!(48 * 8)),
+                restrict!(),
+            ],
+            genflags: CKF_SIGN
+                | CKF_VERIFY
+                | CKF_ENCRYPT
+                | CKF_DECRYPT
+                | CKF_DERIVE,
+        },
+        FipsMechanism {
+            mechanism: CKM_TLS12_EXTENDED_MASTER_KEY_DERIVE,
             operations: CKF_DERIVE,
             restrictions: [
                 restrict!(CKK_GENERIC_SECRET, step!(48 * 8)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2811,8 +2811,10 @@ extern "C" fn fn_derive_key(
                 }
             }
 
-            unsafe {
-                core::ptr::write(key_handle, kh);
+            if !key_handle.is_null() {
+                unsafe {
+                    core::ptr::write(key_handle, kh);
+                }
             }
             CKR_OK
         }
@@ -2855,8 +2857,10 @@ extern "C" fn fn_derive_key(
             }
             let kh =
                 res_or_ret!(token.insert_object(s_handle, result.remove(0)));
-            unsafe {
-                core::ptr::write(key_handle, kh);
+            if !key_handle.is_null() {
+                unsafe {
+                    core::ptr::write(key_handle, kh);
+                }
             }
             CKR_OK
         }

--- a/src/native/tlskdf.rs
+++ b/src/native/tlskdf.rs
@@ -334,6 +334,14 @@ impl TLSKDFOperation {
         let session_hash =
             bytes_to_vec!(params.pSessionHash, params.ulSessionHashLen);
 
+        // The pVersion field of the structure must be set to NULL_PTR since the version
+        // number is not embedded in the "pre_master" key as it is for RSA-like cipher suites.
+        if mech.mechanism == CKM_TLS12_EXTENDED_MASTER_KEY_DERIVE_DH
+            && !params.pVersion.is_null()
+        {
+            return Err(CKR_MECHANISM_PARAM_INVALID)?;
+        }
+
         let version = if params.pVersion.is_null() {
             None
         } else {
@@ -385,6 +393,14 @@ impl TLSKDFOperation {
             Ok(h) => h,
             Err(_) => return Err(CKR_MECHANISM_PARAM_INVALID)?,
         };
+
+        // The pVersion field of the structure must be set to NULL_PTR since the version
+        // number is not embedded in the "pre_master" key as it is for RSA-like cipher suites.
+        if mech.mechanism == CKM_TLS12_MASTER_KEY_DERIVE_DH
+            && !params.pVersion.is_null()
+        {
+            return Err(CKR_MECHANISM_PARAM_INVALID)?;
+        }
 
         let version = if params.pVersion.is_null() {
             None

--- a/src/tlskdf.rs
+++ b/src/tlskdf.rs
@@ -97,6 +97,28 @@ impl TLSPRFMechanism {
                 },
             }),
         );
+        #[cfg(feature = "pkcs11_3_2")]
+        mechs.add_mechanism(
+            CKM_TLS12_EXTENDED_MASTER_KEY_DERIVE,
+            Box::new(TLSPRFMechanism {
+                info: CK_MECHANISM_INFO {
+                    ulMinKeySize: TLS_MASTER_SECRET_SIZE,
+                    ulMaxKeySize: TLS_MASTER_SECRET_SIZE,
+                    flags: CKF_DERIVE,
+                },
+            }),
+        );
+        #[cfg(feature = "pkcs11_3_2")]
+        mechs.add_mechanism(
+            CKM_TLS12_EXTENDED_MASTER_KEY_DERIVE_DH,
+            Box::new(TLSPRFMechanism {
+                info: CK_MECHANISM_INFO {
+                    ulMinKeySize: TLS_MASTER_SECRET_SIZE,
+                    ulMaxKeySize: TLS_MASTER_SECRET_SIZE,
+                    flags: CKF_DERIVE,
+                },
+            }),
+        );
     }
 }
 
@@ -116,6 +138,11 @@ impl Mechanism for TLSPRFMechanism {
         }
 
         match mech.mechanism {
+            #[cfg(feature = "pkcs11_3_2")]
+            CKM_TLS12_EXTENDED_MASTER_KEY_DERIVE
+            | CKM_TLS12_EXTENDED_MASTER_KEY_DERIVE_DH => {
+                Ok(Box::new(TLSKDFOperation::new(mech)?))
+            }
             CKM_TLS12_MASTER_KEY_DERIVE
             | CKM_TLS12_KEY_AND_MAC_DERIVE
             | CKM_TLS12_KEY_SAFE_DERIVE


### PR DESCRIPTION
#### Description

Implementation of `CKM_TLS12_EXTENDED_MASTER_KEY_DERIVE` derive mechanism.

WIP as I need to find some test vectors (was not successful yet).

#### Checklist

- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [X] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
