### PR TITLE
Set CKA_PUBLIC_KEY_INFO for EC private keys

### DIFF
--- a/ossl/src/lib.rs
+++ b/ossl/src/lib.rs
@@ -35,6 +35,21 @@ pub mod signature;
 #[cfg(feature = "fips")]
 pub mod fips;
 
+/// Export the API level of the OpenSSL library these bindings
+/// were built against. This should be used only when probing
+/// for behavior is difficult as it is only a proxy for what was
+/// available at compile time, which may be different from what is
+/// available at runtime when dynamically linking to shared libraries.
+///
+/// This returns a triplet of u8 values representing Major, Minor, and
+/// Patch version.
+pub fn api_level() -> (u8, u8, u8) {
+    let patch: u8 = (OPENSSL_API_LEVEL & 0xff) as u8;
+    let minor: u8 = ((OPENSSL_API_LEVEL & 0xff00) >> 8) as u8;
+    let major: u8 = ((OPENSSL_API_LEVEL & 0xff0000) >> 16) as u8;
+    (major, minor, patch)
+}
+
 /// Securely zeroizes a memory slice using `OPENSSL_cleanse`.
 pub fn zeromem(mem: &mut [u8]) {
     unsafe {

--- a/src/tests/simplekdf.rs
+++ b/src/tests/simplekdf.rs
@@ -2,6 +2,7 @@
 // See LICENSE.txt file for terms
 
 use crate::tests::*;
+use ::ossl::api_level;
 
 use serial_test::parallel;
 
@@ -668,33 +669,34 @@ fn test_derive_pub_from_priv() {
         ],
     });
 
-    // EC params for secp256r1
-    // #[cfg(feature = "ecdsa")]
-    // let secp256r1_oid = hex::decode("06082A8648CE3D030107").unwrap();
-    // #[cfg(feature = "ecdsa")]
-    // let ecdsa_params = [(CKA_EC_PARAMS, secp256r1_oid.as_slice())];
-    // #[cfg(feature = "ecdsa")]
-    // test_cases.push(TestCase {
-    //     name: "ECDSA",
-    //     gen_mech: CKM_EC_KEY_PAIR_GEN,
-    //     pub_ulongs: &[],
-    //     pub_strings: &ecdsa_params,
-    //     pub_bools: &[(CKA_TOKEN, true), (CKA_VERIFY, true)],
-    //     pri_ulongs: &[(CKA_CLASS, CKO_PRIVATE_KEY), (CKA_KEY_TYPE, CKK_EC)],
-    //     pri_strings: &[],
-    //     pri_bools: &[
-    //         (CKA_TOKEN, true),
-    //         (CKA_SENSITIVE, false),
-    //         (CKA_EXTRACTABLE, true),
-    //         (CKA_SIGN, true),
-    //     ],
-    //     check_attrs: &[CKA_EC_POINT, CKA_EC_PARAMS],
-    //     derived_bools: &[
-    //         (CKA_TOKEN, false),
-    //         (CKA_PRIVATE, false),
-    //         (CKA_VERIFY, true),
-    //     ],
-    // });
+    #[cfg(feature = "ecdsa")]
+    let secp256r1_oid = hex::decode("06082A8648CE3D030107").unwrap();
+    #[cfg(feature = "ecdsa")]
+    let ecdsa_params = [(CKA_EC_PARAMS, secp256r1_oid.as_slice())];
+    #[cfg(feature = "ecdsa")]
+    if api_level() >= ossl::common::OPENSSL_4_0 {
+        test_cases.push(TestCase {
+            name: "ECDSA",
+            gen_mech: CKM_EC_KEY_PAIR_GEN,
+            pub_ulongs: &[],
+            pub_strings: &ecdsa_params,
+            pub_bools: &[(CKA_TOKEN, true), (CKA_VERIFY, true)],
+            pri_ulongs: &[(CKA_CLASS, CKO_PRIVATE_KEY), (CKA_KEY_TYPE, CKK_EC)],
+            pri_strings: &[],
+            pri_bools: &[
+                (CKA_TOKEN, true),
+                (CKA_SENSITIVE, false),
+                (CKA_EXTRACTABLE, true),
+                (CKA_SIGN, true),
+            ],
+            check_attrs: &[CKA_EC_POINT, CKA_EC_PARAMS],
+            derived_bools: &[
+                (CKA_TOKEN, false),
+                (CKA_PRIVATE, false),
+                (CKA_VERIFY, true),
+            ],
+        });
+    }
 
     #[cfg(feature = "eddsa")]
     let edwards25519 = hex::decode("130c656477617264733235353139").unwrap();


### PR DESCRIPTION
#### Description

Enable the extraction of the public key from an EC private key to populate the CKA_PUBLIC_KEY_INFO attribute during object creation.

This functionality was previously disabled due to lack of support in older OpenSSL versions. This change adds a new `ossl::api_level()` function to check the OpenSSL version at compile time.

For OpenSSL versions before 4.0.0, where extraction is not supported, the `CKR_KEY_UNEXTRACTABLE` error is handled gracefully, allowing key creation to succeed without the attribute. For OpenSSL 4.0.0 and newer, the attribute is correctly populated. A corresponding test case has been re-enabled and is now conditional on the OpenSSL version.

Fixes: #358 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [x] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
