### PR TITLE
NSS-kryoptic integration finds

### DIFF
--- a/src/fns/keymgmt.rs
+++ b/src/fns/keymgmt.rs
@@ -534,10 +534,38 @@ fn derive_key(
      * because we think this operation should alays be possible regardless
      * of whether private key should generally allow key derivation. This
      * is our (Kryoptic team) interpretation and may change if/when the
-     * OASIS PKCS#11 TC clarifies the spec in this regard */
-    if mechanism.mechanism != CKM_PUB_KEY_FROM_PRIV_KEY {
-        if !key.get_attr_as_bool(CKA_DERIVE)? {
-            return Err(CKR_KEY_FUNCTION_NOT_PERMITTED)?;
+     * OASIS PKCS#11 TC clarifies the spec in this regard.
+     * We also allow HKDF derivation from a DATA object if specific
+     * conditions are met. */
+    match mechanism.mechanism {
+        CKM_PUB_KEY_FROM_PRIV_KEY => (),
+        CKM_HKDF_DERIVE | CKM_HKDF_DATA => {
+            if key.get_class() == CKO_DATA {
+                let params = mechanism.get_parameters::<CK_HKDF_PARAMS>()?;
+                /* 1. Must be used for the extract phase */
+                if params.bExtract == CK_FALSE {
+                    return Err(CKR_MECHANISM_PARAM_INVALID)?;
+                }
+                /* 2. CKA_VALUE length must be the same size as the underlying hash */
+                let hlen = crate::hash::hash_size(params.prfHashMechanism);
+                let klen = key.get_attr_as_bytes(CKA_VALUE)?.len();
+                if hlen == crate::hash::INVALID_HASH_SIZE || hlen != klen {
+                    return Err(CKR_MECHANISM_PARAM_INVALID)?;
+                }
+                /* 3. A non-null salt must be provided */
+                if params.ulSaltType == CKF_HKDF_SALT_NULL
+                    || params.pSalt.is_null()
+                {
+                    return Err(CKR_MECHANISM_PARAM_INVALID)?;
+                }
+            } else if !key.get_attr_as_bool(CKA_DERIVE)? {
+                return Err(CKR_KEY_FUNCTION_NOT_PERMITTED)?;
+            }
+        }
+        _ => {
+            if !key.get_attr_as_bool(CKA_DERIVE)? {
+                return Err(CKR_KEY_FUNCTION_NOT_PERMITTED)?;
+            }
         }
     }
 

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -10,7 +10,10 @@ use std::sync::LazyLock;
 
 use crate::error::Result;
 use crate::mechanism::{Derive, Mechanism, Mechanisms};
-use crate::object::{GenericSecretKeyMechanism, ObjectFactories};
+use crate::object::{
+    GenericSecretKeyFactory, GenericSecretKeyMechanism, ObjectFactories,
+    ObjectFactory, ObjectType,
+};
 use crate::ossl::hkdf::HKDFOperation;
 use crate::pkcs11::*;
 
@@ -28,12 +31,19 @@ static HKDF_MECHS: LazyLock<[Box<dyn Mechanism>; 2]> = LazyLock::new(|| {
     ]
 });
 
+static HKDF_KEY_FACTORY: LazyLock<Box<dyn ObjectFactory>> =
+    LazyLock::new(|| Box::new(GenericSecretKeyFactory::new()));
+
 /// Registers all HKDF related mechanisms
-pub fn register(mechs: &mut Mechanisms, _: &mut ObjectFactories) {
+pub fn register(mechs: &mut Mechanisms, ot: &mut ObjectFactories) {
     for ckm in &[CKM_HKDF_DERIVE, CKM_HKDF_DATA] {
         mechs.add_mechanism(*ckm, &(*HKDF_MECHS)[0]);
     }
     mechs.add_mechanism(CKM_HKDF_KEY_GEN, &(*HKDF_MECHS)[1]);
+    ot.add_factory(
+        ObjectType::new(CKO_SECRET_KEY, CKK_HKDF),
+        &(*HKDF_KEY_FACTORY),
+    );
 }
 
 /// Object that represents the HKDF mechanism

--- a/src/ossl/hash.rs
+++ b/src/ossl/hash.rs
@@ -111,9 +111,6 @@ impl Digest for HashOperation {
     }
 
     fn digest_final(&mut self, digest: &mut [u8]) -> Result<()> {
-        if !self.in_use {
-            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
-        }
         if self.finalized {
             return Err(CKR_OPERATION_NOT_INITIALIZED)?;
         }

--- a/src/tests/kdfs.rs
+++ b/src/tests/kdfs.rs
@@ -1189,3 +1189,124 @@ fn test_sshkdf() {
 
     testtokn.finalize();
 }
+
+#[cfg(feature = "hkdf")]
+#[test]
+#[parallel]
+fn test_hkdf_from_data_object() {
+    let mut testtokn =
+        TestToken::initialized("test_hkdf_from_data_object", None);
+    let session = testtokn.get_session(true);
+
+    /* login */
+    testtokn.login();
+
+    /* 1. Create a CKO_DATA object (32 bytes) */
+    let data_ikm = [0xabu8; 32];
+    let data_handle = ret_or_panic!(import_object(
+        session,
+        CKO_DATA,
+        &[],
+        &[(CKA_VALUE, data_ikm.as_slice())],
+        &[],
+    ));
+
+    let salt_data = "SALT";
+    let hkdf_params = CK_HKDF_PARAMS {
+        bExtract: CK_TRUE,
+        bExpand: CK_TRUE,
+        prfHashMechanism: CKM_SHA256,
+        ulSaltType: CKF_HKDF_SALT_DATA,
+        pSalt: byte_ptr!(salt_data.as_ptr()),
+        ulSaltLen: salt_data.len() as CK_ULONG,
+        hSaltKey: CK_INVALID_HANDLE,
+        pInfo: std::ptr::null_mut(),
+        ulInfoLen: 0,
+    };
+
+    let mut derive_mech = CK_MECHANISM {
+        mechanism: CKM_HKDF_DERIVE,
+        pParameter: void_ptr!(&hkdf_params),
+        ulParameterLen: sizeof!(CK_HKDF_PARAMS),
+    };
+
+    let mut derive_template = make_attr_template(
+        &[
+            (CKA_CLASS, CKO_SECRET_KEY),
+            (CKA_KEY_TYPE, CKK_GENERIC_SECRET),
+            (CKA_VALUE_LEN, 32),
+        ],
+        &[],
+        &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
+    );
+
+    let mut drv_handle = CK_INVALID_HANDLE;
+
+    /* Valid case: should work */
+    let ret = fn_derive_key(
+        session,
+        &mut derive_mech,
+        data_handle,
+        derive_template.as_mut_ptr(),
+        derive_template.len() as CK_ULONG,
+        &mut drv_handle,
+    );
+    assert_eq!(ret, CKR_OK);
+
+    /* 2. Invalid case: bExtract = false */
+    {
+        let mut params = hkdf_params;
+        params.bExtract = CK_FALSE;
+        let mut mech = derive_mech;
+        mech.pParameter = void_ptr!(&params);
+        let ret = fn_derive_key(
+            session,
+            &mut mech,
+            data_handle,
+            derive_template.as_mut_ptr(),
+            derive_template.len() as CK_ULONG,
+            &mut drv_handle,
+        );
+        assert_eq!(ret, CKR_MECHANISM_PARAM_INVALID);
+    }
+
+    /* 3. Invalid case: Wrong size (data object is 32, hash is SHA256 (32), but let's change data size) */
+    let small_data_ikm = [0xabu8; 16];
+    let small_data_handle = ret_or_panic!(import_object(
+        session,
+        CKO_DATA,
+        &[],
+        &[(CKA_VALUE, small_data_ikm.as_slice())],
+        &[],
+    ));
+    let ret = fn_derive_key(
+        session,
+        &mut derive_mech,
+        small_data_handle,
+        derive_template.as_mut_ptr(),
+        derive_template.len() as CK_ULONG,
+        &mut drv_handle,
+    );
+    assert_eq!(ret, CKR_MECHANISM_PARAM_INVALID);
+
+    /* 4. Invalid case: Null salt */
+    {
+        let mut params = hkdf_params;
+        params.ulSaltType = CKF_HKDF_SALT_NULL;
+        params.pSalt = std::ptr::null_mut();
+        params.ulSaltLen = 0;
+        let mut mech = derive_mech;
+        mech.pParameter = void_ptr!(&params);
+        let ret = fn_derive_key(
+            session,
+            &mut mech,
+            data_handle,
+            derive_template.as_mut_ptr(),
+            derive_template.len() as CK_ULONG,
+            &mut drv_handle,
+        );
+        assert_eq!(ret, CKR_MECHANISM_PARAM_INVALID);
+    }
+
+    testtokn.finalize();
+}


### PR DESCRIPTION
#### Description
This PR implements logic to permit `CKO_DATA` objects to be used directly as input key material for HKDF derivation (`CKM_HKDF_DERIVE` and `CKM_HKDF_DATA`), safely bypassing the standard `CKA_DERIVE` check. This aligns with PKCS#11 extraction phase constraints, enabling data objects to be employed provided `bExtract` is set to TRUE, the exact size matches the HMAC hash length, and a non-null salt is supplied.
Additionally, this PR includes:
- Registration of the `GenericSecretKeyFactory` for the `CKK_HKDF` key type to ensure these secret keys can be correctly instantiated.
- Removal of the overly restrictive `in_use` check inside the OpenSSL `HashOperation` wrapper, properly enabling the finalization of digest operations (and HKDF derivations) on empty data streams.
- Comprehensive testing in `src/tests/kdfs.rs` validating success and failure requirements of HKDF derivation from `CKO_DATA` objects.

#### Checklist
- [ ] Test suite updated
- [ ] Rustdoc string were added or updated *(N/A: Only internal logic and tests were touched)*
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change *(N/A: It is a code change)*
#### Reviewer's checklist:
- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated *(N/A: No public APIs had their signatures changed)*