### PR TITLE
Do not allow setting never-settable attributes (+avoid new warnings caused by new Rust version)

### DIFF
--- a/ossl/src/asymcipher.rs
+++ b/ossl/src/asymcipher.rs
@@ -28,7 +28,7 @@ pub struct RsaOaepParams {
 pub fn rsa_enc_params(
     alg: EncAlg,
     oaep_params: Option<&RsaOaepParams>,
-) -> Result<OsslParam, Error> {
+) -> Result<OsslParam<'_>, Error> {
     let mut params_builder = crate::OsslParamBuilder::new();
 
     match alg {

--- a/ossl/src/fips.rs
+++ b/ossl/src/fips.rs
@@ -340,7 +340,7 @@ struct MemBio<'a> {
 }
 
 impl MemBio<'_> {
-    fn new(v: &mut [u8]) -> MemBio {
+    fn new(v: &mut [u8]) -> MemBio<'_> {
         MemBio { mem: v, cursor: 0 }
     }
 

--- a/ossl/src/pkey.rs
+++ b/ossl/src/pkey.rs
@@ -844,7 +844,7 @@ impl EvpPkey {
     ///
     /// The `selection` argument specifies which components to export
     /// (e.g., public, private, parameters).
-    fn export_params(&self, selection: u32) -> Result<OsslParam, Error> {
+    fn export_params(&self, selection: u32) -> Result<OsslParam<'_>, Error> {
         let mut params_builder = OsslParamBuilder::new();
         params_builder.zeroize = true;
         let ret = unsafe {

--- a/ossl/src/signature.rs
+++ b/ossl/src/signature.rs
@@ -300,7 +300,7 @@ pub struct RsaPssParams {
 pub fn rsa_sig_params(
     alg: SigAlg,
     pss_params: &Option<RsaPssParams>,
-) -> Result<Option<OsslParam>, Error> {
+) -> Result<Option<OsslParam<'_>>, Error> {
     match alg {
         SigAlg::RsaNoPad => {
             let mut params_builder = OsslParamBuilder::new();

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -462,6 +462,7 @@ impl Attribute {
     }
 
     /// Constructs an attribute passing in the value as a slice
+    #[cfg(feature = "nssdb")]
     pub fn from_attr_slice(
         id: CK_ULONG,
         at: AttrType,

--- a/src/kasn1/mod.rs
+++ b/src/kasn1/mod.rs
@@ -207,7 +207,7 @@ impl PrivateKeyInfo<'_> {
     }
 
     /// Returns the key type (as an OID)
-    pub fn get_algorithm(&self) -> &pkcs::AlgorithmIdentifier {
+    pub fn get_algorithm(&self) -> &pkcs::AlgorithmIdentifier<'_> {
         &self.algorithm
     }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -850,6 +850,9 @@ pub trait ObjectFactory: Debug + Send + Sync {
             match attrs.iter().find(|a| a.get_type() == ck_attr.type_) {
                 None => return Err(CKR_ATTRIBUTE_TYPE_INVALID)?,
                 Some(attr) => {
+                    if attr.is(OAFlags::NeverSettable) {
+                        return Err(CKR_ACTION_PROHIBITED)?;
+                    }
                     if attr.is(OAFlags::Unchangeable) {
                         if attr.attribute.get_attrtype() == AttrType::BoolType {
                             let val = ck_attr.to_bool()?;

--- a/src/storage/nssdb/ci.rs
+++ b/src/storage/nssdb/ci.rs
@@ -128,7 +128,7 @@ impl KeysWithCaching {
     ///
     /// Returns `None` if the master key is not set (user not authenticated) or
     /// if the lock cannot be acquired.
-    fn get_cached_key(&self, id: &[u8; SHA256_LEN]) -> Option<LockedKey> {
+    fn get_cached_key(&self, id: &[u8; SHA256_LEN]) -> Option<LockedKey<'_>> {
         if self.enckey.is_none() {
             /* access to the cache is available only if enckey is set.
              * When unset it means the user logged off and no

--- a/src/tests/attrs.rs
+++ b/src/tests/attrs.rs
@@ -204,7 +204,22 @@ fn test_set_attr_rsa() {
         template.as_ptr() as *mut _,
         1,
     );
-    assert_eq!(ret, CKR_ATTRIBUTE_READ_ONLY);
+    assert_eq!(ret, CKR_ACTION_PROHIBITED);
+
+    let flag: CK_ULONG = 0x03;
+    let template = make_ptrs_template(&[(
+        CKA_OBJECT_VALIDATION_FLAGS,
+        void_ptr!(std::ptr::addr_of!(flag)),
+        std::mem::size_of::<CK_ULONG>(),
+    )]);
+
+    let ret = fn_set_attribute_value(
+        session2,
+        handle,
+        template.as_ptr() as *mut _,
+        1,
+    );
+    assert_eq!(ret, CKR_ACTION_PROHIBITED);
 
     let ret = fn_close_session(session2);
     assert_eq!(ret, CKR_OK);

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -10,7 +10,7 @@ use crate::tests::*;
 use serial_test::{parallel, serial};
 
 #[cfg(feature = "sqlitedb")]
-fn test_token_setup(name: &str) -> TestToken {
+fn test_token_setup(name: &str) -> TestToken<'_> {
     let mut testtokn = TestToken::new(String::from(name));
     testtokn.setup_db(None);
     testtokn


### PR DESCRIPTION
The never settable attribute was not handled and did allow changing attributes that were never settable (even the OBJECT_VALIDATION, even though it is ephemeral).

~~~~
Additionally the Rust was updated showing new warnings:

```
warning: hiding a lifetime that's elided elsewhere is confusing
  --> ossl/src/asymcipher.rs:30:25
   |
30 |     oaep_params: Option<&RsaOaepParams>,
   |                         ^^^^^^^^^^^^^^ the lifetime is elided here
31 | ) -> Result<OsslParam, Error> {
   |             --------- the same lifetime is hidden here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
31 | ) -> Result<OsslParam<'_>, Error> {
   |                      ++++
```
and similar.

It also turns out the `from_attr_slice` is used only from the nssdb:

```
warning: associated function `from_attr_slice` is never used
   --> src/attribute.rs:465:12
    |
295 | impl Attribute {
    | -------------- associated function in this implementation
...
465 |     pub fn from_attr_slice(
    |            ^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default
```

#### Description

<!--  The description should give a general overview of the goal of the PR.

Individual commit message should highlight important changes that people may
want to know about when looking at the commit years later
-->

#### Checklist

~- [ ] Test suite updated with functionality tests~
~- [ ] Test suite updated with negative tests~
~- [ ] Rustdoc string were added or updated~
~- [ ] CHANGELOG and/or other documentation added or updated~
~- [ ] This is not a code change~

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
