### PR TITLE
openjdk-integration.yml: Warn on container/source version mismatch

### DIFF
--- a/.github/workflows/openjdk-integration.yml
+++ b/.github/workflows/openjdk-integration.yml
@@ -52,7 +52,7 @@ jobs:
           path: ${{ env.KRYOPTIC_OPENSSL_SOURCES }}
           key: ${{ steps.ossl-setup.outputs.cacheid }}
 
-      - name: Cache Rust dependencies
+      - name: Restore Rust dependencies
         uses: actions/cache/restore@v4
         with:
           path: |
@@ -78,10 +78,28 @@ jobs:
 
       - name: Clone and check out OpenJDK test cases
         run: |
-          git clone --depth 1 \
+          # Clone depth 10 for "git describe".
+          git clone --depth 10 \
             --branch \
-            kryoptic-jdk-${{ steps.get-openjdk-version.outputs.version }} \
+            kryoptic-jdk-${{ env.openjdk_feature }} \
             https://github.com/fitzsim/jdk${{ env.openjdk_feature }}u-dev
+
+      - name: Compare container OpenJDK and test versions
+        run: |
+          CONTAINER_VERSION="${{ steps.get-openjdk-version.outputs.version }}"
+          cd jdk${{ env.openjdk_feature }}u-dev
+          OPENJDK_SOURCE_VERSION=$(git tag --contains $(git describe --abbrev=0) \
+            | head --lines 1 | sed 's/^jdk-//')
+          echo OpenJDK test cases are based on "${OPENJDK_SOURCE_VERSION}"
+          cd ..
+          if test "${CONTAINER_VERSION}" != "${OPENJDK_SOURCE_VERSION}"
+          then
+              echo Warning: container/tests version mismatch:
+              echo "container: ${CONTAINER_VERSION}"
+              echo "source:    ${OPENJDK_SOURCE_VERSION}"
+              BRANCH=kryoptic-jdk-${{ env.openjdk_feature }}
+              echo Please rebase "${BRANCH}" branch on jdk-${CONTAINER_VERSION}
+          fi
 
       # Get pkcs11-provider for kryoptic.nss-init.sh used by jtreg-kryoptic.sh.
       - name: Get pkcs11-provider


### PR DESCRIPTION
#### Description

The `Fedora` container recently updated `java-21-openjdk` from `21.0.7+6` to `21.0.8+9`.

The `OpenJDK` integration tests need to be kept up-to-date, so that the test cases being checked out are from the same version as the `OpenJDK`-version-under-test.

Instead of encoding this information in the `jdk` branch name, which will cause build breakages when the container is updated, this change adds a comparison step that warns of a mismatch.

Here is example output from the new `Compare container OpenJDK and test versions` step:

```
Run CONTAINER_VERSION="21.0.8+9"
OpenJDK test cases are based on 21.0.7+6
Warning: container/tests version mismatch:
container: 21.0.8+9
source:    21.0.7+6
Please rebase kryoptic-jdk-21 branch on jdk-21.0.8+9
```

I have rebased the `kryoptic-jdk-21` branch on `jdk-21.0.8+9` now, so the build will be fixed and will not warn of a version mismatch, once this pull request is merged.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] ~Test suite updated with functionality tests~
- [ ] ~Test suite updated with negative tests~
- [ ] ~Rustdoc string were added or updated~
- [ ] ~CHANGELOG and/or other documentation added or updated~
- [X] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible text
- [ ] Doc string are properly updated
