### PR TITLE
Replace check_or_set_attr with ensure_* methods

### DIFF
--- a/src/ec/montgomery.rs
+++ b/src/ec/montgomery.rs
@@ -54,12 +54,10 @@ fn montgomery_public_key_info(
     };
 
     // Check if CKA_PUBLIC_KEY_INFO is already there.
-    if !obj.check_or_set_attr(Attribute::from_bytes(
+    obj.ensure_bytes(
         CKA_PUBLIC_KEY_INFO,
         pkcs::SubjectPublicKeyInfo::new(alg, ec_point_raw)?.serialize()?,
-    ))? {
-        return Err(CKR_TEMPLATE_INCONSISTENT)?;
-    };
+    )?;
 
     Ok(())
 }
@@ -337,46 +335,26 @@ impl Mechanism for ECMontgomeryMechanism {
     ) -> Result<(Object, Object)> {
         let mut pubkey =
             PUBLIC_KEY_FACTORY.default_object_generate(pubkey_template)?;
-        if !pubkey.check_or_set_attr(Attribute::from_ulong(
-            CKA_CLASS,
-            CKO_PUBLIC_KEY,
-        ))? {
-            return Err(CKR_TEMPLATE_INCONSISTENT)?;
-        }
-        if !pubkey.check_or_set_attr(Attribute::from_ulong(
-            CKA_KEY_TYPE,
-            CKK_EC_MONTGOMERY,
-        ))? {
-            return Err(CKR_TEMPLATE_INCONSISTENT)?;
-        }
+        pubkey
+            .ensure_ulong(CKA_CLASS, CKO_PUBLIC_KEY)
+            .map_err(|_| CKR_TEMPLATE_INCONSISTENT)?;
+        pubkey
+            .ensure_ulong(CKA_KEY_TYPE, CKK_EC_MONTGOMERY)
+            .map_err(|_| CKR_TEMPLATE_INCONSISTENT)?;
 
         let mut privkey =
             PRIVATE_KEY_FACTORY.default_object_generate(prikey_template)?;
-        if !privkey.check_or_set_attr(Attribute::from_ulong(
-            CKA_CLASS,
-            CKO_PRIVATE_KEY,
-        ))? {
-            return Err(CKR_TEMPLATE_INCONSISTENT)?;
-        }
-        if !privkey.check_or_set_attr(Attribute::from_ulong(
-            CKA_KEY_TYPE,
-            CKK_EC_MONTGOMERY,
-        ))? {
-            return Err(CKR_TEMPLATE_INCONSISTENT)?;
-        }
+        privkey
+            .ensure_ulong(CKA_CLASS, CKO_PRIVATE_KEY)
+            .map_err(|_| CKR_TEMPLATE_INCONSISTENT)?;
+        privkey
+            .ensure_ulong(CKA_KEY_TYPE, CKK_EC_MONTGOMERY)
+            .map_err(|_| CKR_TEMPLATE_INCONSISTENT)?;
 
-        let ec_params = match pubkey.get_attr_as_bytes(CKA_EC_PARAMS) {
-            Ok(a) => a.clone(),
-            Err(_) => {
-                return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;
-            }
-        };
-        if !privkey.check_or_set_attr(Attribute::from_bytes(
+        privkey.ensure_slice(
             CKA_EC_PARAMS,
-            ec_params,
-        ))? {
-            return Err(CKR_TEMPLATE_INCONSISTENT)?;
-        }
+            pubkey.get_attr_as_bytes(CKA_EC_PARAMS)?,
+        )?;
 
         ECMontgomeryOperation::generate_keypair(&mut pubkey, &mut privkey)?;
         default_key_attributes(&mut privkey, mech.mechanism)?;
@@ -384,13 +362,10 @@ impl Mechanism for ECMontgomeryMechanism {
 
         montgomery_public_key_info(&mut pubkey, None)?;
         /* copy the calculated CKA_PUBLIC_KEY_INFO to the private key */
-        match pubkey.get_attr_as_bytes(CKA_PUBLIC_KEY_INFO) {
-            Ok(info) => privkey.set_attr(Attribute::from_bytes(
-                CKA_PUBLIC_KEY_INFO,
-                info.clone(),
-            ))?,
-            Err(_) => return Err(CKR_GENERAL_ERROR)?,
-        }
+        privkey.ensure_slice(
+            CKA_PUBLIC_KEY_INFO,
+            pubkey.get_attr_as_bytes(CKA_PUBLIC_KEY_INFO)?,
+        )?;
 
         Ok((pubkey, privkey))
     }

--- a/src/ffdh_groups.rs
+++ b/src/ffdh_groups.rs
@@ -1196,16 +1196,6 @@ pub fn get_group_name(obj: &Object) -> Result<DHGroupName> {
     return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;
 }
 
-pub fn group_prime(group: DHGroupName) -> Result<&'static [u8]> {
-    for grp in &FFDHE_NAMED_GROUPS {
-        if grp.id == group {
-            return Ok(grp.prime);
-        }
-    }
-
-    return Err(CKR_GENERAL_ERROR)?;
-}
-
 pub fn group_values(
     group: DHGroupName,
 ) -> Result<(&'static [u8], &'static [u8], &'static [u8])> {

--- a/src/mldsa.rs
+++ b/src/mldsa.rs
@@ -51,12 +51,10 @@ fn mldsa_public_key_info(
     };
 
     // Check if CKA_PUBLIC_KEY_INFO is already there.
-    if !obj.check_or_set_attr(Attribute::from_bytes(
+    obj.ensure_bytes(
         CKA_PUBLIC_KEY_INFO,
         pkcs::SubjectPublicKeyInfo::new(alg, pubkey_raw)?.serialize()?,
-    ))? {
-        return Err(CKR_TEMPLATE_INCONSISTENT)?;
-    };
+    )?;
 
     Ok(())
 }
@@ -440,47 +438,30 @@ impl Mechanism for MlDsaMechanism {
     ) -> Result<(Object, Object)> {
         let mut pubkey =
             PUBLIC_KEY_FACTORY.default_object_generate(pubkey_template)?;
-        if !pubkey.check_or_set_attr(Attribute::from_ulong(
-            CKA_CLASS,
-            CKO_PUBLIC_KEY,
-        ))? {
-            return Err(CKR_TEMPLATE_INCONSISTENT)?;
-        }
-        if !pubkey.check_or_set_attr(Attribute::from_ulong(
-            CKA_KEY_TYPE,
-            CKK_ML_DSA,
-        ))? {
-            return Err(CKR_TEMPLATE_INCONSISTENT)?;
-        }
+        pubkey
+            .ensure_ulong(CKA_CLASS, CKO_PUBLIC_KEY)
+            .map_err(|_| CKR_TEMPLATE_INCONSISTENT)?;
+        pubkey
+            .ensure_ulong(CKA_KEY_TYPE, CKK_ML_DSA)
+            .map_err(|_| CKR_TEMPLATE_INCONSISTENT)?;
 
         let param_set = match pubkey.get_attr_as_ulong(CKA_PARAMETER_SET) {
             Ok(p) => match p {
                 CKP_ML_DSA_44 | CKP_ML_DSA_65 | CKP_ML_DSA_87 => p,
                 _ => return Err(CKR_PARAMETER_SET_NOT_SUPPORTED)?,
             },
-            Err(_) => return Err(CKR_TEMPLATE_INCONSISTENT)?,
+            Err(_) => return Err(CKR_TEMPLATE_INCOMPLETE)?,
         };
 
         let mut privkey =
             PRIVATE_KEY_FACTORY.default_object_generate(prikey_template)?;
-        if !privkey.check_or_set_attr(Attribute::from_ulong(
-            CKA_CLASS,
-            CKO_PRIVATE_KEY,
-        ))? {
-            return Err(CKR_TEMPLATE_INCONSISTENT)?;
-        }
-        if !privkey.check_or_set_attr(Attribute::from_ulong(
-            CKA_KEY_TYPE,
-            CKK_ML_DSA,
-        ))? {
-            return Err(CKR_TEMPLATE_INCONSISTENT)?;
-        }
-        if !privkey.check_or_set_attr(Attribute::from_ulong(
-            CKA_PARAMETER_SET,
-            param_set,
-        ))? {
-            return Err(CKR_TEMPLATE_INCONSISTENT)?;
-        }
+        privkey
+            .ensure_ulong(CKA_CLASS, CKO_PRIVATE_KEY)
+            .map_err(|_| CKR_TEMPLATE_INCONSISTENT)?;
+        privkey
+            .ensure_ulong(CKA_KEY_TYPE, CKK_ML_DSA)
+            .map_err(|_| CKR_TEMPLATE_INCONSISTENT)?;
+        privkey.ensure_ulong(CKA_PARAMETER_SET, param_set)?;
 
         mldsa::generate_keypair(param_set, &mut pubkey, &mut privkey)?;
         default_key_attributes(&mut privkey, mech.mechanism)?;
@@ -488,13 +469,10 @@ impl Mechanism for MlDsaMechanism {
 
         mldsa_public_key_info(&mut pubkey, None)?;
         /* copy the calculated CKA_PUBLIC_KEY_INFO to the private key */
-        match pubkey.get_attr_as_bytes(CKA_PUBLIC_KEY_INFO) {
-            Ok(info) => privkey.set_attr(Attribute::from_bytes(
-                CKA_PUBLIC_KEY_INFO,
-                info.clone(),
-            ))?,
-            Err(_) => return Err(CKR_GENERAL_ERROR)?,
-        }
+        privkey.ensure_slice(
+            CKA_PUBLIC_KEY_INFO,
+            pubkey.get_attr_as_bytes(CKA_PUBLIC_KEY_INFO)?,
+        )?;
 
         Ok((pubkey, privkey))
     }

--- a/src/ossl/ffdh.rs
+++ b/src/ossl/ffdh.rs
@@ -9,7 +9,7 @@ use std::fmt::Debug;
 
 use crate::attribute::{Attribute, CkAttrs};
 use crate::error::{Error, Result};
-use crate::ffdh_groups::{get_group_name, group_prime, DHGroupName};
+use crate::ffdh_groups::{get_group_name, DHGroupName};
 use crate::mechanism::{Derive, MechOperation, Mechanisms};
 use crate::object::{default_key_attributes, Object, ObjectFactories};
 use crate::ossl::common::{osslctx, privkey_from_object};
@@ -123,11 +123,6 @@ impl FFDHOperation {
 
         /* Set Public Key */
         if let Some(key) = ffdh.pubkey.take() {
-            pubkey.check_or_set_attr(Attribute::from_bytes(
-                CKA_PRIME,
-                group_prime(group)?.to_vec(),
-            ))?;
-
             pubkey.set_attr(Attribute::from_bytes(CKA_VALUE, key))?;
         } else {
             return Err(CKR_DEVICE_ERROR)?;
@@ -135,10 +130,6 @@ impl FFDHOperation {
 
         /* Set Private Key */
         if let Some(key) = ffdh.prikey.take() {
-            privkey.check_or_set_attr(Attribute::from_bytes(
-                CKA_PRIME,
-                group_prime(group)?.to_vec(),
-            ))?;
             privkey.set_attr(Attribute::from_ulong(
                 CKA_VALUE_BITS,
                 CK_ULONG::try_from(key.len() * 8)?,

--- a/src/slhdsa.rs
+++ b/src/slhdsa.rs
@@ -60,12 +60,10 @@ fn slhdsa_public_key_info(
     };
 
     // Check if CKA_PUBLIC_KEY_INFO is already there.
-    if !obj.check_or_set_attr(Attribute::from_bytes(
+    obj.ensure_bytes(
         CKA_PUBLIC_KEY_INFO,
         pkcs::SubjectPublicKeyInfo::new(alg, pubkey_raw)?.serialize()?,
-    ))? {
-        return Err(CKR_TEMPLATE_INCONSISTENT)?;
-    };
+    )?;
 
     Ok(())
 }
@@ -445,18 +443,12 @@ impl Mechanism for SlhDsaMechanism {
     ) -> Result<(Object, Object)> {
         let mut pubkey =
             PUBLIC_KEY_FACTORY.default_object_generate(pubkey_template)?;
-        if !pubkey.check_or_set_attr(Attribute::from_ulong(
-            CKA_CLASS,
-            CKO_PUBLIC_KEY,
-        ))? {
-            return Err(CKR_TEMPLATE_INCONSISTENT)?;
-        }
-        if !pubkey.check_or_set_attr(Attribute::from_ulong(
-            CKA_KEY_TYPE,
-            CKK_SLH_DSA,
-        ))? {
-            return Err(CKR_TEMPLATE_INCONSISTENT)?;
-        }
+        pubkey
+            .ensure_ulong(CKA_CLASS, CKO_PUBLIC_KEY)
+            .map_err(|_| CKR_TEMPLATE_INCONSISTENT)?;
+        pubkey
+            .ensure_ulong(CKA_KEY_TYPE, CKK_SLH_DSA)
+            .map_err(|_| CKR_TEMPLATE_INCONSISTENT)?;
 
         let param_set = match pubkey.get_attr_as_ulong(CKA_PARAMETER_SET) {
             Ok(p) => match p {
@@ -479,24 +471,15 @@ impl Mechanism for SlhDsaMechanism {
 
         let mut privkey =
             PRIVATE_KEY_FACTORY.default_object_generate(prikey_template)?;
-        if !privkey.check_or_set_attr(Attribute::from_ulong(
-            CKA_CLASS,
-            CKO_PRIVATE_KEY,
-        ))? {
-            return Err(CKR_TEMPLATE_INCONSISTENT)?;
-        }
-        if !privkey.check_or_set_attr(Attribute::from_ulong(
-            CKA_KEY_TYPE,
-            CKK_SLH_DSA,
-        ))? {
-            return Err(CKR_TEMPLATE_INCONSISTENT)?;
-        }
-        if !privkey.check_or_set_attr(Attribute::from_ulong(
-            CKA_PARAMETER_SET,
-            param_set,
-        ))? {
-            return Err(CKR_TEMPLATE_INCONSISTENT)?;
-        }
+        privkey
+            .ensure_ulong(CKA_CLASS, CKO_PRIVATE_KEY)
+            .map_err(|_| CKR_TEMPLATE_INCONSISTENT)?;
+        privkey
+            .ensure_ulong(CKA_KEY_TYPE, CKK_SLH_DSA)
+            .map_err(|_| CKR_TEMPLATE_INCONSISTENT)?;
+        privkey
+            .ensure_ulong(CKA_PARAMETER_SET, param_set)
+            .map_err(|_| CKR_TEMPLATE_INCONSISTENT)?;
 
         slhdsa::generate_keypair(param_set, &mut pubkey, &mut privkey)?;
         default_key_attributes(&mut privkey, mech.mechanism)?;
@@ -504,13 +487,10 @@ impl Mechanism for SlhDsaMechanism {
 
         slhdsa_public_key_info(&mut pubkey, None)?;
         /* copy the calculated CKA_PUBLIC_KEY_INFO to the private key */
-        match pubkey.get_attr_as_bytes(CKA_PUBLIC_KEY_INFO) {
-            Ok(info) => privkey.set_attr(Attribute::from_bytes(
-                CKA_PUBLIC_KEY_INFO,
-                info.clone(),
-            ))?,
-            Err(_) => return Err(CKR_GENERAL_ERROR)?,
-        }
+        privkey.ensure_slice(
+            CKA_PUBLIC_KEY_INFO,
+            pubkey.get_attr_as_bytes(CKA_PUBLIC_KEY_INFO)?,
+        )?;
 
         Ok((pubkey, privkey))
     }


### PR DESCRIPTION
#### Description

The `Object::check_or_set_attr` method was cumbersome. It returned a boolean within a Result, requiring callers to check the value and return a specific error code, which led to verbose and repetitive boilerplate.

This change replaces it with `ensure_ulong`, `ensure_slice`, and `ensure_bytes`. These methods encapsulate the logic of checking for an existing attribute and verifying its value, or adding it if it doesn't exist. They return `Result<()>` directly, which simplifies the error handling at call sites.

All usages have been refactored, resulting in cleaner and more readable code for object and key generation.


#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [x] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
