### PR TITLE
Add tests for trust object modification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,8 +200,10 @@ jobs:
       - name: Show Build configs and logs on error
         if: failure()
         run: |
-          cd ../openssl
-          perl configdata.pm --dump
+          if [ "${{ matrix.linking }}" = "fips" ] || [ "${{ matrix.linking }}" = "static" ]; then
+            cd ../openssl
+            perl configdata.pm --dump
+          fi
 
       - if: ${{ matrix.linking == 'fips' && steps.cache-fips.outputs.cache-hit != 'true' }}
         name: Cache OpenSSL FIPS build

--- a/src/storage/nssdb/attrs.rs
+++ b/src/storage/nssdb/attrs.rs
@@ -4,7 +4,7 @@
 //! This module defines PKCS#11 attribute type constants specific to or
 //! commonly used within NSS databases, including standard, vendor-defined
 //! (NSS), and trust object attributes. It also provides a unified table of
-//! these attributes with their properties (authenticated, sensitive, vendor,
+//! these attributes with their properties (authenticated, sensitive, masked,
 //! skippable, etc.) and helper functions to check attribute classifications.
 
 use crate::pkcs11::*;
@@ -71,8 +71,8 @@ pub struct NssAttributeInfo {
     pub authenticated: bool,
     /// Is a sensitive attribute
     pub sensitive: bool,
-    /// Is an NSS vendor-specific attribute
-    pub vendor: bool,
+    /// Is an NSS vendor-specific attribute that we mask on reads
+    pub masked: bool,
     /// Is an attribute to be skipped (not stored in DB)
     pub skippable: bool,
     /// Is a deprecated attribute
@@ -85,7 +85,7 @@ macro_rules! nssattrinfo_regular {
             attr_type: $attr,
             authenticated: false,
             sensitive: false,
-            vendor: false,
+            masked: false,
             skippable: false,
             deprecated: false,
         }
@@ -98,7 +98,7 @@ macro_rules! nssattrinfo_authenticated {
             attr_type: $attr,
             authenticated: true,
             sensitive: false,
-            vendor: false,
+            masked: false,
             skippable: false,
             deprecated: false,
         }
@@ -111,20 +111,20 @@ macro_rules! nssattrinfo_sensitive {
             attr_type: $attr,
             authenticated: false,
             sensitive: true,
-            vendor: false,
+            masked: false,
             skippable: false,
             deprecated: false,
         }
     };
 }
 
-macro_rules! nssattrinfo_vendor {
+macro_rules! nssattrinfo_masked {
     ($attr:ident) => {
         NssAttributeInfo {
             attr_type: $attr,
             authenticated: false,
             sensitive: false,
-            vendor: true,
+            masked: true,
             skippable: false,
             deprecated: false,
         }
@@ -137,7 +137,7 @@ macro_rules! nssattrinfo_skippable {
             attr_type: $attr,
             authenticated: false,
             sensitive: false,
-            vendor: false,
+            masked: false,
             skippable: true,
             deprecated: false,
         }
@@ -150,20 +150,20 @@ macro_rules! nssattrinfo_deprecated {
             attr_type: $attr,
             authenticated: false,
             sensitive: false,
-            vendor: false,
+            masked: false,
             skippable: false,
             deprecated: true,
         }
     };
 }
 
-macro_rules! nssattrinfo_auth_vendor {
+macro_rules! nssattrinfo_auth_masked {
     ($attr:ident) => {
         NssAttributeInfo {
             attr_type: $attr,
             authenticated: true,
             sensitive: false,
-            vendor: true,
+            masked: true,
             skippable: false,
             deprecated: false,
         }
@@ -328,42 +328,42 @@ pub static ALL_ATTRIBUTES: &[NssAttributeInfo] = &[
     nssattrinfo_authenticated!(CKA_HASH_OF_CERTIFICATE),
     nssattrinfo_regular!(CKA_PUBLIC_CRC64_VALUE),
     nssattrinfo_sensitive!(CKA_SEED),
-    nssattrinfo_vendor!(CKA_NSS_TRUST),
-    nssattrinfo_vendor!(CKA_NSS_URL),
-    nssattrinfo_vendor!(CKA_NSS_EMAIL),
-    nssattrinfo_vendor!(CKA_NSS_SMIME_INFO),
-    nssattrinfo_vendor!(CKA_NSS_SMIME_TIMESTAMP),
-    nssattrinfo_vendor!(CKA_NSS_PKCS8_SALT),
-    nssattrinfo_vendor!(CKA_NSS_PASSWORD_CHECK),
-    nssattrinfo_vendor!(CKA_NSS_EXPIRES),
-    nssattrinfo_vendor!(CKA_NSS_KRL),
-    nssattrinfo_vendor!(CKA_NSS_PQG_COUNTER),
-    nssattrinfo_vendor!(CKA_NSS_PQG_SEED),
-    nssattrinfo_vendor!(CKA_NSS_PQG_H),
-    nssattrinfo_vendor!(CKA_NSS_PQG_SEED_BITS),
-    nssattrinfo_vendor!(CKA_NSS_MODULE_SPEC),
-    nssattrinfo_auth_vendor!(CKA_NSS_OVERRIDE_EXTENSIONS),
-    nssattrinfo_vendor!(CKA_NSS_SERVER_DISTRUST_AFTER),
-    nssattrinfo_vendor!(CKA_NSS_EMAIL_DISTRUST_AFTER),
-    nssattrinfo_vendor!(CKA_NSS_TRUST_DIGITAL_SIGNATURE),
-    nssattrinfo_vendor!(CKA_NSS_TRUST_NON_REPUDIATION),
-    nssattrinfo_vendor!(CKA_NSS_TRUST_KEY_ENCIPHERMENT),
-    nssattrinfo_vendor!(CKA_NSS_TRUST_DATA_ENCIPHERMENT),
-    nssattrinfo_vendor!(CKA_NSS_TRUST_KEY_AGREEMENT),
-    nssattrinfo_vendor!(CKA_NSS_TRUST_KEY_CERT_SIGN),
-    nssattrinfo_vendor!(CKA_NSS_TRUST_CRL_SIGN),
-    nssattrinfo_auth_vendor!(CKA_NSS_TRUST_SERVER_AUTH),
-    nssattrinfo_auth_vendor!(CKA_NSS_TRUST_CLIENT_AUTH),
-    nssattrinfo_auth_vendor!(CKA_NSS_TRUST_CODE_SIGNING),
-    nssattrinfo_auth_vendor!(CKA_NSS_TRUST_EMAIL_PROTECTION),
-    nssattrinfo_vendor!(CKA_NSS_TRUST_IPSEC_END_SYSTEM),
-    nssattrinfo_vendor!(CKA_NSS_TRUST_IPSEC_TUNNEL),
-    nssattrinfo_vendor!(CKA_NSS_TRUST_IPSEC_USER),
-    nssattrinfo_vendor!(CKA_NSS_TRUST_TIME_STAMPING),
-    nssattrinfo_auth_vendor!(CKA_NSS_TRUST_STEP_UP_APPROVED),
-    nssattrinfo_auth_vendor!(CKA_NSS_CERT_SHA1_HASH),
-    nssattrinfo_auth_vendor!(CKA_NSS_CERT_MD5_HASH),
-    nssattrinfo_vendor!(CKA_NSS_DB),
+    nssattrinfo_masked!(CKA_NSS_TRUST),
+    nssattrinfo_masked!(CKA_NSS_URL),
+    nssattrinfo_masked!(CKA_NSS_EMAIL),
+    nssattrinfo_masked!(CKA_NSS_SMIME_INFO),
+    nssattrinfo_masked!(CKA_NSS_SMIME_TIMESTAMP),
+    nssattrinfo_masked!(CKA_NSS_PKCS8_SALT),
+    nssattrinfo_masked!(CKA_NSS_PASSWORD_CHECK),
+    nssattrinfo_masked!(CKA_NSS_EXPIRES),
+    nssattrinfo_masked!(CKA_NSS_KRL),
+    nssattrinfo_masked!(CKA_NSS_PQG_COUNTER),
+    nssattrinfo_masked!(CKA_NSS_PQG_SEED),
+    nssattrinfo_masked!(CKA_NSS_PQG_H),
+    nssattrinfo_masked!(CKA_NSS_PQG_SEED_BITS),
+    nssattrinfo_masked!(CKA_NSS_MODULE_SPEC),
+    nssattrinfo_auth_masked!(CKA_NSS_OVERRIDE_EXTENSIONS),
+    nssattrinfo_masked!(CKA_NSS_SERVER_DISTRUST_AFTER),
+    nssattrinfo_masked!(CKA_NSS_EMAIL_DISTRUST_AFTER),
+    nssattrinfo_masked!(CKA_NSS_TRUST_DIGITAL_SIGNATURE),
+    nssattrinfo_masked!(CKA_NSS_TRUST_NON_REPUDIATION),
+    nssattrinfo_masked!(CKA_NSS_TRUST_KEY_ENCIPHERMENT),
+    nssattrinfo_masked!(CKA_NSS_TRUST_DATA_ENCIPHERMENT),
+    nssattrinfo_masked!(CKA_NSS_TRUST_KEY_AGREEMENT),
+    nssattrinfo_masked!(CKA_NSS_TRUST_KEY_CERT_SIGN),
+    nssattrinfo_masked!(CKA_NSS_TRUST_CRL_SIGN),
+    nssattrinfo_authenticated!(CKA_NSS_TRUST_SERVER_AUTH),
+    nssattrinfo_authenticated!(CKA_NSS_TRUST_CLIENT_AUTH),
+    nssattrinfo_authenticated!(CKA_NSS_TRUST_CODE_SIGNING),
+    nssattrinfo_authenticated!(CKA_NSS_TRUST_EMAIL_PROTECTION),
+    nssattrinfo_masked!(CKA_NSS_TRUST_IPSEC_END_SYSTEM),
+    nssattrinfo_masked!(CKA_NSS_TRUST_IPSEC_TUNNEL),
+    nssattrinfo_masked!(CKA_NSS_TRUST_IPSEC_USER),
+    nssattrinfo_masked!(CKA_NSS_TRUST_TIME_STAMPING),
+    nssattrinfo_authenticated!(CKA_NSS_TRUST_STEP_UP_APPROVED),
+    nssattrinfo_authenticated!(CKA_NSS_CERT_SHA1_HASH),
+    nssattrinfo_authenticated!(CKA_NSS_CERT_MD5_HASH),
+    nssattrinfo_masked!(CKA_NSS_DB),
     // Skippable attributes
     nssattrinfo_skippable!(CKA_ALLOWED_MECHANISMS),
 ];
@@ -376,7 +376,7 @@ fn get_attr_info(attr: CK_ATTRIBUTE_TYPE) -> Option<&'static NssAttributeInfo> {
 /// deprecated and should generally be ignored.
 pub fn ignore_attribute(attr: CK_ATTRIBUTE_TYPE) -> bool {
     get_attr_info(attr)
-        .map(|info| info.vendor || info.deprecated)
+        .map(|info| info.masked || info.deprecated)
         .unwrap_or(false)
 }
 

--- a/src/tests/objects.rs
+++ b/src/tests/objects.rs
@@ -458,6 +458,88 @@ fn test_create_trust_object() {
 
 #[test]
 #[parallel]
+fn test_modify_trust_object() {
+    let mut testtokn = TestToken::initialized("test_modify_trust_object", None);
+    let session = testtokn.get_session(true);
+
+    /* login */
+    testtokn.login();
+
+    let trust_attributes = [
+        CKA_TRUST_SERVER_AUTH,
+        CKA_TRUST_CLIENT_AUTH,
+        CKA_TRUST_CODE_SIGNING,
+        CKA_TRUST_EMAIL_PROTECTION,
+        CKA_TRUST_IPSEC_IKE,
+        CKA_TRUST_TIME_STAMPING,
+        CKA_TRUST_OCSP_SIGNING,
+    ];
+
+    let trust_values = [
+        CKT_TRUST_UNKNOWN,
+        CKT_TRUSTED,
+        CKT_TRUST_ANCHOR,
+        CKT_NOT_TRUSTED,
+        CKT_TRUST_MUST_VERIFY_TRUST,
+    ];
+
+    // Create a trust object
+    let trust_obj = ret_or_panic!(import_object(
+        session,
+        CKO_TRUST,
+        &[(CKA_NAME_HASH_ALGORITHM, CKM_SHA256),],
+        &[
+            (CKA_ISSUER, "Test Issuer".as_bytes()),
+            (CKA_SERIAL_NUMBER, &[0x01, 0x02, 0x03]),
+            (CKA_HASH_OF_CERTIFICATE, &[0; 32]), // dummy 256-bit hash
+        ],
+        &[(CKA_TOKEN, true)],
+    ));
+
+    for &attr in &trust_attributes {
+        for &val in &trust_values {
+            // Modify the trust attribute
+            let mut new_val: CK_ULONG = val;
+            let mut set_template = make_ptrs_template(&[(
+                attr,
+                void_ptr!(&mut new_val),
+                std::mem::size_of::<CK_ULONG>(),
+            )]);
+            let ret = fn_set_attribute_value(
+                session,
+                trust_obj,
+                set_template.as_mut_ptr(),
+                set_template.len() as CK_ULONG,
+            );
+            assert_eq!(ret, CKR_OK);
+
+            // Verify it changed
+            let mut fetched_val: CK_ULONG = 0;
+            let mut attr_template = make_ptrs_template(&[(
+                attr,
+                void_ptr!(&mut fetched_val),
+                std::mem::size_of::<CK_ULONG>(),
+            )]);
+            let ret = fn_get_attribute_value(
+                session,
+                trust_obj,
+                attr_template.as_mut_ptr(),
+                attr_template.len() as CK_ULONG,
+            );
+            assert_eq!(ret, CKR_OK);
+            assert_eq!(fetched_val, val);
+        }
+    }
+
+    // cleanup
+    let ret = fn_destroy_object(session, trust_obj);
+    assert_eq!(ret, CKR_OK);
+
+    testtokn.finalize();
+}
+
+#[test]
+#[parallel]
 #[cfg(feature = "nssdb")]
 fn test_create_nss_trust_object() {
     let mut testtokn =
@@ -554,6 +636,90 @@ fn test_create_nss_trust_object() {
         ),
         CKR_TEMPLATE_INCOMPLETE
     );
+
+    // cleanup
+    let ret = fn_destroy_object(session, trust_obj);
+    assert_eq!(ret, CKR_OK);
+
+    testtokn.finalize();
+}
+
+#[test]
+#[parallel]
+#[cfg(feature = "nssdb")]
+fn test_modify_nss_trust_object() {
+    let mut testtokn =
+        TestToken::initialized("test_modify_nss_trust_object", None);
+    let session = testtokn.get_session(true);
+
+    /* login */
+    testtokn.login();
+
+    use crate::pkcs11::vendor::nss::*;
+
+    let trust_attributes = [
+        CKA_NSS_TRUST_SERVER_AUTH,
+        CKA_NSS_TRUST_CLIENT_AUTH,
+        CKA_NSS_TRUST_CODE_SIGNING,
+        CKA_NSS_TRUST_EMAIL_PROTECTION,
+    ];
+
+    let trust_values = [
+        CKT_NSS_TRUST_UNKNOWN,
+        CKT_NSS_TRUSTED,
+        CKT_NSS_TRUSTED_DELEGATOR,
+        CKT_NSS_NOT_TRUSTED,
+        CKT_NSS_MUST_VERIFY_TRUST,
+    ];
+
+    // Create a trust object
+    let trust_obj = ret_or_panic!(import_object(
+        session,
+        CKO_NSS_TRUST,
+        &[],
+        &[
+            (CKA_ISSUER, "Test Modify Issuer".as_bytes()),
+            (CKA_SERIAL_NUMBER, &[0x01, 0x02, 0x03, 0x04]),
+            (CKA_NSS_CERT_SHA1_HASH, &[0; 20]),
+            (CKA_NSS_CERT_MD5_HASH, &[0; 16]),
+        ],
+        &[(CKA_TOKEN, true)],
+    ));
+
+    for &attr in &trust_attributes {
+        for &val in &trust_values {
+            // Modify the trust attribute
+            let mut new_val: CK_ULONG = val;
+            let mut set_template = make_ptrs_template(&[(
+                attr,
+                void_ptr!(&mut new_val),
+                std::mem::size_of::<CK_ULONG>(),
+            )]);
+            let ret = fn_set_attribute_value(
+                session,
+                trust_obj,
+                set_template.as_mut_ptr(),
+                set_template.len() as CK_ULONG,
+            );
+            assert_eq!(ret, CKR_OK);
+
+            // Verify it changed
+            let mut fetched_val: CK_ULONG = 0;
+            let mut attr_template = make_ptrs_template(&[(
+                attr,
+                void_ptr!(&mut fetched_val),
+                std::mem::size_of::<CK_ULONG>(),
+            )]);
+            let ret = fn_get_attribute_value(
+                session,
+                trust_obj,
+                attr_template.as_mut_ptr(),
+                attr_template.len() as CK_ULONG,
+            );
+            assert_eq!(ret, CKR_OK);
+            assert_eq_with!(format!("{:#x}", attr), fetched_val, val);
+        }
+    }
 
     // cleanup
     let ret = fn_destroy_object(session, trust_obj);

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -57,6 +57,17 @@ macro_rules! assert_in {
     };
 }
 
+macro_rules! assert_eq_with {
+    ($context:expr, $ret:expr, $val:expr) => {
+        if ($ret != $val) {
+            panic!(
+                "values do not match for test ({}): {} != {}",
+                $context, $ret, $val
+            );
+        }
+    };
+}
+
 pub fn decrypt(
     session: CK_SESSION_HANDLE,
     key: CK_OBJECT_HANDLE,

--- a/testdata/openjdk/jtreg-kryoptic.sh
+++ b/testdata/openjdk/jtreg-kryoptic.sh
@@ -59,6 +59,14 @@ then
     export JTREG="${OPENJDK}"/deps/jtreg
 fi
 
+ptool() {
+    # NSS uses the second slot for certificates, so we need to provide the token
+    # label in the args to allow pkcs11-tool to find the right slot
+    CMDOPTS=(--module="${P11LIB}")
+    CMDOPTS+=("$@")
+    pkcs11-tool "${CMDOPTS[@]}"
+}
+
 # Initialize Kryoptic token.
 export TESTSSRCDIR="${PKCS11_PROVIDER}"/tests
 # Note intentional extra "P" in "TMPPDIR".


### PR DESCRIPTION
#### Description

This adds tests for both standard and NSS-specific trust objects to verify that their attributes can be successfully modified after creation. The new tests ensure that the PKCS#11 implementation correctly processes `C_SetAttributeValue` for trust-related fields (such as server authentication and code signing) and that the updated values can be retrieved.

Fixes #445

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite updated
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [x] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
