### PR TITLE
Load default openssl config when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ All notable changes to this project should be documented in this file.
   - [Handle imports where only the Seed is
      provided](https://github.com/latchset/kryoptic/pull/330)
 
+* Openssl context now loads the default openssl confgiuration file by default
+  - [Load default openssl config when
+     possible](https://github.com/latchset/kryoptic/pull/333)
+
 # [1.2.0]
 ## 2025-06-09
 

--- a/ossl/ossl.h
+++ b/ossl/ossl.h
@@ -12,6 +12,7 @@
 #include "openssl/obj_mac.h"
 #include "openssl/kdf.h"
 #include "openssl/err.h"
+#include "openssl/provider.h"
 
 #ifdef _KRYOPTIC_FIPS_
 #include "crypto/evp.h"


### PR DESCRIPTION
#### Description

Changes kryoptic (in non-fips builds) to try to load the default openssl configuration on the custom context.
Because the configuration file could be missing for "legitimate" reasons, we do not treat as fatal the failure to load the default configuration.

Fixes #319 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite already has enough coverage for this change
- [x] Rustdoc string were added or updated
- [x] CHANGELOG and/or other documentation added or updated
- [ ] ~This is not a code change~

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
