### PR TITLE
Clear errors from signature probe

### DIFF
--- a/ossl/src/signature.rs
+++ b/ossl/src/signature.rs
@@ -755,7 +755,9 @@ impl OsslSignature {
                      * supported.
                      */
                     let ret = unsafe {
-                        match ctx.op {
+                        /* avoid errors from propagating unnecessarily */
+                        ERR_set_mark();
+                        let r = match ctx.op {
                             SigOp::Sign => EVP_PKEY_sign_message_update(
                                 ctx.pkey_ctx.as_mut_ptr(),
                                 std::ptr::null(),
@@ -766,7 +768,11 @@ impl OsslSignature {
                                 std::ptr::null(),
                                 0,
                             ),
-                        }
+                        };
+                        /* we unconditionally pop to the error mark so no
+                         * error are left on the stack as this is just a test */
+                        ERR_pop_to_mark();
+                        r
                     };
                     if ret == 1 {
                         true


### PR DESCRIPTION
#### Description

The ossl bindings checks for support of message_update in the specific signature provider by attempting an update operation. If this probe failed because the function was unsupported, it would leave an error on the OpenSSL error stack.

Because OpenSSL's error stack is tie to a thread local variable rather than the libctx this can propagate to the application kryoptic is loaded into.

This change wraps the underlying EVP calls with `ERR_set_mark` and `ERR_pop_to_mark`. This ensures that any errors generated by the probe are cleared, preventing them from propagating and causing spurious failures in subsequent code.

Found while working on https://github.com/latchset/pkcs11-provider/pull/657

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
