### PR TITLE
Add fips checks for KDFs additional input keys

### DIFF
--- a/src/fips/indicators.rs
+++ b/src/fips/indicators.rs
@@ -1304,6 +1304,17 @@ fn add_fips_flag(key: &mut Object) {
         key.set_attr(Attribute::from_ulong(CKA_OBJECT_VALIDATION_FLAGS, flag));
 }
 
+/// Allows to check if a key is considered fips approved for the
+/// requested operation. Checks overall key validity based on minimum
+/// length and type, as well as whether the key allows the specific
+/// operation in FIPS mode
+pub fn is_key_approved(key: &Object, op: CK_FLAGS) -> bool {
+    if has_fips_flag(key) {
+        return true;
+    }
+    check_key(key, op, None, None)
+}
+
 /// Helper to check if an operation is approved
 ///
 /// Applies key checks as well as mechanism checks according to the
@@ -1346,11 +1357,7 @@ pub fn is_approved(
 
         if checks & 1 == 1 {
             let valid_key = if let Some(obj) = iobj {
-                if has_fips_flag(obj) {
-                    true
-                } else {
-                    check_key(obj, op, None, None)
-                }
+                is_key_approved(obj, op)
             } else {
                 false
             };

--- a/src/tests/simplekdf.rs
+++ b/src/tests/simplekdf.rs
@@ -69,9 +69,7 @@ fn test_concatenate_kdf() {
     assert_eq!(check_validation(session, 0), true);
 
     let exp_value = hex::decode("0123456789abcdef").unwrap();
-    let exp_value_len = 8;
-    let value =
-        ret_or_panic!(extract_key_value(session, dk_handle, exp_value_len));
+    let value = ret_or_panic!(extract_key_value(session, dk_handle));
     assert_eq!(value, exp_value);
 
     // Concatenate base and data
@@ -100,9 +98,7 @@ fn test_concatenate_kdf() {
     assert_eq!(check_validation(session, 0), true);
 
     let exp_value = hex::decode("0123456789abcdef").unwrap();
-    let exp_value_len = 8;
-    let value =
-        ret_or_panic!(extract_key_value(session, dk_handle, exp_value_len));
+    let value = ret_or_panic!(extract_key_value(session, dk_handle));
     assert_eq!(value, exp_value);
 
     // Concatenate data and base
@@ -131,9 +127,7 @@ fn test_concatenate_kdf() {
     assert_eq!(check_validation(session, 0), true);
 
     let exp_value = hex::decode("89abcdef01234567").unwrap();
-    let exp_value_len = 8;
-    let value =
-        ret_or_panic!(extract_key_value(session, dk_handle, exp_value_len));
+    let value = ret_or_panic!(extract_key_value(session, dk_handle));
     assert_eq!(value, exp_value);
 
     // XOR key and data
@@ -162,9 +156,7 @@ fn test_concatenate_kdf() {
     assert_eq!(check_validation(session, 0), true);
 
     let exp_value = hex::decode("88888888").unwrap();
-    let exp_value_len = 4;
-    let value =
-        ret_or_panic!(extract_key_value(session, dk_handle, exp_value_len));
+    let value = ret_or_panic!(extract_key_value(session, dk_handle));
     assert_eq!(value, exp_value);
 }
 
@@ -232,9 +224,7 @@ fn test_concatenate_kdf_fips() {
     let exp_value =
         hex::decode("000102030405060708090a0b0c0d00102030405060708090a0b0c0d0")
             .unwrap();
-    let exp_value_len = 28;
-    let value =
-        ret_or_panic!(extract_key_value(session, dk_handle, exp_value_len));
+    let value = ret_or_panic!(extract_key_value(session, dk_handle));
     assert_eq!(value, exp_value);
     assert_eq!(check_validation(session, 1), true);
 
@@ -264,9 +254,7 @@ fn test_concatenate_kdf_fips() {
     assert_eq!(check_validation(session, 1), true);
 
     let exp_value = hex::decode("000102030405060708090a0b0c0d0e0f").unwrap();
-    let exp_value_len = 16;
-    let value =
-        ret_or_panic!(extract_key_value(session, dk_handle, exp_value_len));
+    let value = ret_or_panic!(extract_key_value(session, dk_handle));
     assert_eq!(value, exp_value);
 
     // Concatenate data and base
@@ -295,9 +283,7 @@ fn test_concatenate_kdf_fips() {
     assert_eq!(check_validation(session, 1), true);
 
     let exp_value = hex::decode("0e0f000102030405060708090a0b0c0d").unwrap();
-    let exp_value_len = 16;
-    let value =
-        ret_or_panic!(extract_key_value(session, dk_handle, exp_value_len));
+    let value = ret_or_panic!(extract_key_value(session, dk_handle));
     assert_eq!(value, exp_value);
 
     // XOR key and data

--- a/src/tests/tls.rs
+++ b/src/tests/tls.rs
@@ -338,11 +338,7 @@ fn test_tlskdf_units(
                 panic!("Failed ({}) unit test at line {}", ret, unit.line);
             }
 
-            let value = ret_or_panic!(extract_key_value(
-                session,
-                dk_handle,
-                unit.ms.len()
-            ));
+            let value = ret_or_panic!(extract_key_value(session, dk_handle));
             if value != unit.ms {
                 panic!("Failed ({}) unit test {} at line {} - values differ [{} != {}]",
                        ret, unit.count, unit.line, hex::encode(value), hex::encode(unit.ms));
@@ -417,16 +413,10 @@ fn test_tlskdf_units(
                 panic!("Failed ({}) unit test at line {}", ret, unit.line);
             }
 
-            let clikeyval = ret_or_panic!(extract_key_value(
-                session,
-                mat_out.hClientKey,
-                keylen
-            ));
-            let srvkeyval = ret_or_panic!(extract_key_value(
-                session,
-                mat_out.hServerKey,
-                keylen
-            ));
+            let clikeyval =
+                ret_or_panic!(extract_key_value(session, mat_out.hClientKey));
+            let srvkeyval =
+                ret_or_panic!(extract_key_value(session, mat_out.hServerKey));
 
             let mut value = Vec::<u8>::with_capacity(unit.kb.len());
             value.extend_from_slice(clikeyval.as_slice());
@@ -837,7 +827,7 @@ fn test_tls_ems_vector() {
     assert_eq!(ret, CKR_OK);
 
     let exp_value = hex::decode("4EC38663D2CEFE30EDA0F30957649953A5437D37CDBC409408DA44F30BD8D9F280E07EE55233AFA69E1C90D8A24239E3").unwrap();
-    let value = ret_or_panic!(extract_key_value(session, dk_handle, value_len));
+    let value = ret_or_panic!(extract_key_value(session, dk_handle));
     if value != exp_value {
         panic!("The derived extended master secret value does not match");
     }


### PR DESCRIPTION
#### Description

Allows to check that input keys in KDFs that are passed via parameters are fips compliant.

Note that even though the bug mentions HKDF, in that case the input key is used as salt and the code there (in openssl) already checks that the salt length complies with FIPS requirements where needed, so the key must not be checked for fips approval in that case as the salt length may have separate requirements.

Fixes #280

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite updated with functionality tests
- [x] Test suite updated with negative tests
- [x] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
