### PR TITLE
Update rusqlite to 0.38 with fallible_uint

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -53,7 +53,7 @@ jobs:
                 'crate(data-encoding/default)' 'crate(getrandom/default)' 'crate(hex/default)' \
                 'crate(itertools/default)' 'crate(libc/default)' 'crate(num-bigint/default)' \
                 'crate(num-integer/default)' 'crate(num-traits/default)' \
-                'crate(pkg-config/default)' 'crate(rusqlite/default)' \
+                'crate(pkg-config/default)' 'crate(rusqlite/default)' 'crate(rusqlite/fallible_uint)' \
                 'crate(serde/default)' 'crate(serde/derive)' 'crate(serde_json/default)' \
                 'crate(serial_test/default)' \
                 'crate(toml)' 'crate(toml/display)' 'crate(toml/parse)' 'crate(toml/serde)' \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ log = { version = "0.4.27", default-features = false, features = ["std"], option
 num-bigint = "0.4.4"
 num-integer = "0.1.45"
 num-traits = "0.2.17"
-rusqlite = { version = "0.31.0", optional = true }
+rusqlite = { version = "0.38.0", optional = true, features = ["fallible_uint"] }
 serde = { version = "1.0.180", features = ["derive"] }
 serde_json = "1.0.104"
 serial_test = "3.1.1"


### PR DESCRIPTION
#### Description

The new rusqlite has breaking change the u64 does not have from/into converters anymore, unless we have `fallible_uint`. Using this is fast fix. Its safe because we do not really store anything larger than u32 bounds.

Right thing would be casting it to/from u32 explicitly without the specific feature on rusqlite, but thats for proper change later. :)

Fixes: #392

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [~] Test suite updated with functionality tests
- [~] Test suite updated with negative tests
- [~] Rustdoc string were added or updated
- [~] CHANGELOG and/or other documentation added or updated
- [X] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
