### PR TITLE
Add support for OCB, OsslCipher::block_size, and RSA helpers for implementations of RFC9580

### DIFF
--- a/ossl/Cargo.toml
+++ b/ossl/Cargo.toml
@@ -33,3 +33,4 @@ dynamic = [] # Builds against system libcrypto.so
 fips = ["ossl350"] # Builds against sources and libfips.a instead of libcrypto
 log = ["dep:log", "dep:vsprintf"] # Error tracing using log crate
 dummy-integrity = [] # USE ONLY for testing as a dev-depenency
+rfc9580 = [] # Enables features required for OpenPGP implementations

--- a/ossl/src/cipher.rs
+++ b/ossl/src/cipher.rs
@@ -230,7 +230,8 @@ pub struct OsslCipher {
     aad: Option<Vec<u8>>,
     /// The block size used in this operation. It is used to
     /// calculate the minimum acceptable output buffer size in
-    /// update operations. This is 1 for streaming ciphers.
+    /// update operations. This is 1 for streaming ciphers and
+    /// AEAD constructions
     blocksize: usize,
 }
 
@@ -380,14 +381,14 @@ impl OsslCipher {
                     }
                 }
             }
-            None => (),
+            None => {
+                ctx.blocksize = unsafe {
+                    usize::try_from(EVP_CIPHER_CTX_get_block_size(
+                        ctx.ctx.as_mut_ptr(),
+                    ))?
+                };
+            }
         }
-
-        ctx.blocksize = unsafe {
-            usize::try_from(EVP_CIPHER_CTX_get_block_size(
-                ctx.ctx.as_mut_ptr(),
-            ))?
-        };
 
         Ok(ctx)
     }

--- a/ossl/src/cipher.rs
+++ b/ossl/src/cipher.rs
@@ -114,6 +114,7 @@ pub enum EncAlg {
     AesCfb8(AesSize),
     AesCfb1(AesSize),
     AesCfb128(AesSize),
+    AesOcb(AesSize),
     AesOfb(AesSize),
     AesWrap(AesSize),
     AesWrapPad(AesSize),
@@ -166,6 +167,11 @@ fn cipher_to_name(alg: EncAlg) -> &'static CStr {
             AesSize::Aes128 => cstr!(LN_aes_128_cfb128),
             AesSize::Aes192 => cstr!(LN_aes_192_cfb128),
             AesSize::Aes256 => cstr!(LN_aes_256_cfb128),
+        },
+        EncAlg::AesOcb(size) => match size {
+            AesSize::Aes128 => cstr!(LN_aes_128_ocb),
+            AesSize::Aes192 => cstr!(LN_aes_192_ocb),
+            AesSize::Aes256 => cstr!(LN_aes_256_ocb),
         },
         EncAlg::AesOfb(size) => match size {
             AesSize::Aes128 => cstr!(LN_aes_128_ofb128),
@@ -273,7 +279,7 @@ impl OsslCipher {
         /* For some modes there is setup that needs to be done
          * early, before the cipher ctx is fully initialized */
         match alg {
-            EncAlg::AesCcm(_) | EncAlg::AesGcm(_) => {
+            EncAlg::AesCcm(_) | EncAlg::AesGcm(_) | EncAlg::AesOcb(_) => {
                 ctx.aead_setup(alg, &aead)?
             }
             EncAlg::AesCts(_, mode) => {

--- a/ossl/src/cipher.rs
+++ b/ossl/src/cipher.rs
@@ -572,6 +572,16 @@ impl OsslCipher {
         Ok(())
     }
 
+    /// Returns the block size, or `None` for stream ciphers and AEAD
+    /// constructions.
+    pub fn block_size(&self) -> Option<usize> {
+        if self.blocksize == 1 {
+            None
+        } else {
+            Some(self.blocksize)
+        }
+    }
+
     pub fn buffer_size(&self, input: usize) -> usize {
         if self.blocksize == 1 {
             return input;

--- a/ossl/src/lib.rs
+++ b/ossl/src/lib.rs
@@ -245,6 +245,19 @@ impl BigNum {
     pub fn as_mut_ptr(&mut self) -> *mut BIGNUM {
         self.bn
     }
+
+    /// Allocates a new BIGNUM.
+    pub fn new() -> Result<BigNum, Error> {
+        let bn = unsafe { BN_secure_new() };
+
+        if bn.is_null() {
+            trace_ossl!("BN_secure_new()");
+            Err(Error::new(ErrorKind::NullPtr))
+        } else {
+            Ok(BigNum { bn })
+        }
+    }
+
     /// Allocates a new BIGNUM from a slice of bytes with the binary
     /// representation of the number in big endian byte order (most
     /// significant byte first).

--- a/ossl/src/lib.rs
+++ b/ossl/src/lib.rs
@@ -264,18 +264,21 @@ impl BigNum {
     ///
     /// Returns a wrapped `BigNum` or an error if the import fails.
     pub fn from_bigendian_slice(v: &[u8]) -> Result<BigNum, Error> {
-        let bn = unsafe {
+        let mut bn = BigNum::new()?;
+
+        let ret = unsafe {
             BN_bin2bn(
                 v.as_ptr() as *mut u8,
                 c_int::try_from(v.len())?,
-                std::ptr::null_mut(),
+                bn.as_mut_ptr(),
             )
         };
-        if bn.is_null() {
+        if ret.is_null() {
             trace_ossl!("BN_bin2bn()");
             return Err(Error::new(ErrorKind::NullPtr));
         }
-        Ok(BigNum { bn })
+
+        Ok(bn)
     }
 
     /// Calculates the minimum number of bytes needed to represent the `BIGNUM`.


### PR DESCRIPTION
#### Description

This patch series adds functionality required to port Sequoia PGP to ossl.  First, we add support for OCB, which is the MTI AEAD mode of RFC9580.  Second, we tweak ossl's notion of block size so that AEAD constructions are treated the same way as stream ciphers by `OsslCipher::buffer_size`, and we expose the block size as `OsslCipher::block_size`.  Third, we add some helper functions to load and store RSA keys using the OpenPGP wire format.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [x] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
