### PR TITLE
Implement Drop to cleanse sensitive key data

### DIFF
--- a/ossl/src/lib.rs
+++ b/ossl/src/lib.rs
@@ -940,6 +940,14 @@ impl OsslSecret {
         }
     }
 
+    /// Creates a new `OsslSecret` from an existing vector.
+    ///
+    /// This method takes ownership of the provided `Vec<u8>`, avoiding an
+    /// unnecessary copy of the secret data.
+    pub fn from_vec(secret: Vec<u8>) -> OsslSecret {
+        OsslSecret { data: secret }
+    }
+
     /// Returns the number of bytes in the secret.
     pub fn len(&self) -> usize {
         self.data.len()

--- a/ossl/src/mac.rs
+++ b/ossl/src/mac.rs
@@ -19,7 +19,7 @@ pub struct EvpMacCtx {
 
 /// Methods for creating (from a named MAC) and accessing `EvpMacCtx`.
 impl EvpMacCtx {
-    pub fn new(ctx: &OsslContext, name: &CStr) -> Result<EvpMacCtx, Error> {
+    fn new(ctx: &OsslContext, name: &CStr) -> Result<EvpMacCtx, Error> {
         let arg = unsafe {
             EVP_MAC_fetch(ctx.ptr(), name.as_ptr(), std::ptr::null_mut())
         };
@@ -38,13 +38,8 @@ impl EvpMacCtx {
         Ok(EvpMacCtx { ptr })
     }
 
-    /// Returns a const pointer to the underlying `EVP_MAC_CTX`.
-    pub unsafe fn as_ptr(&self) -> *const EVP_MAC_CTX {
-        self.ptr
-    }
-
     /// Returns a mutable pointer to the underlying `EVP_MAC_CTX`.
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut EVP_MAC_CTX {
+    fn as_mut_ptr(&mut self) -> *mut EVP_MAC_CTX {
         self.ptr
     }
 }

--- a/src/ossl/aes.rs
+++ b/src/ossl/aes.rs
@@ -18,6 +18,7 @@ use crate::pkcs11::*;
 use constant_time_eq::constant_time_eq;
 use ossl::cipher::{AeadParams, AesCtsMode, AesSize, EncAlg, OsslCipher};
 use ossl::mac::{MacAlg, OsslMac};
+use ossl::OsslSecret;
 
 #[cfg(feature = "fips")]
 use ossl::fips::FipsApproval;
@@ -550,11 +551,11 @@ impl AesOperation {
             Self::generate_iv(params)?;
         }
 
-        let mut ctx = OsslCipher::cipher_new(
+        let mut ctx = OsslCipher::new(
             osslctx(),
             Self::get_cipher(mech, params, key.len())?,
             enc,
-            key.clone(),
+            OsslSecret::from_slice(key.as_slice()),
             if params.iv.buf.len() > 0 {
                 Some(params.iv.buf.clone())
             } else {

--- a/src/ossl/ecdsa.rs
+++ b/src/ossl/ecdsa.rs
@@ -241,13 +241,13 @@ impl EcdsaOperation {
     ) -> Result<()> {
         let pkey =
             EvpPkey::generate(osslctx(), get_evp_pkey_type_from_obj(pubkey)?)?;
-        let ecc = match pkey.export()? {
+        let mut ecc = match pkey.export()? {
             PkeyData::Ecc(e) => e,
             _ => return Err(CKR_GENERAL_ERROR)?,
         };
 
         /* Set Public Key */
-        if let Some(key) = ecc.pubkey {
+        if let Some(key) = ecc.pubkey.take() {
             let point_encoded = match asn1::write_single(&key.as_slice()) {
                 Ok(b) => b,
                 Err(_) => return Err(CKR_GENERAL_ERROR)?,
@@ -259,7 +259,7 @@ impl EcdsaOperation {
         }
 
         /* Set Private Key */
-        if let Some(key) = ecc.prikey {
+        if let Some(key) = ecc.prikey.take() {
             privkey.set_attr(Attribute::from_bytes(CKA_VALUE, key))?;
         } else {
             return Err(CKR_DEVICE_ERROR)?;

--- a/src/ossl/eddsa.rs
+++ b/src/ossl/eddsa.rs
@@ -187,20 +187,20 @@ impl EddsaOperation {
     ) -> Result<()> {
         let pkey =
             EvpPkey::generate(osslctx(), get_evp_pkey_type_from_obj(pubkey)?)?;
-        let ecc = match pkey.export()? {
+        let mut ecc = match pkey.export()? {
             PkeyData::Ecc(e) => e,
             _ => return Err(CKR_GENERAL_ERROR)?,
         };
 
         /* Set Public Key */
-        if let Some(key) = ecc.pubkey {
+        if let Some(key) = ecc.pubkey.take() {
             pubkey.set_attr(Attribute::from_bytes(CKA_EC_POINT, key))?;
         } else {
             return Err(CKR_DEVICE_ERROR)?;
         }
 
         /* Set Private Key */
-        if let Some(key) = ecc.prikey {
+        if let Some(key) = ecc.prikey.take() {
             privkey.set_attr(Attribute::from_bytes(CKA_VALUE, key))?;
         } else {
             return Err(CKR_DEVICE_ERROR)?;

--- a/src/ossl/ffdh.rs
+++ b/src/ossl/ffdh.rs
@@ -114,13 +114,13 @@ impl FFDHOperation {
     ) -> Result<()> {
         let pkey = EvpPkey::generate(osslctx(), group_to_pkey_type(group)?)?;
 
-        let ffdh = match pkey.export()? {
+        let mut ffdh = match pkey.export()? {
             PkeyData::Ffdh(f) => f,
             _ => return Err(CKR_GENERAL_ERROR)?,
         };
 
         /* Set Public Key */
-        if let Some(key) = ffdh.pubkey {
+        if let Some(key) = ffdh.pubkey.take() {
             pubkey.check_or_set_attr(Attribute::from_bytes(
                 CKA_PRIME,
                 group_prime(group)?,
@@ -132,7 +132,7 @@ impl FFDHOperation {
         }
 
         /* Set Private Key */
-        if let Some(key) = ffdh.prikey {
+        if let Some(key) = ffdh.prikey.take() {
             privkey.check_or_set_attr(Attribute::from_bytes(
                 CKA_PRIME,
                 group_prime(group)?,

--- a/src/ossl/hmac.rs
+++ b/src/ossl/hmac.rs
@@ -12,6 +12,7 @@ use crate::pkcs11::*;
 
 use constant_time_eq::constant_time_eq;
 use ossl::mac::{MacAlg, OsslMac};
+use ossl::OsslSecret;
 
 use ossl::fips::FipsApproval;
 
@@ -59,8 +60,9 @@ impl HMACOperation {
         #[cfg(feature = "fips")]
         let mut fips_approval = FipsApproval::init();
 
-        let ctx =
-            OsslMac::new(osslctx(), hmac_mech_to_mac_alg(mech)?, key.take())?;
+        let secret = OsslSecret::from_vec(key.take());
+
+        let ctx = OsslMac::new(osslctx(), hmac_mech_to_mac_alg(mech)?, secret)?;
 
         #[cfg(feature = "fips")]
         fips_approval.update();

--- a/src/ossl/mldsa.rs
+++ b/src/ossl/mldsa.rs
@@ -770,13 +770,13 @@ pub fn generate_keypair(
 ) -> Result<()> {
     let pkey =
         EvpPkey::generate(osslctx(), mldsa_param_set_to_pkey_type(param_set)?)?;
-    let mlk = match pkey.export()? {
+    let mut mlk = match pkey.export()? {
         PkeyData::Mlkey(m) => m,
         _ => return Err(CKR_GENERAL_ERROR)?,
     };
 
     /* Set Public Key */
-    if let Some(key) = mlk.pubkey {
+    if let Some(key) = mlk.pubkey.take() {
         pubkey.set_attr(Attribute::from_bytes(CKA_VALUE, key))?;
     } else {
         return Err(CKR_DEVICE_ERROR)?;
@@ -786,10 +786,10 @@ pub fn generate_keypair(
     if mlk.prikey.is_none() && mlk.seed.is_none() {
         return Err(CKR_DEVICE_ERROR)?;
     }
-    if let Some(key) = mlk.prikey {
+    if let Some(key) = mlk.prikey.take() {
         privkey.set_attr(Attribute::from_bytes(CKA_VALUE, key))?;
     }
-    if let Some(seed) = mlk.seed {
+    if let Some(seed) = mlk.seed.take() {
         privkey.set_attr(Attribute::from_bytes(CKA_SEED, seed))?;
     }
 

--- a/src/ossl/mlkem.rs
+++ b/src/ossl/mlkem.rs
@@ -117,13 +117,13 @@ pub fn generate_keypair(
     let pkey =
         EvpPkey::generate(osslctx(), mlkem_param_set_to_pkey_type(param_set)?)?;
 
-    let mlk = match pkey.export()? {
+    let mut mlk = match pkey.export()? {
         PkeyData::Mlkey(m) => m,
         _ => return Err(CKR_GENERAL_ERROR)?,
     };
 
     /* Set Public Key */
-    if let Some(key) = mlk.pubkey {
+    if let Some(key) = mlk.pubkey.take() {
         pubkey.set_attr(Attribute::from_bytes(CKA_VALUE, key))?;
     } else {
         return Err(CKR_DEVICE_ERROR)?;
@@ -133,10 +133,10 @@ pub fn generate_keypair(
     if mlk.prikey.is_none() && mlk.seed.is_none() {
         return Err(CKR_DEVICE_ERROR)?;
     }
-    if let Some(key) = mlk.prikey {
+    if let Some(key) = mlk.prikey.take() {
         privkey.set_attr(Attribute::from_bytes(CKA_VALUE, key))?;
     }
-    if let Some(seed) = mlk.seed {
+    if let Some(seed) = mlk.seed.take() {
         privkey.set_attr(Attribute::from_bytes(CKA_SEED, seed))?;
     }
 

--- a/src/ossl/montgomery.rs
+++ b/src/ossl/montgomery.rs
@@ -67,20 +67,20 @@ impl ECMontgomeryOperation {
     ) -> Result<()> {
         let pkey =
             EvpPkey::generate(osslctx(), get_evp_pkey_type_from_obj(pubkey)?)?;
-        let ecc = match pkey.export()? {
+        let mut ecc = match pkey.export()? {
             PkeyData::Ecc(e) => e,
             _ => return Err(CKR_GENERAL_ERROR)?,
         };
 
         /* Set Public Key */
-        if let Some(key) = ecc.pubkey {
+        if let Some(key) = ecc.pubkey.take() {
             pubkey.set_attr(Attribute::from_bytes(CKA_EC_POINT, key))?;
         } else {
             return Err(CKR_DEVICE_ERROR)?;
         }
 
         /* Set Private Key */
-        if let Some(key) = ecc.prikey {
+        if let Some(key) = ecc.prikey.take() {
             privkey.set_attr(Attribute::from_bytes(CKA_VALUE, key))?;
         } else {
             return Err(CKR_DEVICE_ERROR)?;

--- a/src/ossl/rsa.rs
+++ b/src/ossl/rsa.rs
@@ -430,7 +430,7 @@ impl RsaPKCSOperation {
             osslctx(),
             EvpPkeyType::Rsa(bits, exponent.clone()),
         )?;
-        let rsa = match pkey.export()? {
+        let mut rsa = match pkey.export()? {
             PkeyData::Rsa(r) => r,
             _ => return Err(CKR_GENERAL_ERROR)?,
         };
@@ -439,37 +439,37 @@ impl RsaPKCSOperation {
         pubkey.set_attr(Attribute::from_bytes(CKA_MODULUS, rsa.n.clone()))?;
 
         /* Private Key */
-        privkey.set_attr(Attribute::from_bytes(CKA_MODULUS, rsa.n))?;
+        privkey.set_attr(Attribute::from_bytes(CKA_MODULUS, rsa.n.clone()))?;
         privkey.set_attr(Attribute::from_bytes(
             CKA_PUBLIC_EXPONENT,
             exponent.clone(),
         ))?;
-        if let Some(d) = rsa.d {
+        if let Some(d) = rsa.d.take() {
             privkey.set_attr(Attribute::from_bytes(CKA_PRIVATE_EXPONENT, d))?;
         } else {
             return Err(CKR_DEVICE_ERROR)?;
         }
-        if let Some(p) = rsa.p {
+        if let Some(p) = rsa.p.take() {
             privkey.set_attr(Attribute::from_bytes(CKA_PRIME_1, p))?;
         } else {
             return Err(CKR_DEVICE_ERROR)?;
         }
-        if let Some(q) = rsa.q {
+        if let Some(q) = rsa.q.take() {
             privkey.set_attr(Attribute::from_bytes(CKA_PRIME_2, q))?;
         } else {
             return Err(CKR_DEVICE_ERROR)?;
         }
-        if let Some(a) = rsa.a {
+        if let Some(a) = rsa.a.take() {
             privkey.set_attr(Attribute::from_bytes(CKA_EXPONENT_1, a))?;
         } else {
             return Err(CKR_DEVICE_ERROR)?;
         }
-        if let Some(b) = rsa.b {
+        if let Some(b) = rsa.b.take() {
             privkey.set_attr(Attribute::from_bytes(CKA_EXPONENT_2, b))?;
         } else {
             return Err(CKR_DEVICE_ERROR)?;
         }
-        if let Some(c) = rsa.c {
+        if let Some(c) = rsa.c.take() {
             privkey.set_attr(Attribute::from_bytes(CKA_COEFFICIENT, c))?;
         } else {
             return Err(CKR_DEVICE_ERROR)?;


### PR DESCRIPTION
#### Description

Add `Drop` implementations for the `EccData`, `FfdhData`, `MlkeyData`, and `RsaData` structs.

These implementations use `OPENSSL_cleanse` to securely zero out sensitive key material (private keys, seeds, RSA components) when the structs go out of scope. This prevents key data from lingering in memory, reducing the risk of exposure.

Fixes #295 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite already covers this code
- [x] Refactoring
- [ ] ~Rustdoc string were added or updated~
- [ ] ~CHANGELOG and/or other documentation added or updated~
- [ ] ~This is not a code change~

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
