### PR TITLE
Ossl: Ensure libctx is freed on drop

### DIFF
--- a/.github/workflows/pkcs11-provider.yml
+++ b/.github/workflows/pkcs11-provider.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     name: Integration test with pkcs11-provider
     runs-on: ubuntu-22.04
-    container: fedora:latest
+    container: fedora:rawhide
     steps:
       - name: Get Date for DNF cache entry
         id: get-date
@@ -53,8 +53,8 @@ jobs:
 
       - name: Build & test
         run: |
-          cargo build --no-default-features --features dynamic,standard,nssdb
-          cargo test --no-default-features --features dynamic,standard,nssdb | tee testout.log 2>&1
+          cargo build --no-default-features --features dynamic,standard,nssdb,pqc
+          cargo test --no-default-features --features dynamic,standard,nssdb,pqc | tee testout.log 2>&1
           grep -q "0 failed" testout.log
 
       - name: Get pkcs11-provider

--- a/ossl/src/lib.rs
+++ b/ossl/src/lib.rs
@@ -224,6 +224,14 @@ impl OsslContext {
     }
 }
 
+impl Drop for OsslContext {
+    fn drop(&mut self) {
+        unsafe {
+            OSSL_LIB_CTX_free(self.context);
+        }
+    }
+}
+
 unsafe impl Send for OsslContext {}
 unsafe impl Sync for OsslContext {}
 


### PR DESCRIPTION
#### Description

As pointed out in #311 we do not free the Context on drop.
When this code was embedded in kryoptic this was not really necessary as Kryoptic uses a single global context in a lazyly initialized static variable.

But now Ossl exposes the ability to create as many as you want, so they need to be freed on drop.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
