### PR TITLE
Use modern API for secure key parameter export

### DIFF
--- a/ossl/build.rs
+++ b/ossl/build.rs
@@ -58,6 +58,12 @@ impl bindgen::callbacks::ParseCallbacks for OsslCallbacks {
             println!("cargo::rustc-cfg=ossl_mlkem")
         }
     }
+
+    fn func_macro(&self, name: &str, _value: &[&[u8]]) {
+        if name == "OSSL_PARAM_clear_free" {
+            println!("cargo::rustc-cfg=param_clear_free")
+        }
+    }
 }
 
 fn ossl_bindings(args: &[&str], out_file: &Path) {
@@ -285,7 +291,7 @@ fn main() {
     let ossl_bindings = out_path.join("ossl_bindings.rs");
 
     /* Always emit known configs */
-    println!("cargo::rustc-check-cfg=cfg(ossl_v307,ossl_v320,ossl_v350,ossl_mldsa,ossl_mlkem,ossl_slhdsa)");
+    println!("cargo::rustc-check-cfg=cfg(ossl_v307,ossl_v320,ossl_v350,ossl_mldsa,ossl_mlkem,ossl_slhdsa,param_clear_free)");
 
     /* OpenSSL Cryptography */
     if cfg!(feature = "dynamic") {


### PR DESCRIPTION
Refactor key parameter export to use the modern `EVP_PKEY_todata` and `OSSL_PARAM_clear_free` functions when available (OpenSSL 4.0+).

This new API provides a more secure and robust method for handling sensitive key material, as `OSSL_PARAM_clear_free` ensures memory is zeroed before deallocation.

The build script now detects this function. For backward compatibility with older OpenSSL versions, the code falls back to the previous implementation using the deprecated `EVP_PKEY_export` and a custom callback to manually copy and zeroize the data.

#### Description

<!--  The description should give a general overview of the goal of the PR.

Individual commit message should highlight important changes that people may
want to know about when looking at the commit years later
-->

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
