### PR TITLE
Fix self reference in load_configuration API

### DIFF
--- a/ossl/src/lib.rs
+++ b/ossl/src/lib.rs
@@ -221,7 +221,7 @@ impl OsslContext {
     }
 
     pub fn load_configuration_file(
-        self,
+        &self,
         fname: Option<&Path>,
     ) -> Result<(), Error> {
         let filename: *const c_char = match fname {
@@ -239,7 +239,7 @@ impl OsslContext {
         }
     }
 
-    pub fn load_default_configuration(self) -> Result<(), Error> {
+    pub fn load_default_configuration(&self) -> Result<(), Error> {
         self.load_configuration_file(None)
     }
 


### PR DESCRIPTION
#### Description

This was missed during code review in #327. It does not make sense to hand over the ownership of the context to these functions.

#### Checklist

~- [ ] Test suite updated with functionality tests~
~- [ ] Test suite updated with negative tests~
~- [ ] Rustdoc string were added or updated~
~- [ ] CHANGELOG and/or other documentation added or updated~
~- [ ] This is not a code change~

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
