### PR TITLE
Minor rework of dummy integrity check

### DIFF
--- a/dummy.txt
+++ b/dummy.txt
@@ -1,1 +1,0 @@
-Dummy fle to deal with self-test HMAC until infra is ready

--- a/ossl/dummy.txt
+++ b/ossl/dummy.txt
@@ -1,1 +1,0 @@
-Dummy fle to deal with self-test HMAC until infra is ready


### PR DESCRIPTION
#### Description

This is needed to deal with integrity checks during cargo tests, as they can't use the rodata method on test binaries.

This change drops the need for exaternal dummy.txt files and instead creates the check file on the fly at test time.


#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite already covers this area

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
