### PR TITLE
Add Kryoptic user guide

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -43,8 +43,10 @@ jobs:
         run: |
           if [ "${{ matrix.name }}" = "centos10" ]; then
             dnf -y install rustc rpm-build openssl-devel cargo rust-toolset sqlite-devel clang git
+            dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+            dnf -y install pandoc
           else
-            dnf -y install rustc rpm-build cargo-rpm-macros openssl-devel git \
+            dnf -y install rustc rpm-build cargo-rpm-macros openssl-devel git pandoc \
                 'crate(asn1/default)' 'crate(bimap/default)' 'crate(bindgen/default) >= 0.72.0' \
                 'crate(bitflags/default)' 'crate(cfg-if/default)' \
                 'crate(clap)' 'crate(clap/cargo)' 'crate(clap/derive)' 'crate(clap/help)' \

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,11 @@ tags
 *.tar.gz.asc
 cdylib/*.sql
 cdylib/target
+*.1
+*.2
+*.3
+*.4
+*.5
+*.6
+*.7
+*.8

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,11 @@ docs:
 docs-fips:
 	cargo doc --no-default-features --features fips --document-private-items
 
+manpages:
+	pandoc -s -t man doc/kryoptic.conf.man.md -o kryoptic.conf.5
+	pandoc -s -t man doc/kryoptic.man.md -o kryoptic.7
+	pandoc -s -t man tools/softhsm/softhsm_migrate.man.md -o softhsm_migrate.1
+
 .ONESHELL:
 SHELL = /bin/bash
 scope:

--- a/doc/User_Guide.md
+++ b/doc/User_Guide.md
@@ -1,0 +1,147 @@
+# Kryoptic for Users
+
+## What is Kryoptic ?
+
+Kryoptic is a PKCS#11 soft token written in Rust. It uses OpenSSL for cryptography and supports multiple storage backends, such as SQLite and NSS DB.
+
+## Module Initialization
+
+Kryoptic is built as a dynamic library (`libkryoptic_pkcs11.so`) that can be loaded by applications expecting a PKCS#11 module. 
+
+Applications initialize the token via the `C_Initialize()` function. Kryoptic can process custom configurations passed through the reserved argument in `C_Initialize()`:
+* **Config file path:** By passing a string like `kryoptic_conf=/path/to/config.toml`.
+* **Legacy SQLite path:** By directly passing the path to an SQLite database file ending in `.sql` (e.g., `/path/to/database.sql`).
+* **NSS config directory:** By passing an NSS-style argument string containing `configDir=...`.
+
+If no arguments are provided, Kryoptic falls back to searching for a TOML configuration file in predefined locations (e.g. /home/user/.config/kryoptic/token.conf).
+
+## Environment variables
+
+### Build Environment Variables
+* `CONFDIR`: The directory where to search the default configuration. Defaults to `/usr/local/etc` if not provided.
+* `KRYOPTIC_OPENSSL_SOURCES`: Path where OpenSSL sources are unpacked, used to statically link OpenSSL instead of using the system's dynamic libraries.
+* `OSSL_BINDGEN_CLANG_ARGS`: Additional arguments passed into bindgen.
+* `KRYOPTIC_FIPS_VENDOR`, `KRYOPTIC_FIPS_VERSION`, `KRYOPTIC_FIPS_BUILD`: Specifies the name, version, and additional build information returned by the embedded OpenSSL FIPS provider (requires FIPS build).
+
+### Runtime Environment Variables
+* `KRYOPTIC_CONF`: The path to the Kryoptic configuration file. This has the highest precedence.
+* `XDG_CONFIG_HOME`: Used as a fallback if `KRYOPTIC_CONF` is not set. Kryoptic will look for `${XDG_CONFIG_HOME}/kryoptic/token.conf`.
+* `HOME`: Used as a fallback if `XDG_CONFIG_HOME` is not set. Kryoptic will look for `${HOME}/.config/kryoptic/token.conf`.
+* `KRYOPTIC_EC_POINT_ENCODING`: Can be used to override the `ec_point_encoding` specified in the configuration file. Valid values are `BYTES` or `DER`. This is useful when multiple applications use the same configuration file but expect different behaviors.
+
+## Configuration Options
+
+Kryoptic is typically configured using a TOML file. The main structure consists of global options and a list of independent slots. Slots cannot share the same storage.
+
+**Note:** When a token storage SQL file is provided as the configuration option, an internal configuration is automatically generated, and the first available slot is assigned.
+
+**Note:** Multiple tokens can be loaded via repeated invocations of `C_Initialize` using custom arguments. While configurations passed this way are useful for testing environments, they should be avoided in production. A comprehensive configuration file should be provided instead, as conflicts between configurations provided on the fly will cause initialization errors.
+
+### Global Options
+
+* `ec_point_encoding`: Allows setting a global default encoding for `CKA_EC_POINT` attributes, useful for applications that expect DER encoded EC Points. Values can be `Bytes` or `Der` (Default: `Bytes`).
+
+### Slot Options (`[[slots]]`)
+
+Each slot represents an idealized hardware slot for cryptographic operations and storage. It is defined within a `[[slots]]` block.
+
+* `slot`: (Integer) The slot number identifier.
+* `description`: (String, optional) The slot's description. A default one is returned if not provided.
+* `manufacturer`: (String, optional) The slot's manufacturer string. A default one is returned if not provided.
+* `dbtype`: (String) The token type / storage implementation (e.g., `"sqlite"`, `"nssdb"`).
+* `dbargs`: (String) Storage specific configuration options. For example, the path to the token's database.
+* `mechanisms`: (Array of Strings, optional) List of allowed mechanisms. It can be an allow list (e.g., `["CKM_SHA256"]`) to expose only the explicitly mentioned mechanisms. It can also act as a deny list if the exact string `"DENY"` is the first element (e.g., `["DENY", "CKM_SHA256"]`). Using `"DENY"` in any position other than the first is an error.
+* `fips_behavior`: (Table, optional) Tweaks for behavior in FIPS mode.
+  * `keys_always_sensitive`: (Boolean) Changes the behavior of the token in the slot to always enforce keys to be private/sensitive. (For NSS DB, this typically defaults to true).
+
+### Example Configuration
+
+```toml
+[ec_point_encoding]
+encoding = "Bytes"
+
+[[slots]]
+slot = 1
+dbtype = "sqlite"
+dbargs = "/var/lib/kryoptic/token.sql"
+mechanisms = ["DENY", "CKM_SHA256"]
+
+[[slots]]
+slot = 2
+dbtype = "nssdb"
+dbargs = "configDir=/etc/pki/nssdb"
+```
+
+## Example Uses
+
+### Using pkcs11-tool to initialize a new token
+
+You can use OpenSC's `pkcs11-tool` to initialize a token and set its PIN. Make sure you specify the `kryoptic` library using the `--module` argument.
+
+**Note:** The user and SO PINs do not need to be just numerical; any strong passphrase can be used.
+
+```bash
+# Initialize a token and set the SO PIN
+pkcs11-tool --module /path/to/libkryoptic_pkcs11.so \
+    --init-token \
+    --label "MyToken" \
+    --so-pin 123456
+
+# Initialize the User PIN
+pkcs11-tool --module /path/to/libkryoptic_pkcs11.so \
+    --init-pin \
+    --login --login-type so --so-pin 123456 \
+    --pin 1234
+```
+
+### Using OpenSSL with pkcs11-provider
+
+You can use `kryoptic` with `openssl` by utilizing the `pkcs11-provider` module. To do this, configure OpenSSL to load the `pkcs11` provider via its configuration file. 
+
+Here is an example `openssl.cnf` snippet demonstrating how to configure the `pkcs11-provider` with `kryoptic`. We prioritize using an environment variable expansion within the OpenSSL configuration for defining the `kryoptic` module path for flexibility:
+
+```ini
+[...]
+
+[provider_sect]
+default = default_sect
+base = base_sect
+pkcs11 = pkcs11_sect
+
+[base_sect]
+activate = 1
+
+[default_sect]
+activate = 1
+
+[pkcs11_sect]
+module = pkcs11
+pkcs11-module-path = /usr/lib/pkcs11/libkryoptic_pkcs11.so
+activate = 1
+
+[...]
+```
+
+Here is an example demonstrating how to configure the environment and use `openssl` to generate a key pair and sign a certificate, similarly to how it's tested in the `pkcs11-provider` setup scripts:
+
+```bash
+# Optionally point the OpenSSL configuration to the kryoptic module via the environment variable
+export PKCS11_PROVIDER_MODULE=/path/to/libkryoptic_pkcs11.so
+
+# If a custom config file is used point OpenSSL at it.
+export OPENSSL_CONF=/path/to/openssl.cnf
+
+# Generate a new EC key pair directly in the token
+openssl genpkey -propquery "provider=pkcs11" \
+    -algorithm EC \
+    -pkeyopt "ec_paramgen_curve:prime256v1" \
+    -pkeyopt "pkcs11_uri:pkcs11:token=MyToken;object=my-ec-key"
+
+# Create a self-signed certificate using the key stored in the token.
+# Note: The URI is passed directly to the -signkey argument.
+openssl x509 -new \
+    -subj "/O=My Organization/CN=My Cert/" \
+    -days 365 \
+    -out cert.crt \
+    -signkey "pkcs11:token=MyToken;object=my-ec-key;type=private?pin-value=1234"
+```

--- a/doc/kryoptic.conf.man.md
+++ b/doc/kryoptic.conf.man.md
@@ -1,0 +1,103 @@
+% KRYOPTIC.CONF(5)
+% 
+% 
+
+# NAME
+
+kryoptic.conf - Configuration file for the Kryoptic PKCS#11 module
+
+# SYNOPSIS
+
+**/etc/kryoptic/token.conf**
+
+**${XDG_CONFIG_HOME}/kryoptic/token.conf**
+
+**${HOME}/.config/kryoptic/token.conf**
+
+# DESCRIPTION
+
+The **kryoptic.conf** file is a TOML-formatted configuration file used by the Kryoptic PKCS#11 module. It allows configuring global settings and provisioning multiple independent slots, each representing an idealized hardware slot where a cryptographic token can be utilized.
+
+Kryoptic searches for the configuration file in the following order:
+
+1. The path specified by the **KRYOPTIC_CONF** environment variable.
+2. **${XDG_CONFIG_HOME}/kryoptic/token.conf** (if the **XDG_CONFIG_HOME** environment variable is set).
+3. **${HOME}/.config/kryoptic/token.conf** (if the **HOME** environment variable is set).
+4. A system-wide directory, typically **/usr/local/etc/kryoptic/token.conf** or **/etc/kryoptic/token.conf** depending on build-time configuration.
+
+# GLOBAL OPTIONS
+
+**[ec_point_encoding]**
+:   Allows setting a global default encoding for `CKA_EC_POINT` attributes to maintain compatibility with applications that expect specific encodings (e.g., DER encoded EC Points).
+
+    **encoding** = *string*
+    :   Valid values are **"Bytes"** or **"Der"**. The default is **"Bytes"**.
+        This can be overridden at runtime by setting the **KRYOPTIC_EC_POINT_ENCODING** environment variable.
+
+# SLOT CONFIGURATION
+
+Tokens are configured by defining one or more `[[slots]]` sections. In Kryoptic, slots provide independent tokens with their own separate storage. Slots cannot share the same storage.
+
+**[[slots]]**
+
+**slot** = *integer*
+:   *(Required)* The slot number (a 32-bit unsigned integer) identifying this slot.
+
+**description** = *string*
+:   *(Optional)* A customized description for the slot. If not provided, a default description is returned to PKCS#11 applications.
+
+**manufacturer** = *string*
+:   *(Optional)* A customized manufacturer string. If not provided, a default string is used.
+
+**dbtype** = *string*
+:   *(Required)* The storage implementation (token type) for the slot (e.g., **"sqlite"**, **"nssdb"**).
+
+**dbargs** = *string*
+:   *(Required)* Storage-specific configuration options. For example, the path to a SQLite database file (e.g., `"/var/lib/kryoptic/token.sql"`).
+
+**mechanisms** = *array of strings*
+:   *(Optional)* A list of allowed or denied mechanisms, altering the mechanisms this token claims to implement.
+    
+    By default, this acts as an *allow list* (e.g., `["CKM_SHA256", "CKM_RSA_PKCS"]`), making only the explicitly mentioned mechanisms available.
+    
+    To configure a *deny list*, the first element must be the exact string `"DENY"`, followed by the mechanisms to be removed (e.g., `["DENY", "CKM_SHA256"]`). Using `"DENY"` in any position other than the first is not supported and will cause an error.
+
+**[slots.fips_behavior]**
+:   *(Optional)* Add tweaks for behavior in FIPS mode.
+
+    **keys_always_sensitive** = *boolean*
+    :   Changes the behavior of the token in the slot to always enforce keys to be private/sensitive. The default is **false** (unless `dbtype` is `"nssdb"`, which defaults to **true**).
+
+# ENVIRONMENT VARIABLES
+
+**KRYOPTIC_CONF**
+:   Specifies the exact path to the **kryoptic.conf** file, bypassing default search paths. It is strongly advised to set this variable for most use cases.
+
+**KRYOPTIC_EC_POINT_ENCODING**
+:   Overrides the `ec_point_encoding.encoding` setting specified in the configuration file. Valid values are **"BYTES"** or **"DER"**.
+
+# EXAMPLES
+
+Below is an example of a **kryoptic.conf** file configuring two slots and specifying EC point encoding:
+
+```toml
+[ec_point_encoding]
+encoding = "Der"
+
+[[slots]]
+slot = 1
+description = "My SQLite Token"
+manufacturer = "Kryoptic"
+dbtype = "sqlite"
+dbargs = "/var/lib/kryoptic/token.sql"
+mechanisms = ["DENY", "CKM_MD5"]
+
+[[slots]]
+slot = 2
+dbtype = "nssdb"
+dbargs = "configDir=/etc/pki/nssdb"
+```
+
+# SEE ALSO
+
+**kryoptic**(7), **softhsm_migrate**(1)

--- a/doc/kryoptic.man.md
+++ b/doc/kryoptic.man.md
@@ -1,0 +1,47 @@
+% KRYOPTIC(7)
+% 
+% 
+
+# NAME
+
+kryoptic - A PKCS#11 soft token written in Rust
+
+# SYNOPSIS
+
+**libkryoptic_pkcs11.so**
+
+# DESCRIPTION
+
+**Kryoptic** is a PKCS#11 software token implemented in Rust. It utilizes OpenSSL for cryptographic operations and provides support for multiple storage backends, including SQLite and NSS DB. It is distributed as a dynamic library (`libkryoptic_pkcs11.so`) that can be loaded by applications expecting a standard PKCS#11 module.
+
+Kryoptic aims to provide a modern, secure, and flexible software token. It can be built to use the system OpenSSL dynamically or can be statically linked. It also includes support for FIPS 140-3 builds (when linked against OpenSSL's `libfips.a`), restricting algorithms and enforcing FIPS approved behaviors.
+
+# INITIALIZATION
+
+Applications initialize the Kryoptic token via the standard PKCS#11 `C_Initialize()` function. Kryoptic can process custom configurations passed through the reserved argument in `C_Initialize()`, allowing flexible initialization methods:
+
+* **Config file path:** e.g., `kryoptic_conf=/path/to/config.toml`
+* **Legacy SQLite path:** e.g., `/path/to/database.sql`
+* **NSS config directory:** e.g., `configDir=/etc/pki/nssdb`
+
+If no explicit arguments are provided, Kryoptic falls back to searching for its TOML configuration file in predefined system and user locations.
+
+# ENVIRONMENT VARIABLES
+
+Several environment variables affect the runtime behavior of Kryoptic:
+
+**KRYOPTIC_CONF**
+:   The path to the Kryoptic configuration file. This has the highest precedence.
+
+**XDG_CONFIG_HOME**
+:   Used as a fallback if **KRYOPTIC_CONF** is not set. Kryoptic will look for `${XDG_CONFIG_HOME}/kryoptic/token.conf`.
+
+**HOME**
+:   Used as a fallback if **XDG_CONFIG_HOME** is not set. Kryoptic will look for `${HOME}/.config/kryoptic/token.conf`.
+
+**KRYOPTIC_EC_POINT_ENCODING**
+:   Can be used to override the default `ec_point_encoding` specified in the configuration file. Valid values are **BYTES** or **DER**.
+
+# SEE ALSO
+
+**kryoptic.conf**(5), **softhsm_migrate**(1)

--- a/packaging/kryoptic.spec
+++ b/packaging/kryoptic.spec
@@ -48,6 +48,7 @@ Source4:        https://people.redhat.com/~ssorce/simo_redhat.asc
 %endif
 
 BuildRequires:  openssl-devel
+BuildRequires:  pandoc
 %if %{with gpgcheck}
 BuildRequires: gnupg2
 %endif
@@ -99,12 +100,20 @@ export CONFDIR=%{_sysconfdir}
 %{cargo_license_summary -f %{features}}
 %{cargo_license -f %{features}} > LICENSE.dependencies
 
+pandoc -s -t man doc/kryoptic.conf.man.md -o kryoptic.conf.5
+pandoc -s -t man doc/kryoptic.man.md -o kryoptic.7
+pandoc -s -t man tools/softhsm/softhsm_migrate.man.md -o softhsm_migrate.1
+
 %install
 install -Dp target/rpm/softhsm_migrate $RPM_BUILD_ROOT%{_bindir}/softhsm_migrate
 install -Dp target/rpm/%{soname}.so $RPM_BUILD_ROOT%{_libdir}/pkcs11/%{soname}.so
 
 mkdir -p $RPM_BUILD_ROOT%{_datadir}/p11-kit/modules/
 echo "module: %{soname}.so" > $RPM_BUILD_ROOT%{_datadir}/p11-kit/modules/kryoptic.module
+
+install -Dp -m 0644 kryoptic.conf.5 $RPM_BUILD_ROOT%{_mandir}/man5/kryoptic.conf.5
+install -Dp -m 0644 kryoptic.7 $RPM_BUILD_ROOT%{_mandir}/man7/kryoptic.7
+install -Dp -m 0644 softhsm_migrate.1 $RPM_BUILD_ROOT%{_mandir}/man1/softhsm_migrate.1
 
 %if %{with check}
 %check
@@ -122,10 +131,13 @@ export TEST_PKCS11_MODULE=$RPM_BUILD_ROOT%{_libdir}/pkcs11/%{soname}.so
 %dir %{_datadir}/p11-kit
 %dir %{_datadir}/p11-kit/modules
 %{_datadir}/p11-kit/modules/kryoptic.module
+%{_mandir}/man5/kryoptic.conf.5*
+%{_mandir}/man7/kryoptic.7*
 
 
 %files tools
 %{_bindir}/softhsm_migrate
+%{_mandir}/man1/softhsm_migrate.1*
 
 %changelog
 %autochangelog

--- a/tools/softhsm/softhsm_migrate.man.md
+++ b/tools/softhsm/softhsm_migrate.man.md
@@ -1,0 +1,62 @@
+# NAME
+
+softhsm_migrate - migrate SoftHSM v2 tokens to a PKCS#11 module
+
+# SYNOPSIS
+
+**softhsm_migrate** \[**-m**|**--pkcs11-module** _MODULE_\] \[**-i**|**--pkcs11-initargs** _INITARGS_\] \[**-p**|**--pkcs11-pin** _PIN_\] \[**-s**|**--pkcs11-slot** _SLOT_\] **-q**|**--softhsm2-pin** _PIN_ _SOFTHSM2_TOKEN_
+
+# DESCRIPTION
+
+**softhsm_migrate** reads cryptographic objects (such as keys and certificates) from a SoftHSM v2 token directory and imports them into a target PKCS#11 module, such as Kryoptic. 
+
+It reads the internal SoftHSM v2 `.object` files, uses the provided SoftHSM v2 token PIN to derive the decryption key, decrypts the token's private and secret keys, and creates equivalent objects in the target PKCS#11 token.
+
+# OPTIONS
+
+**-m**, **--pkcs11-module** _MODULE_
+: Path to the target PKCS#11 module shared library.
+
+**-i**, **--pkcs11-initargs** _INITARGS_
+: Initialization arguments passed to the target PKCS#11 module.
+
+**-p**, **--pkcs11-pin** _PIN_
+: PIN used for logging into the target PKCS#11 token.
+
+**-s**, **--pkcs11-slot** _SLOT_
+: Target PKCS#11 slot number.
+
+**-q**, **--softhsm2-pin** _PIN_
+: User PIN of the SoftHSM v2 token. This is required to decrypt the token's private and secret keys.
+
+_SOFTHSM2_TOKEN_
+: Path to the SoftHSM v2 token directory (the directory containing the `token.object` file).
+
+# EXIT STATUS
+
+**0**
+: Success. All objects were migrated successfully.
+
+**1-253**
+: The number of objects that failed to import.
+
+**254 (0xFE)**
+: Fatal error parsing the SoftHSM v2 token or deriving its decryption key.
+
+**255 (0xFF)**
+: Fatal error loading, initializing, or authenticating to the target PKCS#11 module.
+
+# EXAMPLES
+
+Migrate a SoftHSM v2 token to a Kryoptic token:
+
+    softhsm_migrate \
+        -m /usr/lib/libkryoptic_pkcs11.so \
+        -i /etc/kryoptic/kryoptic.conf \
+        -p target_pin \
+        -q softhsm_pin \
+        /var/lib/softhsm/tokens/9a19985a-9037-e9df-657d-9947f7ba2120
+
+# SEE ALSO
+
+**kryoptic**(7), **kryoptic.conf**(5)


### PR DESCRIPTION
#### Description

Adds a new user guide (`doc/User_Guide.md`) to document the configuration and usage of the Kryoptic PKCS#11 soft token.

This documentation is added to provide users with a centralized reference for interacting with the library. It explains supported environment variables, TOML configuration structures (including global and slot-specific options), and provides practical examples for initializing tokens via `pkcs11-tool` and integrating with OpenSSL.

Fixes #441

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] ~Test suite updated~
- [ ] ~Rustdoc string were added or updated~
- [x] CHANGELOG and/or other documentation added or updated
- [x] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
