### PR TITLE
Add docs.rs CI workflow

### DIFF
--- a/.github/workflows/docsrs.yml
+++ b/.github/workflows/docsrs.yml
@@ -1,0 +1,29 @@
+name: build docs with docs-rs
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+jobs:
+  doc:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+    steps:
+      - name: Install dependencies
+        run: sudo apt-get install libssl-dev
+
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Checkout Nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Checkout Cargo-docs-rs
+        uses: dtolnay/install@cargo-docs-rs
+
+      - name: Build Docs
+        run: cargo docs-rs


### PR DESCRIPTION
#### Description

Add a GitHub Actions workflow to automatically build project documentation using cargo docs-rs on pushes and pull requests.

This ensures the documentation builds correctly in an environment similar to docs.rs and uses the nightly toolchain with warnings denied to catch documentation issues early in CI.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] Test suite updated
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [x] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
