### PR TITLE
Improve length lookups in DecryptFinal/EncryptFinal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1492,17 +1492,17 @@ extern "C" fn fn_encrypt_final(
     }
     let mut session = res_or_ret!(rstate.get_session_mut(s_handle));
     let operation = res_or_ret!(session.get_operation::<dyn Encryption>());
-    let penclen = unsafe { *pul_last_encrypted_part_len as CK_ULONG };
-    let enclen = cast_or_ret!(usize from penclen => CKR_ARGUMENTS_BAD);
     if last_encrypted_part.is_null() {
         let encryption_len = cast_or_ret!(
-            CK_ULONG from res_or_ret!(operation.encryption_len(enclen, true))
+            CK_ULONG from res_or_ret!(operation.encryption_len(0, true))
         );
         unsafe {
             *pul_last_encrypted_part_len = encryption_len;
         }
         return CKR_OK;
     }
+    let penclen = unsafe { *pul_last_encrypted_part_len as CK_ULONG };
+    let enclen = cast_or_ret!(usize from penclen => CKR_ARGUMENTS_BAD);
     let enclast: &mut [u8] =
         unsafe { std::slice::from_raw_parts_mut(last_encrypted_part, enclen) };
     let outlen = res_or_ret!(operation.encrypt_final(enclast));
@@ -1660,17 +1660,17 @@ extern "C" fn fn_decrypt_final(
     let rstate = global_rlock!((*STATE));
     let mut session = res_or_ret!(rstate.get_session_mut(s_handle));
     let operation = res_or_ret!(session.get_operation::<dyn Decryption>());
-    let pplen = unsafe { *pul_last_part_len as CK_ULONG };
-    let plen = cast_or_ret!(usize from pplen => CKR_ARGUMENTS_BAD);
     if last_part.is_null() {
         let decryption_len = cast_or_ret!(
-            CK_ULONG from res_or_ret!(operation.decryption_len(plen, true))
+            CK_ULONG from res_or_ret!(operation.decryption_len(0, true))
         );
         unsafe {
             *pul_last_part_len = decryption_len;
         }
         return CKR_OK;
     }
+    let pplen = unsafe { *pul_last_part_len as CK_ULONG };
+    let plen = cast_or_ret!(usize from pplen => CKR_ARGUMENTS_BAD);
     let dlast: &mut [u8] =
         unsafe { std::slice::from_raw_parts_mut(last_part, plen) };
     let outlen = res_or_ret!(operation.decrypt_final(dlast));

--- a/src/ossl/aes.rs
+++ b/src/ossl/aes.rs
@@ -1916,23 +1916,23 @@ impl Decryption for AesOperation {
         let outlen = if fin {
             match self.mech {
                 CKM_AES_GCM => {
-                    if data_len < self.params.taglen {
-                        return Err(self.op_err(CKR_DATA_LEN_RANGE));
+                    if self.buffer.len() + data_len < self.params.taglen {
+                        return Err(self.op_err(CKR_ENCRYPTED_DATA_LEN_RANGE));
                     }
-                    data_len - self.params.taglen
+                    self.buffer.len() + data_len - self.params.taglen
                 }
                 CKM_AES_CCM => {
                     if self.buffer.len() + data_len
                         > self.params.datalen + self.params.taglen
                     {
-                        return Err(self.op_err(CKR_DATA_LEN_RANGE));
+                        return Err(self.op_err(CKR_ENCRYPTED_DATA_LEN_RANGE));
                     }
                     self.params.datalen + self.params.taglen
                 }
                 CKM_AES_CTR | CKM_AES_CTS => data_len,
                 CKM_AES_CBC | CKM_AES_ECB => {
                     if (self.buffer.len() + data_len) % AES_BLOCK_SIZE != 0 {
-                        return Err(self.op_err(CKR_DATA_LEN_RANGE));
+                        return Err(self.op_err(CKR_ENCRYPTED_DATA_LEN_RANGE));
                     }
                     self.buffer.len() + data_len
                 }
@@ -1942,13 +1942,13 @@ impl Decryption for AesOperation {
                 }
                 CKM_AES_CBC_PAD => {
                     if (self.buffer.len() + data_len) % AES_BLOCK_SIZE != 0 {
-                        return Err(self.op_err(CKR_DATA_LEN_RANGE));
+                        return Err(self.op_err(CKR_ENCRYPTED_DATA_LEN_RANGE));
                     }
                     self.buffer.len() + data_len
                 }
                 CKM_AES_KEY_WRAP | CKM_AES_KEY_WRAP_KWP => {
                     if data_len % AES_KWP_BLOCK != 0 {
-                        return Err(self.op_err(CKR_DATA_LEN_RANGE));
+                        return Err(self.op_err(CKR_ENCRYPTED_DATA_LEN_RANGE));
                     }
                     self.buffer.len() + data_len
                 }
@@ -1958,7 +1958,7 @@ impl Decryption for AesOperation {
             match self.mech {
                 CKM_AES_CCM => {
                     if self.buffer.len() + data_len < self.params.taglen {
-                        return Err(self.op_err(CKR_DATA_LEN_RANGE));
+                        return Err(self.op_err(CKR_ENCRYPTED_DATA_LEN_RANGE));
                     }
                     self.buffer.len() + data_len - self.params.taglen
                 }
@@ -1980,7 +1980,7 @@ impl Decryption for AesOperation {
                 }
                 CKM_AES_KEY_WRAP | CKM_AES_KEY_WRAP_KWP => {
                     if data_len % AES_KWP_BLOCK != 0 {
-                        return Err(self.op_err(CKR_DATA_LEN_RANGE));
+                        return Err(self.op_err(CKR_ENCRYPTED_DATA_LEN_RANGE));
                     } else {
                         /* Originally this was ((data_len / 8) * 8) - 8
                          * however this caused stack corruption on decryption

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -100,6 +100,55 @@ pub fn decrypt(
     Ok(dec)
 }
 
+pub fn decrypt_update(
+    session: CK_SESSION_HANDLE,
+    ciphertext: &[u8],
+) -> Result<Vec<u8>> {
+    let mut dec_len: CK_ULONG = 0;
+    let ret = fn_decrypt_update(
+        session,
+        ciphertext.as_ptr() as *mut u8,
+        ciphertext.len() as CK_ULONG,
+        std::ptr::null_mut(),
+        &mut dec_len,
+    );
+    if ret != CKR_OK {
+        return Err(ret)?;
+    }
+
+    let mut dec = vec![0u8; dec_len as usize];
+    let ret = fn_decrypt_update(
+        session,
+        ciphertext.as_ptr() as *mut u8,
+        ciphertext.len() as CK_ULONG,
+        dec.as_mut_ptr(),
+        &mut dec_len,
+    );
+    if ret != CKR_OK {
+        return Err(ret)?;
+    }
+    dec.resize(dec_len as usize, 0);
+
+    Ok(dec)
+}
+
+pub fn decrypt_final(session: CK_SESSION_HANDLE) -> Result<Vec<u8>> {
+    let mut dec_len: CK_ULONG = 0;
+    let ret = fn_decrypt_final(session, std::ptr::null_mut(), &mut dec_len);
+    if ret != CKR_OK {
+        return Err(ret)?;
+    }
+
+    let mut dec = vec![0u8; dec_len as usize];
+    let ret = fn_decrypt_final(session, dec.as_mut_ptr(), &mut dec_len);
+    if ret != CKR_OK {
+        return Err(ret)?;
+    }
+    dec.resize(dec_len as usize, 0);
+
+    Ok(dec)
+}
+
 pub fn encrypt(
     session: CK_SESSION_HANDLE,
     key: CK_OBJECT_HANDLE,
@@ -135,6 +184,55 @@ pub fn encrypt(
         enc.as_mut_ptr(),
         &mut enc_len,
     );
+    if ret != CKR_OK {
+        return Err(ret)?;
+    }
+    enc.resize(enc_len as usize, 0);
+
+    Ok(enc)
+}
+
+pub fn encrypt_update(
+    session: CK_SESSION_HANDLE,
+    plaintext: &[u8],
+) -> Result<Vec<u8>> {
+    let mut enc_len: CK_ULONG = 0;
+    let ret = fn_encrypt_update(
+        session,
+        plaintext.as_ptr() as *mut u8,
+        plaintext.len() as CK_ULONG,
+        std::ptr::null_mut(),
+        &mut enc_len,
+    );
+    if ret != CKR_OK {
+        return Err(ret)?;
+    }
+
+    let mut enc = vec![0u8; enc_len as usize];
+    let ret = fn_encrypt_update(
+        session,
+        plaintext.as_ptr() as *mut u8,
+        plaintext.len() as CK_ULONG,
+        enc.as_mut_ptr(),
+        &mut enc_len,
+    );
+    if ret != CKR_OK {
+        return Err(ret)?;
+    }
+    enc.resize(enc_len as usize, 0);
+
+    Ok(enc)
+}
+
+pub fn encrypt_final(session: CK_SESSION_HANDLE) -> Result<Vec<u8>> {
+    let mut enc_len: CK_ULONG = 0;
+    let ret = fn_encrypt_final(session, std::ptr::null_mut(), &mut enc_len);
+    if ret != CKR_OK {
+        return Err(ret)?;
+    }
+
+    let mut enc = vec![0u8; enc_len as usize];
+    let ret = fn_encrypt_final(session, enc.as_mut_ptr(), &mut enc_len);
     if ret != CKR_OK {
         return Err(ret)?;
     }


### PR DESCRIPTION
#### Description

Resolves #381

A small set of key changes:
- `fn_encrypt_final` and `fn_decrypt_final` were passing the value of the receiving length pointer to `encryption_len`/`decryption_len`, this should be zero instead.
- `decryption_len` now takes the buffer length of an ongoing AES-GCM operation into account when checking that the provided data is at least the size of the tag. This ensures that a tag previously passed via `DecryptUpdate` is accounted for in the check.
- Minor: `decryption_len` should likely error with `CKR_ENCRYPTED_DATA_LEN_RANGE`, not `CKR_DATA_LEN_RANGE`

The rest of the code churn is just a refactor in the AES test suite, adding `{encrypt,decrypt}_{update,final}` helpers besides the existing `encrypt/decrypt` helpers such that tests use Section 5.2 semantics and thereby call into `encryption_len`/`decryption_len`. I've also added a multi-part decryption test for AES-GCM which was previously not covered.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite updated with functionality tests
- [ ] ~~Test suite updated with negative tests~~
- [ ] ~~Rustdoc string were added or updated~~
- [ ] ~~CHANGELOG and/or other documentation added or updated~~
- [ ] ~~This is not a code change~~

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
