### PR TITLE
ossl: Allow passing propq to the key creation API

### DIFF
--- a/ossl/src/tests/brainpool.rs
+++ b/ossl/src/tests/brainpool.rs
@@ -43,11 +43,12 @@ fn do_ecdh_test(
             pubkey: None,
             prikey: Some(OsslSecret::from_slice(&da)),
         }),
+        None,
     )
     .unwrap();
 
     let mut peer_b = key_a
-        .make_peer(test_ossl_context(), &pub_b_uncompressed)
+        .make_peer(test_ossl_context(), &pub_b_uncompressed, None)
         .unwrap();
     let mut ecdh_a = EcdhDerive::new(test_ossl_context(), &mut key_a).unwrap();
     let mut shared_secret_a = vec![0u8; expected_z.len()];
@@ -64,11 +65,12 @@ fn do_ecdh_test(
             pubkey: None,
             prikey: Some(OsslSecret::from_slice(&db)),
         }),
+        None,
     )
     .unwrap();
 
     let mut peer_a = key_b
-        .make_peer(test_ossl_context(), &pub_a_uncompressed)
+        .make_peer(test_ossl_context(), &pub_a_uncompressed, None)
         .unwrap();
     let mut ecdh_b = EcdhDerive::new(test_ossl_context(), &mut key_b).unwrap();
     let mut shared_secret_b = vec![0u8; expected_z.len()];
@@ -192,9 +194,12 @@ use crate::signature::{OsslSignature, SigAlg, SigOp};
 #[parallel]
 fn test_brainpool_p256r1_signature() {
     // Generate a key pair
-    let mut key =
-        EvpPkey::generate(test_ossl_context(), EvpPkeyType::BrainpoolP256r1)
-            .unwrap();
+    let mut key = EvpPkey::generate(
+        test_ossl_context(),
+        EvpPkeyType::BrainpoolP256r1,
+        None,
+    )
+    .unwrap();
 
     // Sample data to sign. Use ECDSA without a pre-computed digest.
     let data = b"some sample data to sign";

--- a/src/ossl/ecdh.rs
+++ b/src/ossl/ecdh.rs
@@ -187,7 +187,7 @@ impl Derive for ECDHOperation {
 
         let mut secret = vec![0u8; raw_max];
         let outlen = ecdh.derive(
-            &mut pkey.make_peer(osslctx(), &ec_point)?,
+            &mut pkey.make_peer(osslctx(), &ec_point, None)?,
             secret.as_mut_slice(),
         )?;
         secret.resize(outlen, 0);

--- a/src/ossl/ecdsa.rs
+++ b/src/ossl/ecdsa.rs
@@ -40,6 +40,7 @@ pub fn ecc_object_to_pkey(
                 pubkey: Some(get_ec_point_from_obj(key)?),
                 prikey: None,
             }),
+            None,
         )?),
         CKO_PRIVATE_KEY => Ok(EvpPkey::import(
             osslctx(),
@@ -50,6 +51,7 @@ pub fn ecc_object_to_pkey(
                     key.get_attr_as_bytes(CKA_VALUE)?.clone(),
                 )),
             }),
+            None,
         )?),
         _ => Err(CKR_KEY_TYPE_INCONSISTENT)?,
     }
@@ -242,8 +244,11 @@ impl EcdsaOperation {
         pubkey: &mut Object,
         privkey: &mut Object,
     ) -> Result<()> {
-        let pkey =
-            EvpPkey::generate(osslctx(), get_evp_pkey_type_from_obj(pubkey)?)?;
+        let pkey = EvpPkey::generate(
+            osslctx(),
+            get_evp_pkey_type_from_obj(pubkey)?,
+            None,
+        )?;
         let mut ecc = match pkey.export()? {
             PkeyData::Ecc(e) => e,
             _ => return Err(CKR_GENERAL_ERROR)?,

--- a/src/ossl/eddsa.rs
+++ b/src/ossl/eddsa.rs
@@ -86,6 +86,7 @@ pub fn eddsa_object_to_pkey(
                 pubkey: Some(get_ec_point_from_obj(key)?),
                 prikey: None,
             }),
+            None,
         )?),
         CKO_PRIVATE_KEY => Ok(EvpPkey::import(
             osslctx(),
@@ -96,6 +97,7 @@ pub fn eddsa_object_to_pkey(
                     key.get_attr_as_bytes(CKA_VALUE)?.to_vec(),
                 )),
             }),
+            None,
         )?),
         _ => Err(CKR_KEY_TYPE_INCONSISTENT)?,
     }
@@ -201,8 +203,11 @@ impl EddsaOperation {
         pubkey: &mut Object,
         privkey: &mut Object,
     ) -> Result<()> {
-        let pkey =
-            EvpPkey::generate(osslctx(), get_evp_pkey_type_from_obj(pubkey)?)?;
+        let pkey = EvpPkey::generate(
+            osslctx(),
+            get_evp_pkey_type_from_obj(pubkey)?,
+            None,
+        )?;
         let mut ecc = match pkey.export()? {
             PkeyData::Ecc(e) => e,
             _ => return Err(CKR_GENERAL_ERROR)?,

--- a/src/ossl/ffdh.rs
+++ b/src/ossl/ffdh.rs
@@ -61,6 +61,7 @@ pub fn ffdh_object_to_pkey(
                 pubkey: Some(key.get_attr_as_bytes(CKA_VALUE)?.clone()),
                 prikey: None,
             }),
+            None,
         )?),
         CKO_PRIVATE_KEY => Ok(EvpPkey::import(
             osslctx(),
@@ -71,6 +72,7 @@ pub fn ffdh_object_to_pkey(
                     key.get_attr_as_bytes(CKA_VALUE)?.clone(),
                 )),
             }),
+            None,
         )?),
         _ => Err(CKR_KEY_TYPE_INCONSISTENT)?,
     }
@@ -114,7 +116,8 @@ impl FFDHOperation {
         pubkey: &mut Object,
         privkey: &mut Object,
     ) -> Result<()> {
-        let pkey = EvpPkey::generate(osslctx(), group_to_pkey_type(group)?)?;
+        let pkey =
+            EvpPkey::generate(osslctx(), group_to_pkey_type(group)?, None)?;
 
         let mut ffdh = match pkey.export()? {
             PkeyData::Ffdh(f) => f,
@@ -179,7 +182,8 @@ impl Derive for FFDHOperation {
             objectfactories.get_obj_factory_from_key_template(template)?;
 
         let mut pkey = privkey_from_object(key)?;
-        let mut peer = pkey.make_peer(osslctx(), self.public.as_slice())?;
+        let mut peer =
+            pkey.make_peer(osslctx(), self.public.as_slice(), None)?;
         let mut ffdh = FfdhDerive::new(osslctx(), &mut pkey)?;
 
         let pkey_size = pkey.get_size()?;

--- a/src/ossl/mldsa.rs
+++ b/src/ossl/mldsa.rs
@@ -90,6 +90,7 @@ pub fn mldsa_object_to_pkey(
                 prikey: None,
                 seed: None,
             }),
+            None,
         )?),
         CKO_PRIVATE_KEY => Ok(EvpPkey::import(
             osslctx(),
@@ -104,6 +105,7 @@ pub fn mldsa_object_to_pkey(
                     Err(_) => None,
                 },
             }),
+            None,
         )?),
         _ => Err(CKR_KEY_TYPE_INCONSISTENT)?,
     }
@@ -770,8 +772,11 @@ pub fn generate_keypair(
     pubkey: &mut Object,
     privkey: &mut Object,
 ) -> Result<()> {
-    let pkey =
-        EvpPkey::generate(osslctx(), mldsa_param_set_to_pkey_type(param_set)?)?;
+    let pkey = EvpPkey::generate(
+        osslctx(),
+        mldsa_param_set_to_pkey_type(param_set)?,
+        None,
+    )?;
     let mut mlk = match pkey.export()? {
         PkeyData::Mlkey(m) => m,
         _ => return Err(CKR_GENERAL_ERROR)?,

--- a/src/ossl/mlkem.rs
+++ b/src/ossl/mlkem.rs
@@ -52,6 +52,7 @@ pub fn mlkem_object_to_pkey(
                 prikey: None,
                 seed: None,
             }),
+            None,
         )?),
         CKO_PRIVATE_KEY => Ok(EvpPkey::import(
             osslctx(),
@@ -66,6 +67,7 @@ pub fn mlkem_object_to_pkey(
                     Err(_) => None,
                 },
             }),
+            None,
         )?),
         _ => Err(CKR_KEY_TYPE_INCONSISTENT)?,
     }
@@ -116,8 +118,11 @@ pub fn generate_keypair(
     pubkey: &mut Object,
     privkey: &mut Object,
 ) -> Result<()> {
-    let pkey =
-        EvpPkey::generate(osslctx(), mlkem_param_set_to_pkey_type(param_set)?)?;
+    let pkey = EvpPkey::generate(
+        osslctx(),
+        mlkem_param_set_to_pkey_type(param_set)?,
+        None,
+    )?;
 
     let mut mlk = match pkey.export()? {
         PkeyData::Mlkey(m) => m,

--- a/src/ossl/montgomery.rs
+++ b/src/ossl/montgomery.rs
@@ -37,6 +37,7 @@ pub fn ecm_object_to_pkey(
                 pubkey: Some(get_ec_point_from_obj(key)?),
                 prikey: None,
             }),
+            None,
         )?),
         CKO_PRIVATE_KEY => Ok(EvpPkey::import(
             osslctx(),
@@ -47,6 +48,7 @@ pub fn ecm_object_to_pkey(
                     key.get_attr_as_bytes(CKA_VALUE)?.clone(),
                 )),
             }),
+            None,
         )?),
         _ => Err(CKR_KEY_TYPE_INCONSISTENT)?,
     }
@@ -68,8 +70,11 @@ impl ECMontgomeryOperation {
         pubkey: &mut Object,
         privkey: &mut Object,
     ) -> Result<()> {
-        let pkey =
-            EvpPkey::generate(osslctx(), get_evp_pkey_type_from_obj(pubkey)?)?;
+        let pkey = EvpPkey::generate(
+            osslctx(),
+            get_evp_pkey_type_from_obj(pubkey)?,
+            None,
+        )?;
         let mut ecc = match pkey.export()? {
             PkeyData::Ecc(e) => e,
             _ => return Err(CKR_GENERAL_ERROR)?,

--- a/src/ossl/rsa.rs
+++ b/src/ossl/rsa.rs
@@ -97,6 +97,7 @@ pub fn rsa_object_to_pkey(
             b: b,
             c: c,
         }),
+        None,
     )?)
 }
 
@@ -432,6 +433,7 @@ impl RsaPKCSOperation {
         let pkey = EvpPkey::generate(
             osslctx(),
             EvpPkeyType::Rsa(bits, exponent.clone()),
+            None,
         )?;
         let mut rsa = match pkey.export()? {
             PkeyData::Rsa(r) => r,


### PR DESCRIPTION
#### Description

This change is motivated by the need to be able to use the ML-DSA and ed448 signature algorithms in FIPS mode. Currently, the fips provider in RHEL 10.1 does not have these implemented so it fails during import of the certificate (which consists of verification of binding signatures).

This extends the ossl API to be able to provide the optional `propq` to the key creation API (as a `&Cstr` -- if you wish, we could make it some special type, but this looked like the least pain to start with.

#### Checklist

- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
