### PR TITLE
Disable SLH-DSA in FIPS builds without ossl400

### DIFF
--- a/src/enabled.rs
+++ b/src/enabled.rs
@@ -45,7 +45,12 @@ mod mlkem;
 #[cfg(feature = "mldsa")]
 mod mldsa;
 
-#[cfg(feature = "slhdsa")]
+// In fips builds enable slhdsa only if ossl400 was selected, which is required
+// for deferred self tests
+#[cfg(all(
+    feature = "slhdsa",
+    any(not(feature = "fips"), feature = "ossl400")
+))]
 mod slhdsa;
 
 use mechanism::Mechanisms;
@@ -107,7 +112,10 @@ fn register_all(mechs: &mut Mechanisms, ot: &mut ObjectFactories) {
     #[cfg(feature = "mldsa")]
     mldsa::register(mechs, ot);
 
-    #[cfg(feature = "slhdsa")]
+    #[cfg(all(
+        feature = "slhdsa",
+        any(not(feature = "fips"), feature = "ossl400")
+    ))]
     slhdsa::register(mechs, ot);
 
     #[cfg(feature = "fips")]

--- a/src/ossl/common.rs
+++ b/src/ossl/common.rs
@@ -33,7 +33,10 @@ use crate::ossl::mlkem;
 use crate::ossl::montgomery as ecm;
 #[cfg(feature = "rsa")]
 use crate::ossl::rsa;
-#[cfg(feature = "slhdsa")]
+#[cfg(all(
+    feature = "slhdsa",
+    any(not(feature = "fips"), feature = "ossl400")
+))]
 use crate::ossl::slhdsa;
 
 pub fn osslctx() -> &'static OsslContext {
@@ -73,7 +76,10 @@ pub fn evp_pkey_from_object(
         CKK_ML_KEM => return mlkem::mlkem_object_to_pkey(obj, class),
         #[cfg(feature = "mldsa")]
         CKK_ML_DSA => return mldsa::mldsa_object_to_pkey(obj, class),
-        #[cfg(feature = "slhdsa")]
+        #[cfg(all(
+            feature = "slhdsa",
+            any(not(feature = "fips"), feature = "ossl400")
+        ))]
         CKK_SLH_DSA => return slhdsa::slhdsa_object_to_pkey(obj, class),
         _ => return Err(CKR_KEY_TYPE_INCONSISTENT)?,
     }

--- a/src/ossl/mod.rs
+++ b/src/ossl/mod.rs
@@ -51,5 +51,9 @@ pub mod mlkem;
 
 #[cfg(feature = "mldsa")]
 pub mod mldsa;
-#[cfg(feature = "slhdsa")]
+
+#[cfg(all(
+    feature = "slhdsa",
+    any(not(feature = "fips"), feature = "ossl400")
+))]
 pub mod slhdsa;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -359,7 +359,10 @@ mod mlkem;
 #[cfg(feature = "mldsa")]
 mod mldsa;
 
-#[cfg(feature = "slhdsa")]
+#[cfg(all(
+    feature = "slhdsa",
+    any(not(feature = "fips"), feature = "ossl400")
+))]
 mod slhdsa;
 
 mod pkcs11;

--- a/src/tests/simplekdf.rs
+++ b/src/tests/simplekdf.rs
@@ -802,7 +802,10 @@ fn test_derive_pub_from_priv() {
         ],
     });
 
-    #[cfg(feature = "slhdsa")]
+    #[cfg(all(
+        feature = "slhdsa",
+        any(not(feature = "fips"), feature = "ossl400")
+    ))]
     test_cases.push(TestCase {
         name: "SLHDSA",
         gen_mech: CKM_SLH_DSA_KEY_PAIR_GEN,


### PR DESCRIPTION
#### Description

The SLH-DSA module is now only compiled in FIPS builds when the `ossl400` feature is also enabled.

This is necessary because SLH-DSA requires deferred self-tests for FIPS compliance, and these tests are only available with the `ossl400` feature. Non-FIPS builds are unaffected.

Fixes #318 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [x] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
