### PR TITLE
Add jtreg-kryoptic.sh OpenJDK test script

### DIFF
--- a/.github/workflows/openjdk-integration.yml
+++ b/.github/workflows/openjdk-integration.yml
@@ -1,11 +1,10 @@
 ---
 name: OpenJDK Integration Tests
 
+# Run OpenJDK tests listed in testdata/openjdk/openjdk-jtreg-tests.txt.
+
 env:
   OPENSSL_BRANCH: kryoptic_ossl35
-  # List of OpenJDK tests to run, under openjdk/test/jdk/sun/security/pkcs11/.
-  openjdk_tests: |
-    Cipher/EncryptionPadding.java
   jtreg_version: 7.5.2+1
   openjdk_feature: 21
 
@@ -78,20 +77,23 @@ jobs:
 
       - name: Clone and check out OpenJDK test cases
         run: |
+          mkdir -p testdata/openjdk/deps
+          cd testdata/openjdk/deps
           # Clone depth 10 for "git describe".
           git clone --depth 10 \
             --branch \
             kryoptic-jdk-${{ env.openjdk_feature }} \
             https://github.com/fitzsim/jdk${{ env.openjdk_feature }}u-dev
+          cd ../../..
 
       - name: Compare container OpenJDK and test versions
         run: |
           CONTAINER_VERSION="${{ steps.get-openjdk-version.outputs.version }}"
-          cd jdk${{ env.openjdk_feature }}u-dev
+          cd testdata/openjdk/deps/jdk${{ env.openjdk_feature }}u-dev
           OPENJDK_SOURCE_VERSION=$(git tag --contains $(git describe --abbrev=0) \
             | head --lines 1 | sed 's/^jdk-//')
           echo OpenJDK test cases are based on "${OPENJDK_SOURCE_VERSION}"
-          cd ..
+          cd ../../../..
           if test "${CONTAINER_VERSION}" != "${OPENJDK_SOURCE_VERSION}"
           then
               echo Warning: container/tests version mismatch:
@@ -104,7 +106,11 @@ jobs:
       # Get pkcs11-provider for kryoptic.nss-init.sh used by jtreg-kryoptic.sh.
       - name: Get pkcs11-provider
         id: get-pkcs11-provider
-        run: git clone https://github.com/latchset/pkcs11-provider.git
+        run: |
+          mkdir -p testdata/openjdk/deps
+          cd testdata/openjdk/deps
+          git clone https://github.com/latchset/pkcs11-provider.git
+          cd ../../..
 
       # JTReg archive.
       - name: Restore JTReg binary from cache
@@ -131,11 +137,15 @@ jobs:
       # Extract JTReg.
       - name: Extract JTReg binary
         id: extract-jtreg-binary
-        run: unzip jtreg-*.zip && chmod +x jtreg/bin/jtreg
+        run: |
+          mkdir -p testdata/openjdk/deps
+          cd testdata/openjdk/deps
+          unzip ../../../jtreg-${{ env.jtreg_version }}.zip
+          chmod +x jtreg/bin/jtreg
+          cd ../../..
 
       # Run test suite.
       - name: Run OpenJDK JTReg test cases
         id: run-openjdk-jtreg-test-cases
         run: |
-          bash jdk${{ env.openjdk_feature }}u-dev/bin/jtreg-kryoptic.sh \
-            $openjdk_tests
+          testdata/openjdk/jtreg-kryoptic.sh check-jtreg

--- a/testdata/openjdk/jtreg-kryoptic.sh
+++ b/testdata/openjdk/jtreg-kryoptic.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+if test "$1" != "check-jtreg"
+then
+    echo "Usage: $(basename "$0") check-jtreg"
+    exit 1
+fi
+
+set -o errexit
+set -o xtrace
+
+KRYOPTIC="$(realpath "$(dirname "$0")"/../..)"
+export KRYOPTIC
+
+OPENJDK="${KRYOPTIC}"/testdata/openjdk
+
+get_variable_from_yaml() {
+    grep "  $1: " "${KRYOPTIC}"/.github/workflows/openjdk-integration.yml \
+        | sed "s/  $1: //"
+}
+jtreg_version=$(get_variable_from_yaml jtreg_version)
+openjdk_feature=$(get_variable_from_yaml openjdk_feature)
+
+# Download dependencies.
+if test -z "${PKCS11_PROVIDER}"
+then
+    if ! test -d "${OPENJDK}"/deps/pkcs11-provider
+    then
+        mkdir -p "${OPENJDK}"/deps
+        pushd "${OPENJDK}"/deps
+        git clone https://github.com/latchset/pkcs11-provider.git
+        popd
+    fi
+    export PKCS11_PROVIDER="${OPENJDK}"/deps/pkcs11-provider
+fi
+if test -z "${JDK}"
+then
+    if ! test -d "${OPENJDK}"/deps/jdk"${openjdk_feature}"u-dev
+    then
+        mkdir -p "${OPENJDK}"/deps
+        pushd "${OPENJDK}"/deps
+        git clone --depth 10 --branch kryoptic-jdk-"${openjdk_feature}" \
+            https://github.com/fitzsim/jdk"${openjdk_feature}"u-dev
+        popd
+    fi
+    export JDK="${OPENJDK}"/deps/jdk"${openjdk_feature}"u-dev
+fi
+if test -z "${JTREG}"
+then
+    if ! test -d "${OPENJDK}"/deps/jtreg
+    then
+        mkdir -p "${OPENJDK}"/deps
+        pushd "${OPENJDK}"/deps
+        wget --no-verbose \
+             https://builds.shipilev.net/jtreg/jtreg-"${jtreg_version}".zip
+        unzip jtreg-"${jtreg_version}".zip
+        chmod +x jtreg/bin/jtreg
+        popd
+    fi
+    export JTREG="${OPENJDK}"/deps/jtreg
+fi
+
+# Initialize Kryoptic token.
+export TESTSSRCDIR="${PKCS11_PROVIDER}"/tests
+# Note intentional extra "P" in "TMPPDIR".
+export TMPPDIR="${OPENJDK}"/conf
+export TOKDIR="${TMPPDIR}/db"
+export PINVALUE="fo0m4nchU"
+mkdir --parents "${TOKDIR}"
+title() { echo "$@"; }
+# Needed so that kryoptic.nss-init.sh can be rerun without error.
+rm --force "${TOKDIR}"/cert9.db
+# Clean up other files too.
+rm --force "${TOKDIR}"/key4.db \
+   "${TOKDIR}"/kryoptic.conf \
+   "${TMPPDIR}"/kryoptic.conf \
+   "${TMPPDIR}"/libkryoptic_pkcs11.so
+source "${TESTSSRCDIR}"/kryoptic.nss-init.sh
+# Remove superfluous configuration file created by kryoptic-init.sh
+# when it is called from kryoptic.nss-init.sh (which creates its own
+# configuration file, "${TMPPDIR}"/kryoptic.conf).
+rm --force "${TOKDIR}"/kryoptic.conf
+
+# PKCS11Test.java does a depth-first search for the first file with
+# this name under jdk.test.lib.artifacts.nsslib-linux_x64.  It finds
+# kryoptic/target/debug/deps/libkryoptic_pkcs11.so.  This fails with:
+#
+# |thread '<unnamed>' panicked at ossl/src/fips.rs:706:5:
+# |assertion failed: ret == 1
+# |note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+# |fatal runtime error: failed to initiate panic, error 5
+#
+# because hmacify.sh is only run on kryoptic/target/debug/libkryoptic_pkcs11.so.
+#
+# To protect against this, copy libkryoptic_pkcs11.so to
+# kryoptic-configuration and point
+# jdk.test.lib.artifacts.nsslib-linux_x64 there.
+cp "${P11LIB}" "${TMPPDIR}"
+
+NATIVE_DEBUGGER=${NATIVE_DEBUGGER:-}
+export JAVA_HOME=${JAVA_HOME:-/usr/lib/jvm/java-"${openjdk_feature}"-openjdk}
+JAVA_RUNNER=${JAVA_RUNNER:-java}
+pushd "${JDK}"
+${NATIVE_DEBUGGER} "${JAVA_HOME}"/bin/"${JAVA_RUNNER}" \
+    -Dprogram=jtreg \
+    -jar "${JTREG}"/lib/jtreg.jar \
+    -verbose:fail,error \
+    -javaoption:-DCUSTOM_P11_CONFIG="${OPENJDK}"/p11-kryoptic.txt \
+    -javaoption:-DCUSTOM_P11_LIBRARY_NAME=kryoptic_pkcs11 \
+    -javaoption:-Djdk.test.lib.artifacts.nsslib-linux_x64="${TMPPDIR}" \
+    -javaoption:-DCUSTOM_DB_DIR="${TMPPDIR}" \
+    -testjdk:"${JAVA_HOME}" \
+    -javacoption:-g \
+    @"${OPENJDK}"/openjdk-jtreg-tests.txt
+popd
+
+# Local Variables:
+# compile-command: "shellcheck --external-sources $(pwd)/jtreg-kryoptic.sh"
+# fill-column: 80
+# End:

--- a/testdata/openjdk/openjdk-jtreg-tests.txt
+++ b/testdata/openjdk/openjdk-jtreg-tests.txt
@@ -1,0 +1,23 @@
+# Successful FIPS tests.
+test/jdk/sun/security/pkcs11/Cipher/KeyWrap/XMLEncKAT.java
+test/jdk/sun/security/pkcs11/Cipher/Test4512704.java
+test/jdk/sun/security/pkcs11/Cipher/TestCICOWithGCM.java
+test/jdk/sun/security/pkcs11/Cipher/TestCICOWithGCMAndAAD.java
+test/jdk/sun/security/pkcs11/Cipher/TestGCMKeyAndIvCheck.java
+test/jdk/sun/security/pkcs11/Cipher/TestKATForGCM.java
+test/jdk/sun/security/pkcs11/Cipher/TestPaddingOOB.java
+test/jdk/sun/security/pkcs11/KeyAgreement/UnsupportedDHKeys.java
+test/jdk/sun/security/pkcs11/KeyGenerator/HmacDefKeySizeTest.java
+test/jdk/sun/security/pkcs11/KeyGenerator/TestAES.java
+test/jdk/sun/security/pkcs11/MessageDigest/ByteBuffers.java
+test/jdk/sun/security/pkcs11/Provider/Absolute.java
+test/jdk/sun/security/pkcs11/Provider/CheckRegistration.java
+test/jdk/sun/security/pkcs11/Provider/ConfigShortPath.java
+test/jdk/sun/security/pkcs11/Provider/LoginISE.java
+test/jdk/sun/security/pkcs11/SampleTest.java
+test/jdk/sun/security/pkcs11/Signature/ByteBuffers.java
+test/jdk/sun/security/pkcs11/Signature/InitAgainPSS.java
+test/jdk/sun/security/pkcs11/ec/TestECDH.java
+test/jdk/sun/security/pkcs11/ec/TestECDH2.java
+test/jdk/sun/security/pkcs11/ec/TestECDSA2.java
+test/jdk/sun/security/pkcs11/ec/TestECGenSpec.java

--- a/testdata/openjdk/p11-kryoptic-sensitive.txt
+++ b/testdata/openjdk/p11-kryoptic-sensitive.txt
@@ -1,0 +1,34 @@
+name = Kryoptic
+slot = 42
+showInfo = true
+library = ${pkcs11test.nss.lib}
+nssArgs = "kryoptic_conf=${pkcs11test.nss.db}/kryoptic.conf"
+disabledMechanisms = {
+  CKM_DSA_SHA224
+  CKM_DSA_SHA256
+  CKM_DSA_SHA384
+  CKM_DSA_SHA512
+  CKM_DSA_SHA3_224
+  CKM_DSA_SHA3_256
+  CKM_DSA_SHA3_384
+  CKM_DSA_SHA3_512
+  CKM_ECDSA_SHA224
+  CKM_ECDSA_SHA256
+  CKM_ECDSA_SHA384
+  CKM_ECDSA_SHA512
+  CKM_ECDSA_SHA3_224
+  CKM_ECDSA_SHA3_256
+  CKM_ECDSA_SHA3_384
+  CKM_ECDSA_SHA3_512
+}
+attributes = compatibility
+attributes(*,CKO_SECRET_KEY,*) = {
+  CKA_EXTRACTABLE = true
+  CKA_SENSITIVE = true
+  CKA_ENCRYPT = true
+}
+attributes(*,CKO_PRIVATE_KEY,*) = {
+  CKA_EXTRACTABLE = true
+  CKA_SENSITIVE = true
+  CKA_SIGN = true
+}

--- a/testdata/openjdk/p11-kryoptic.txt
+++ b/testdata/openjdk/p11-kryoptic.txt
@@ -1,0 +1,34 @@
+name = Kryoptic
+slot = 42
+showInfo = true
+library = ${pkcs11test.nss.lib}
+nssArgs = "kryoptic_conf=${pkcs11test.nss.db}/kryoptic.conf"
+disabledMechanisms = {
+  CKM_DSA_SHA224
+  CKM_DSA_SHA256
+  CKM_DSA_SHA384
+  CKM_DSA_SHA512
+  CKM_DSA_SHA3_224
+  CKM_DSA_SHA3_256
+  CKM_DSA_SHA3_384
+  CKM_DSA_SHA3_512
+  CKM_ECDSA_SHA224
+  CKM_ECDSA_SHA256
+  CKM_ECDSA_SHA384
+  CKM_ECDSA_SHA512
+  CKM_ECDSA_SHA3_224
+  CKM_ECDSA_SHA3_256
+  CKM_ECDSA_SHA3_384
+  CKM_ECDSA_SHA3_512
+}
+attributes = compatibility
+attributes(*,CKO_SECRET_KEY,*) = {
+  CKA_EXTRACTABLE = true
+  CKA_SENSITIVE = false
+  CKA_ENCRYPT = true
+}
+attributes(*,CKO_PRIVATE_KEY,*) = {
+  CKA_EXTRACTABLE = true
+  CKA_SENSITIVE = false
+  CKA_SIGN = true
+}


### PR DESCRIPTION
#### Description

Add `p11-kryoptic.txt` and `p11-kryoptic-sensitive.txt` `OpenJDK` configuration files and `openjdk-jtreg-tests.txt`, used by `jtreg-kryoptic.sh`.

Modify `openjdk-integration.yml` to accommodate default dependency locations expected by `jtreg-kryoptic.sh`.

Also change the set of tests to the subset of `PKCS11Test.java` tests that pass on my `CentOS` `9` `NSS` `FIPS` system, and that also pass on current `Kryoptic`.

`jtreg-kryoptic.sh` can now be run outside of the `.yml` file:

```
$ testdata/openjdk/jtreg-kryoptic.sh check-jtreg
```

I think it makes sense for this script and its associated configuration files to live in `Kryoptic`.  I can still maintain them via pull requests if the continuous integration job fails.  And I plan to add more test cases as they are made to work.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] ~Test suite updated with functionality tests~
- [ ] ~Test suite updated with negative tests~
- [ ] ~Rustdoc string were added or updated~
- [ ] ~CHANGELOG and/or other documentation added or updated~
- [x] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
