### PR TITLE
Some `ossl` API work, mostly polishing

### DIFF
--- a/ossl/src/asymcipher.rs
+++ b/ossl/src/asymcipher.rs
@@ -29,30 +29,30 @@ pub fn rsa_enc_params(
     alg: EncAlg,
     oaep_params: Option<&RsaOaepParams>,
 ) -> Result<OsslParam, Error> {
-    let mut params = OsslParam::new();
+    let mut params_builder = crate::OsslParamBuilder::new();
 
     match alg {
-        EncAlg::RsaNoPad => params.add_const_c_string(
+        EncAlg::RsaNoPad => params_builder.add_const_c_string(
             cstr!(OSSL_PKEY_PARAM_PAD_MODE),
             cstr!(OSSL_PKEY_RSA_PAD_MODE_NONE),
         )?,
         EncAlg::RsaOaep => {
             if let Some(oaep) = &oaep_params {
-                params.add_const_c_string(
+                params_builder.add_const_c_string(
                     cstr!(OSSL_PKEY_PARAM_PAD_MODE),
                     cstr!(OSSL_PKEY_RSA_PAD_MODE_OAEP),
                 )?;
-                params.add_const_c_string(
+                params_builder.add_const_c_string(
                     cstr!(OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST),
                     digest_to_string(oaep.digest),
                 )?;
-                params.add_const_c_string(
+                params_builder.add_const_c_string(
                     cstr!(OSSL_PKEY_PARAM_MGF1_DIGEST),
                     digest_to_string(oaep.mgf1),
                 )?;
                 match &oaep.label {
                     None => (),
-                    Some(label) => params.add_octet_string(
+                    Some(label) => params_builder.add_octet_string(
                         cstr!(OSSL_ASYM_CIPHER_PARAM_OAEP_LABEL),
                         &label,
                     )?,
@@ -61,14 +61,13 @@ pub fn rsa_enc_params(
                 return Err(Error::new(ErrorKind::NullPtr));
             }
         }
-        EncAlg::RsaPkcs1_5 => params.add_const_c_string(
+        EncAlg::RsaPkcs1_5 => params_builder.add_const_c_string(
             cstr!(OSSL_PKEY_PARAM_PAD_MODE),
             cstr!(OSSL_PKEY_RSA_PAD_MODE_PKCSV15),
         )?,
     }
 
-    params.finalize();
-    return Ok(params);
+    Ok(params_builder.finalize())
 }
 
 /// Asymmetric Cipher Operation

--- a/ossl/src/lib.rs
+++ b/ossl/src/lib.rs
@@ -83,6 +83,21 @@ pub enum ErrorKind {
     BadArg,
 }
 
+impl std::fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            ErrorKind::NullPtr => "OpenSSL returned a NULL ptr as an error",
+            ErrorKind::OsslError => "OpenSSL returned a 0 c_int as an error",
+            ErrorKind::KeyError => "A falure resulting from wrong key usage",
+            ErrorKind::WrapperError => "A wrapper error",
+            ErrorKind::BufferSize => "A buffer is not of the correct size",
+            ErrorKind::BadArg => {
+                "An optional argument is required or has a bad value"
+            }
+        })
+    }
+}
+
 #[derive(Debug)]
 pub struct Error {
     kind: ErrorKind,
@@ -95,6 +110,14 @@ impl Error {
 
     pub fn kind(&self) -> ErrorKind {
         self.kind
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.kind())
     }
 }
 

--- a/ossl/src/lib.rs
+++ b/ossl/src/lib.rs
@@ -98,7 +98,7 @@ impl std::fmt::Display for ErrorKind {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Error {
     kind: ErrorKind,
 }

--- a/ossl/src/lib.rs
+++ b/ossl/src/lib.rs
@@ -75,7 +75,7 @@ pub enum ErrorKind {
     OsslError,
     /// A falure resulting from wrong key usage
     KeyError,
-    /// A warpper error
+    /// A wrapper error
     WrapperError,
     /// A buffer is not of the correct size
     BufferSize,

--- a/ossl/src/mac.rs
+++ b/ossl/src/mac.rs
@@ -8,7 +8,8 @@ use std::ffi::CStr;
 use crate::bindings::*;
 use crate::digest::DigestAlg;
 use crate::{
-    cstr, trace_ossl, Error, ErrorKind, OsslContext, OsslParam, OsslSecret,
+    cstr, trace_ossl, Error, ErrorKind, OsslContext, OsslParamBuilder,
+    OsslSecret,
 };
 
 /// Wrapper around OpenSSL's `EVP_MAC_CTX`, managing its lifecycle.
@@ -114,7 +115,7 @@ pub(crate) fn mac_to_digest_and_type(
 }
 
 pub(crate) fn add_mac_alg_to_params(
-    params: &mut OsslParam,
+    params: &mut OsslParamBuilder,
     mac: MacAlg,
     digest_key_str: &CStr,
     cipher_key_str: &CStr,
@@ -229,14 +230,14 @@ impl OsslMac {
         mac: MacAlg,
         key: OsslSecret,
     ) -> Result<OsslMac, Error> {
-        let mut params = OsslParam::with_capacity(1);
+        let mut params = OsslParamBuilder::with_capacity(1);
         let mac_type = add_mac_alg_to_params(
             &mut params,
             mac,
             cstr!(OSSL_MAC_PARAM_DIGEST),
             cstr!(OSSL_MAC_PARAM_CIPHER),
         )?;
-        params.finalize();
+        let params = params.finalize();
 
         let mut mctx = OsslMac {
             ctx: EvpMacCtx::new(ctx, mac_type)?,

--- a/ossl/src/pkey.rs
+++ b/ossl/src/pkey.rs
@@ -614,9 +614,6 @@ impl EvpPkey {
 
     /// Generates a new key pair based on provided algorithm name and
     /// parameters.
-    ///
-    /// The parameters (`OsslParam`) specify details like key size or curve
-    /// name.
     pub fn generate(
         ctx: &OsslContext,
         pkey_type: EvpPkeyType,

--- a/ossl/src/rand.rs
+++ b/ossl/src/rand.rs
@@ -5,7 +5,9 @@
 
 use crate::bindings::*;
 use crate::digest::{digest_to_string, DigestAlg};
-use crate::{cstr, trace_ossl, Error, ErrorKind, OsslContext, OsslParam};
+use crate::{
+    cstr, trace_ossl, Error, ErrorKind, OsslContext, OsslParamBuilder,
+};
 
 /// Wrapper around OpenSSL's `EVP_RAND_CTX`.
 /// Represents a random generator instance, using
@@ -45,13 +47,13 @@ impl EvpRandCtx {
             return Err(Error::new(ErrorKind::OsslError));
         }
 
-        let mut params = OsslParam::with_capacity(2);
+        let mut params = OsslParamBuilder::with_capacity(2);
         params.add_const_c_string(cstr!(OSSL_DRBG_PARAM_MAC), c"HMAC")?;
         params.add_const_c_string(
             cstr!(OSSL_DRBG_PARAM_DIGEST),
             digest_to_string(digest),
         )?;
-        params.finalize();
+        let params = params.finalize();
 
         let ret = unsafe {
             EVP_RAND_instantiate(

--- a/src/config.rs
+++ b/src/config.rs
@@ -344,7 +344,7 @@ impl Config {
     }
 
     /// Ensure all slot numbers are consistent, and allocates new slot
-    /// numbers for slots that have the special invalid slow number of
+    /// numbers for slots that have the special invalid slot number of
     /// u32::MAX
     fn fix_slot_numbers(&mut self) {
         let mut slotnum: u32 = 0;


### PR DESCRIPTION
#### Description

I ported `sequoia-openpgp` from `rust-openssl` to (a slightly patched version of) `ossl`.  This is the first set of patches from that effort.  I picked them in the hope that they are uncontroversial, and we can get them out of the way.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [x] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
