### PR TITLE
Reduce max key sizes to avoid overflow

### DIFF
--- a/src/fips/indicators.rs
+++ b/src/fips/indicators.rs
@@ -974,7 +974,7 @@ const FIPS_CHECKS: FipsChecks = FipsChecks {
             operations: CKF_DERIVE,
             restrictions: [
                 restrict!(CKK_AES),
-                restrict!(KRY_UNSPEC, range!(112, 0xffffffff)),
+                restrict!(KRY_UNSPEC, range!(112, 0x1000000)),
             ],
             genflags: CKF_SIGN
                 | CKF_VERIFY
@@ -989,7 +989,7 @@ const FIPS_CHECKS: FipsChecks = FipsChecks {
             operations: CKF_DERIVE,
             restrictions: [
                 restrict!(CKK_AES),
-                restrict!(KRY_UNSPEC, range!(112, 0xffffffff)),
+                restrict!(KRY_UNSPEC, range!(112, 0x1000000)),
             ],
             genflags: CKF_SIGN
                 | CKF_VERIFY


### PR DESCRIPTION
#### Description

On i686 the value 0xffffffff is the maximum value that a CK_ULONG can carry, which causes an overflow when we use ($val + 7 )/ 8 to convert bits to bytes.

Given that it is never reasonable to have keys that are gigabits long anyway let's clam the max down to 16M bits (2MiB) for now.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
