### PR TITLE
Fix build of conformance tools on i686 architecture

### DIFF
--- a/packaging/kryoptic.spec
+++ b/packaging/kryoptic.spec
@@ -96,7 +96,7 @@ rm -f Cargo.lock
 
 %build
 export CONFDIR=%{_sysconfdir}
-%cargo_build -f  %{features} -- --all
+%cargo_build -f %{features} -- --all
 %{cargo_license_summary -f %{features}}
 %{cargo_license -f %{features}} > LICENSE.dependencies
 

--- a/tools/profiles/conformance_lib/token_init.rs
+++ b/tools/profiles/conformance_lib/token_init.rs
@@ -300,7 +300,7 @@ pub fn init_token(args: &Arguments) -> Result<(), Box<dyn std::error::Error>> {
         println!("PKCS#11 library initialized.");
 
         let slot_id = if let Some(sid) = args.pkcs11_slot {
-            sid
+            sid as pkcs11::CK_ULONG
         } else {
             println!("No slot specified, finding first slot with a token...");
             let num_slots = pkcs11.get_slot_list(pkcs11::CK_TRUE, None)?;


### PR DESCRIPTION
#### Description

Surfaced during enabling the profiles in Fedora build:

https://koji.fedoraproject.org/koji/taskinfo?taskID=145221940

#### Checklist

- [X] Test suite updated
- [~] Rustdoc string were added or updated
- [~] CHANGELOG and/or other documentation added or updated
- [~] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
