### PR TITLE
Update CI to use OpenSSL 4.0 branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
     branches: ["main"]
 
 env:
-  OPENSSL_FIPS_BRANCH: kryoptic_ossl35
+  OPENSSL_FIPS_BRANCH: kryoptic_ossl40
   OPENSSL_STATIC_BRANCH: master
 
 jobs:

--- a/.github/workflows/openjdk-integration.yml
+++ b/.github/workflows/openjdk-integration.yml
@@ -4,7 +4,7 @@ name: OpenJDK Integration Tests
 # Run OpenJDK tests listed in testdata/openjdk/openjdk-jtreg-tests.txt.
 
 env:
-  OPENSSL_BRANCH: kryoptic_ossl35
+  OPENSSL_BRANCH: kryoptic_ossl40
   # Keep jtreg_version, openjdk_feature, and openjdk_name in sync with
   # testdata/openjdk/jtreg-kryoptic.sh.
   jtreg_version: 8+2


### PR DESCRIPTION
#### Description

Update the `build` and `openjdk-integration` GitHub Actions workflows to use the `kryoptic_ossl40` branch for OpenSSL.

This ensures the project is built and tested against the newer OpenSSL 4.0 development branch instead of the previous `kryoptic_ossl35` branch.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
