### PR TITLE
Return more specific error for unsupported parameter set

### DIFF
--- a/src/mldsa.rs
+++ b/src/mldsa.rs
@@ -105,7 +105,7 @@ fn mldsa_pub_check_import(obj: &Object) -> Result<()> {
                     return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;
                 }
             }
-            _ => return Err(CKR_ATTRIBUTE_VALUE_INVALID)?,
+            _ => return Err(CKR_PARAMETER_SET_NOT_SUPPORTED)?,
         },
         Err(_) => return Err(CKR_TEMPLATE_INCOMPLETE)?,
     }
@@ -205,7 +205,7 @@ fn mldsa_priv_check_import(obj: &mut Object) -> Result<()> {
                         return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;
                     }
                 }
-                _ => return Err(CKR_ATTRIBUTE_VALUE_INVALID)?,
+                _ => return Err(CKR_PARAMETER_SET_NOT_SUPPORTED)?,
             }
             Some(value)
         }
@@ -397,7 +397,7 @@ impl Mechanism for MlDsaMechanism {
         let param_set = match pubkey.get_attr_as_ulong(CKA_PARAMETER_SET) {
             Ok(p) => match p {
                 CKP_ML_DSA_44 | CKP_ML_DSA_65 | CKP_ML_DSA_87 => p,
-                _ => return Err(CKR_ATTRIBUTE_VALUE_INVALID)?,
+                _ => return Err(CKR_PARAMETER_SET_NOT_SUPPORTED)?,
             },
             Err(_) => return Err(CKR_TEMPLATE_INCONSISTENT)?,
         };

--- a/src/mlkem.rs
+++ b/src/mlkem.rs
@@ -98,7 +98,7 @@ fn mlkem_pub_check_import(obj: &Object) -> Result<()> {
                     return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;
                 }
             }
-            _ => return Err(CKR_ATTRIBUTE_VALUE_INVALID)?,
+            _ => return Err(CKR_PARAMETER_SET_NOT_SUPPORTED)?,
         },
         Err(_) => return Err(CKR_TEMPLATE_INCOMPLETE)?,
     }
@@ -198,7 +198,7 @@ fn mlkem_priv_check_import(obj: &mut Object) -> Result<()> {
                         return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;
                     }
                 }
-                _ => return Err(CKR_ATTRIBUTE_VALUE_INVALID)?,
+                _ => return Err(CKR_PARAMETER_SET_NOT_SUPPORTED)?,
             }
             Some(value)
         }
@@ -401,7 +401,7 @@ impl Mechanism for MlKemMechanism {
         let param_set = match pubkey.get_attr_as_ulong(CKA_PARAMETER_SET) {
             Ok(p) => match p {
                 CKP_ML_KEM_512 | CKP_ML_KEM_768 | CKP_ML_KEM_1024 => p,
-                _ => return Err(CKR_ATTRIBUTE_VALUE_INVALID)?,
+                _ => return Err(CKR_PARAMETER_SET_NOT_SUPPORTED)?,
             },
             Err(_) => return Err(CKR_TEMPLATE_INCONSISTENT)?,
         };

--- a/src/slhdsa.rs
+++ b/src/slhdsa.rs
@@ -118,7 +118,7 @@ fn slhdsa_pub_check_import(obj: &Object) -> Result<()> {
                     return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;
                 }
             }
-            _ => return Err(CKR_ATTRIBUTE_VALUE_INVALID)?,
+            _ => return Err(CKR_PARAMETER_SET_NOT_SUPPORTED)?,
         },
         Err(_) => return Err(CKR_TEMPLATE_INCOMPLETE)?,
     }
@@ -214,7 +214,7 @@ fn slhdsa_priv_check_import(obj: &Object) -> Result<()> {
                     return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;
                 }
             }
-            _ => return Err(CKR_ATTRIBUTE_VALUE_INVALID)?,
+            _ => return Err(CKR_PARAMETER_SET_NOT_SUPPORTED)?,
         },
         Err(_) => return Err(CKR_TEMPLATE_INCOMPLETE)?,
     };
@@ -404,7 +404,7 @@ impl Mechanism for SlhDsaMechanism {
                 | CKP_SLH_DSA_SHAKE_256S
                 | CKP_SLH_DSA_SHA2_256F
                 | CKP_SLH_DSA_SHAKE_256F => p,
-                _ => return Err(CKR_ATTRIBUTE_VALUE_INVALID)?,
+                _ => return Err(CKR_PARAMETER_SET_NOT_SUPPORTED)?,
             },
             Err(_) => return Err(CKR_TEMPLATE_INCONSISTENT)?,
         };


### PR DESCRIPTION
#### Description

While going through the specs, I noticed there is more specific error we can return for unsupported parameter set:

> CKR_PARAMETER_SET_NOT_SUPPORTED: This parameter set is not supported by this token.
> Used with XMSS, XMSSMT, ML-KEM, ML-DSA and SLH-DSA mechanisms.

I think it is more informative to return this than generic `CKR_ATTRIBUTE_VALUE_INVALID`.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

~- [] Test suite updated with functionality tests~
~- [ ] Test suite updated with negative tests~
~- [ ] Rustdoc string were added or updated~
~- [ ] CHANGELOG and/or other documentation added or updated~
~- [ ] This is not a code change~

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible text
- [ ] Doc string are properly updated
