### PR TITLE
packaging: stop duplicating the license list in comments

### DIFF
--- a/packaging/kryoptic.spec
+++ b/packaging/kryoptic.spec
@@ -23,19 +23,20 @@ Release:        %autorelease
 Summary:        PKCS #11 software token written in Rust
 
 SourceLicense:  GPL-3.0-or-later
-# Apache-2.0
-# Apache-2.0 OR BSL-1.0
-# Apache-2.0 OR MIT
-# BSD-3-Clause
-# GPL-3.0-or-later
-# ISC
-# MIT
-# MIT OR Apache-2.0
-# MIT-0 OR Apache-2.0
-# Unlicense OR MIT
-# Zlib
-License: Apache-2.0 AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (BSD-3-Clause) AND (GPL-3.0-or-later) AND (ISC) AND (MIT) AND (MIT OR Apache-2.0) AND (MIT-0 OR Apache-2.0) AND (Unlicense OR MIT) AND (Zlib)
 # LICENSE.dependencies contains a full license breakdown
+License: %{shrink:
+ Apache-2.0 AND
+ (Apache-2.0 OR BSL-1.0) AND
+ (Apache-2.0 OR MIT) AND
+ BSD-3-Clause AND
+ GPL-3.0-or-later AND
+ ISC AND
+ MIT AND
+ (MIT OR Apache-2.0) AND
+ (MIT-0 OR Apache-2.0) AND
+ (Unlicense OR MIT) AND
+ Zlib
+}
 
 URL:            https://github.com/latchset/kryoptic
 Source0:        https://github.com/latchset/kryoptic/releases/download/v%{version}/%{name}-%{version}.tar.gz


### PR DESCRIPTION
#### Description

This eliminates the need for license duplication in the RPM spec file

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] ~~Test suite updated with functionality tests~~
- [ ] ~~Test suite updated with negative tests~~
- [ ] ~~Rustdoc string were added or updated~
- [ ] ~~CHANGELOG and/or other documentation added or updated~~
- [x] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
