### PR TITLE
Verify attributes in trust object tests

### DIFF
--- a/src/tests/objects.rs
+++ b/src/tests/objects.rs
@@ -291,6 +291,37 @@ fn test_create_trust_object() {
         &[(CKA_TOKEN, true)],
     ));
 
+    let mut server_auth: CK_ULONG = 0;
+    let mut client_auth: CK_ULONG = 0;
+    let mut hash_alg: CK_ULONG = 0;
+    let mut attr_template = make_ptrs_template(&[
+        (
+            CKA_TRUST_SERVER_AUTH,
+            void_ptr!(&mut server_auth),
+            std::mem::size_of::<CK_ULONG>(),
+        ),
+        (
+            CKA_TRUST_CLIENT_AUTH,
+            void_ptr!(&mut client_auth),
+            std::mem::size_of::<CK_ULONG>(),
+        ),
+        (
+            CKA_NAME_HASH_ALGORITHM,
+            void_ptr!(&mut hash_alg),
+            std::mem::size_of::<CK_ULONG>(),
+        ),
+    ]);
+    let ret = fn_get_attribute_value(
+        session,
+        trust_obj,
+        attr_template.as_mut_ptr(),
+        attr_template.len() as CK_ULONG,
+    );
+    assert_eq!(ret, CKR_OK);
+    assert_eq!(server_auth, CKT_TRUSTED);
+    assert_eq!(client_auth, CKT_TRUST_ANCHOR);
+    assert_eq!(hash_alg, CKM_SHA256);
+
     // Test case 2: Successful creation of a non-trusted object without hash
     let trust_obj2 = ret_or_panic!(import_object(
         session,
@@ -303,13 +334,22 @@ fn test_create_trust_object() {
         &[(CKA_TOKEN, true)],
     ));
 
-    // check that CKA_NAME_HASH_ALGORITHM defaulted to SHA1
+    // check that CKA_NAME_HASH_ALGORITHM defaulted to SHA1 and trust
+    // attribute is set to CKA_NOT_TRUSTED
     let mut hash_alg: CK_ULONG = 0;
-    let mut attr_template = make_ptrs_template(&[(
-        CKA_NAME_HASH_ALGORITHM,
-        void_ptr!(&mut hash_alg),
-        std::mem::size_of::<CK_ULONG>(),
-    )]);
+    let mut server_auth: CK_ULONG = 0;
+    let mut attr_template = make_ptrs_template(&[
+        (
+            CKA_NAME_HASH_ALGORITHM,
+            void_ptr!(&mut hash_alg),
+            std::mem::size_of::<CK_ULONG>(),
+        ),
+        (
+            CKA_TRUST_SERVER_AUTH,
+            void_ptr!(&mut server_auth),
+            std::mem::size_of::<CK_ULONG>(),
+        ),
+    ]);
     let ret = fn_get_attribute_value(
         session,
         trust_obj2,
@@ -318,6 +358,7 @@ fn test_create_trust_object() {
     );
     assert_eq!(ret, CKR_OK);
     assert_eq!(hash_alg, CKM_SHA_1);
+    assert_eq!(server_auth, CKT_NOT_TRUSTED);
 
     // Test case 3: Failure due to missing issuer
     err_or_panic!(


### PR DESCRIPTION

#### Description

Added a few tests while checking a problem with an application, might as well commit them.

Expand the test_create_trust_object function to retrieve and assert attributes like CKA_TRUST_SERVER_AUTH, CKA_TRUST_CLIENT_AUTH, and CKA_NAME_HASH_ALGORITHM. This ensures that newly created or imported trust objects properly set or default their authentication flags and hash algorithms.


#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite updated
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
