### PR TITLE
Fix FIPS initialization and integrity check

### DIFF
--- a/misc/hmacify.sh
+++ b/misc/hmacify.sh
@@ -6,7 +6,9 @@ if [[ $# -eq 0 ]]; then
 fi
 
 
-openssl dgst -binary -sha256 -mac HMAC -macopt hexkey:f4556650ac31d35461610bac4ed81b1a181b2d8a43ea2854cbae22ca74560813 < $1 > $1.hmac
-objcopy --update-section .rodata1=$1.hmac $1 $1.mac
+objcopy $1 $1.norm
+openssl dgst -binary -sha256 -mac HMAC -macopt hexkey:f4556650ac31d35461610bac4ed81b1a181b2d8a43ea2854cbae22ca74560813 < $1.norm > $1.hmac
+objcopy --update-section .rodata1=$1.hmac $1.norm $1.mac
 cp $1 $1.orig
 mv $1.mac $1
+rm $1.norm


### PR DESCRIPTION
- Update misc/hmacify.sh to perform a normalization pass with objcopy before calculating the HMAC. This ensures the binary layout is finalized before the checksum is generated, preventing mismatches caused by objcopy's internal optimizations/re-alignments.

#### Description
There is a issue where the binary section alignment can change by invoking `objcopy` thus resulting in invalid hmac, this change first performs the `objcopy` on the original `.so` file and calculates the hmac on this copy which is already aligned.

#### Checklist

_I don't see these applicable_ 
- [ ] Test suite updated
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
