### PR TITLE
openjdk-integration.yml: Run on pull_request and push

### DIFF
--- a/.github/workflows/openjdk-integration.yml
+++ b/.github/workflows/openjdk-integration.yml
@@ -11,15 +11,13 @@ env:
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Build"]
-    branches: [main]
-    types:
-      - completed
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
 
 jobs:
   test-openjdk-integration:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: OpenJDK Integration Tests
     runs-on: ubuntu-22.04
     container: fedora:latest


### PR DESCRIPTION
Run `openjdk-integration.yml` regardless of outcome of `build.yml`, and on push and pull request events.

#### Description

This change makes `openjdk-integration.yml` run on `push` and `pull_request` events (like `build.yml`), regardless of whether `build.yml` succeeds.

I kept `workflow_dispatch` so I have a button to run the job in case I want to change the `jdk21u-dev` repository.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] ~~Test suite updated with functionality tests~~
- [ ] ~~Test suite updated with negative tests~~
- [ ] ~~Rustdoc string were added or updated~~
- [ ] ~~CHANGELOG and/or other documentation added or updated~~
- [X] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
