### PR TITLE
Update to rust-cryptoki 0.11

### DIFF
--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -29,7 +29,7 @@ required-features = ["profiles"]
 [dependencies]
 clap = { version = "4.5.26", default-features = false, features = ["cargo", "derive", "help", "std", "usage"] }
 kryoptic-lib.workspace = true
-cryptoki = "0.10.0"
+cryptoki = "0.11.0"
 hex = "0.4.3"
 libc = "0.2.151"
 serde = { version = "1.0.180", features = ["derive"] }

--- a/tools/softhsm/test_init.rs
+++ b/tools/softhsm/test_init.rs
@@ -1,7 +1,7 @@
 use std::process::ExitCode;
 
 use clap::Parser;
-use cryptoki::context::{CInitializeArgs, Pkcs11};
+use cryptoki::context::{CInitializeArgs, CInitializeFlags, Pkcs11};
 use cryptoki::session::UserType;
 use cryptoki::types::AuthPin;
 
@@ -27,7 +27,9 @@ fn main() -> ExitCode {
     let pkcs11 = Pkcs11::new(args.pkcs11_module).unwrap();
 
     // initialize the library
-    pkcs11.initialize(CInitializeArgs::OsThreads).unwrap();
+    pkcs11
+        .initialize(CInitializeArgs::new(CInitializeFlags::OS_LOCKING_OK))
+        .unwrap();
 
     // find a slot, get the first one
     let slot = pkcs11.get_slots_with_token().unwrap().remove(0);

--- a/tools/softhsm/test_signature.rs
+++ b/tools/softhsm/test_signature.rs
@@ -1,7 +1,7 @@
 use std::process::ExitCode;
 
 use clap::Parser;
-use cryptoki::context::{CInitializeArgs, Pkcs11};
+use cryptoki::context::{CInitializeArgs, CInitializeFlags, Pkcs11};
 use cryptoki::mechanism::Mechanism;
 use cryptoki::object::{Attribute, ObjectClass};
 use cryptoki::session::UserType;
@@ -23,7 +23,9 @@ fn main() -> ExitCode {
     let pkcs11 = Pkcs11::new(args.pkcs11_module).unwrap();
 
     // initialize the library
-    pkcs11.initialize(CInitializeArgs::OsThreads).unwrap();
+    pkcs11
+        .initialize(CInitializeArgs::new(CInitializeFlags::OS_LOCKING_OK))
+        .unwrap();
 
     // find a slot, get the first one
     let slot = pkcs11.get_slots_with_token().unwrap().remove(0);


### PR DESCRIPTION
#### Description

The API break happened in the following commit https://github.com/parallaxsecond/rust-cryptoki/commit/926c43e200e0a98d992edd8db0ead37633be443a

Based on the discussion in https://bugzilla.redhat.com/show_bug.cgi?id=2423922 the simplest would be updating the kryoptic to cryptoki 0.11 and then updating rust-cryptoki and kryoptic in Fedora to avoid over-complicating things.

The RPM CI will fail here.

#### Checklist
~- [ ] Test suite updated with functionality tests~
~- [ ] Test suite updated with negative tests~
~- [ ] Rustdoc string were added or updated~
~- [ ] CHANGELOG and/or other documentation added or updated~
~- [ ] This is not a code change~

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible text
- [x] Doc string are properly updated
