### PR TITLE
Remove explicit C standard from build script

### DIFF
--- a/ossl/build.rs
+++ b/ossl/build.rs
@@ -247,7 +247,7 @@ fn build_ossl(out_file: &Path) {
             .unwrap()
     );
 
-    let mut args = vec![&include_path, "-std=c90"];
+    let mut args = vec![include_path.as_str()];
     if cfg!(feature = "fips") {
         args.push("-D_KRYOPTIC_FIPS_");
     }
@@ -261,20 +261,7 @@ fn use_system_ossl(out_file: &Path) {
         .probe("openssl")
         .unwrap();
 
-    let mut c_standard = "-std=c90".to_owned();
-    let version: Vec<u32> = library
-        .version
-        .split('.')
-        .take(2)
-        .map(|value| value.parse::<u32>().unwrap())
-        .collect();
-    if version[0] > 3 || (version[0] == 3 && version[1] >= 6) {
-        // "Starting with 3.6 OpenSSL project is going to gradually adopt C-99 features."
-        // https://github.com/openssl/openssl/blob/master/NOTES-C99.md
-        c_standard = "-std=c99".to_owned();
-    }
-
-    let mut args: Vec<String> = vec![c_standard];
+    let mut args: Vec<String> = Vec::new();
     for include_path in library.include_paths {
         args.push(["-I", include_path.to_str().unwrap()].concat());
     }


### PR DESCRIPTION
#### Description

The build script no longer passes `-std=c90` or `-std=c99` to the C compiler when building the wrapper.

This logic is not necessary, as the compiler's default standard is sufficient. Removing the explicit flags simplifies the build script and avoids potential compilation issues.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
