### PR TITLE
Fix Simple KDFs to work with token objects

### DIFF
--- a/ossl/src/tests/mod.rs
+++ b/ossl/src/tests/mod.rs
@@ -16,7 +16,7 @@ pub fn test_ossl_context() -> &'static crate::OsslContext {
     }
 }
 
-#[cfg(not(feature = "fips"))]
+#[cfg(all(not(feature = "fips"), feature = "rfc9580"))]
 static TEST_LEGACY_CONTEXT: ::std::sync::LazyLock<crate::OsslContext> =
     ::std::sync::LazyLock::new(|| {
         let mut context = crate::OsslContext::new_lib_ctx();
@@ -25,6 +25,7 @@ static TEST_LEGACY_CONTEXT: ::std::sync::LazyLock<crate::OsslContext> =
         context
     });
 
+#[cfg(feature = "rfc9580")]
 pub fn test_ossl_legacy_context() -> &'static crate::OsslContext {
     #[cfg(feature = "fips")]
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1026,6 +1026,9 @@ extern "C" fn fn_create_object(
                     CKK_RSA => CKM_RSA_PKCS_KEY_PAIR_GEN,
                     CKK_EC => CKM_EC_KEY_PAIR_GEN,
                     CKK_EC_EDWARDS => CKM_EC_EDWARDS_KEY_PAIR_GEN,
+                    CKK_ML_DSA => CKM_ML_DSA_KEY_PAIR_GEN,
+                    CKK_ML_KEM => CKM_ML_KEM_KEY_PAIR_GEN,
+                    CKK_SLH_DSA => CKM_SLH_DSA_KEY_PAIR_GEN,
                     _ => CK_UNAVAILABLE_INFORMATION,
                 };
                 session.set_fips_indicator(fips::indicators::is_approved(


### PR DESCRIPTION
#### Description

Reported in parallaxsecond/rust-cryptoki#310 that the token objects do not behave as expected. After some investigation, I figured out I messed up the key creation there and attributes were off.

This attempts to fix it, but still the ALWAYS/NEVER attributes do not seem to be set to the right values and I am unable to figure out why. Any thoughts?

#### Checklist

- [X] Test suite updated with functionality tests
- [X] Test suite updated with negative tests
~- [ ] Rustdoc string were added or updated~
- [ ] CHANGELOG and/or other documentation added or updated
~- [ ] This is not a code change~

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
