### PR TITLE
Add function to load legacy provider

### DIFF
--- a/ossl/ossl.h
+++ b/ossl/ossl.h
@@ -12,6 +12,7 @@
 #include "openssl/obj_mac.h"
 #include "openssl/kdf.h"
 #include "openssl/err.h"
+#include "openssl/provider.h"
 
 #ifdef _KRYOPTIC_FIPS_
 #include "crypto/evp.h"


### PR DESCRIPTION
#### Description

- Adds a way to load legacy providers for ossl bindings


#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] ~Test suite updated with functionality tests~
- [ ] ~Test suite updated with negative tests~
- [ ] ~Rustdoc string were added or updated~
- [ ] ~CHANGELOG and/or other documentation added or updated~
- [ ] ~This is not a code change~

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
