### PR TITLE
storage: Use explicit casts to avoid fallible_uint feature of rusqlite

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -53,7 +53,7 @@ jobs:
                 'crate(data-encoding/default)' 'crate(getrandom/default)' 'crate(hex/default)' \
                 'crate(itertools/default)' 'crate(libc/default)' 'crate(num-bigint/default)' \
                 'crate(num-integer/default)' 'crate(num-traits/default)' \
-                'crate(pkg-config/default)' 'crate(rusqlite/default)' 'crate(rusqlite/fallible_uint)' \
+                'crate(pkg-config/default)' 'crate(rusqlite/default)' \
                 'crate(serde/default)' 'crate(serde/derive)' 'crate(serde_json/default)' \
                 'crate(serial_test/default)' \
                 'crate(toml)' 'crate(toml/display)' 'crate(toml/parse)' 'crate(toml/serde)' \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ log = { version = "0.4.27", default-features = false, features = ["std"], option
 num-bigint = "0.4.4"
 num-integer = "0.1.45"
 num-traits = "0.2.17"
-rusqlite = { version = "0.38.0", optional = true, features = ["fallible_uint"] }
+rusqlite = { version = "0.38.0", optional = true }
 serde = { version = "1.0.180", features = ["derive"] }
 serde_json = "1.0.104"
 serial_test = "3.1.1"


### PR DESCRIPTION
Fixes: #395

#### Description

Follow-up from temporary fix in #394, which introduced compatibility, but fallible casts.

#### Checklist

- [~] Test suite updated with functionality tests
- [~] Test suite updated with negative tests
- [~] Rustdoc string were added or updated
- [~] CHANGELOG and/or other documentation added or updated
- [~] This is not a code change

#### Reviewer's checklist:

- [x] Any issues marked for closing are fully addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible text
- [ ] Doc string are properly updated
