### PR TITLE
Prevent dynamic linking in FIPS builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,9 @@
 use std::env;
 use std::path::PathBuf;
 
+#[cfg(all(feature = "fips", feature = "dynamic"))]
+compile_error!("FIPS builds are incompatible with dynamic linking to OpenSSL");
+
 #[derive(Debug)]
 pub struct Pkcs11Callbacks;
 


### PR DESCRIPTION
#### Description

Add a compile-time check to `build.rs` that fails the build if both the `fips` and `dynamic` features are enabled.

FIPS-compliant builds require statically linking against the OpenSSL FIPS module. Attempting to dynamically link is an invalid configuration, so this change prevents it explicitly.

Fixes #272 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [x] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
