### PR TITLE
Use standard CKR_TOKEN_NOT_INITIALIZED error

### DIFF
--- a/src/pkcs11/vendor.rs
+++ b/src/pkcs11/vendor.rs
@@ -17,7 +17,9 @@ pub const KRA_LOGIN_ATTEMPTS: CK_ATTRIBUTE_TYPE = KRY_VENDOR_OFFSET + 2;
 /* + 10 taken by pkcs11/validation_draft.rs */
 
 /* Errors */
-pub const KRR_TOKEN_NOT_INITIALIZED: CK_ULONG = KRY_VENDOR_OFFSET + 1;
+/* R.I.P. KRR_TOKEN_NOT_INITIALIZED (1),
+ * you served us well (replaced by CKR_TOKEN_NOT_INITIALIZED)
+ */
 pub const KRR_SLOT_CONFIG: CK_ULONG = KRY_VENDOR_OFFSET + 2;
 pub const KRR_CONFIG_ERROR: CK_ULONG = KRY_VENDOR_OFFSET + 3;
 

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -11,7 +11,6 @@ use crate::config;
 use crate::defaults;
 use crate::error::Result;
 use crate::misc::copy_sized_string;
-use crate::pkcs11::vendor::KRR_TOKEN_NOT_INITIALIZED;
 use crate::pkcs11::*;
 use crate::session::Session;
 use crate::token::Token;
@@ -111,9 +110,7 @@ impl Slot {
                 if token.is_initialized() {
                     Ok(token)
                 } else {
-                    /* FIXME: once we have CKR_TOKEN_NOT_INITIALIZED as an
-                     * available error, we should rreturn that instead */
-                    Err(KRR_TOKEN_NOT_INITIALIZED)?
+                    Err(CKR_TOKEN_NOT_INITIALIZED)?
                 }
             }
             Err(_) => Err(CKR_GENERAL_ERROR)?,
@@ -134,9 +131,7 @@ impl Slot {
                 } else if token.is_initialized() {
                     Ok(token)
                 } else {
-                    /* FIXME: once we have CKR_TOKEN_NOT_INITIALIZED as an
-                     * available error, we should rreturn that instead */
-                    Err(KRR_TOKEN_NOT_INITIALIZED)?
+                    Err(CKR_TOKEN_NOT_INITIALIZED)?
                 }
             }
             Err(_) => Err(CKR_GENERAL_ERROR)?,


### PR DESCRIPTION
#### Description

Replace the custom vendor error `KRR_TOKEN_NOT_INITIALIZED` with the standard PKCS#11 error `CKR_TOKEN_NOT_INITIALIZED`.

This resolves a FIXME and improves compliance with the PKCS#11 standard by using a standard error code where appropriate.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
