### PR TITLE
Nss uniqe violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project should be documented in this file.
 
 ### What Changed
 
---
+* Added support for deduplicating objects on insertion
+    - [Add support for object dedup](https://github.com/latchset/kryoptic/pull/453)
 
 ## [1.5.0]
 ## 2026-03-04

--- a/doc/kryoptic.conf.man.md
+++ b/doc/kryoptic.conf.man.md
@@ -62,6 +62,11 @@ Tokens are configured by defining one or more `[[slots]]` sections. In Kryoptic,
     
     To configure a *deny list*, the first element must be the exact string `"DENY"`, followed by the mechanisms to be removed (e.g., `["DENY", "CKM_SHA256"]`). Using `"DENY"` in any position other than the first is not supported and will cause an error.
 
+**objects_dedup** = *string*
+:   *(Optional)* Specifies which objects to deduplicate on creation. For compatibility with NSS softokn, some or all objects can be deduplicated on insertion; upon match, the original object is overridden with the attributes of the new object being created instead of creating a separate object.
+    Valid values are **"TrustOnly"**, **"TrustAndCertificates"**, or **"All"**. Defaults to not set for configured databases, but defaults to **"All"** for NSS databases loaded via initialization string options.
+    **WARNING:** It is recommended to leave this empty. Side effects may include destroying key material irrecoverably if the **"All"** option is used.
+
 **[slots.fips_behavior]**
 :   *(Optional)* Add tweaks for behavior in FIPS mode.
 
@@ -91,6 +96,7 @@ manufacturer = "Kryoptic"
 dbtype = "sqlite"
 dbargs = "/var/lib/kryoptic/token.sql"
 mechanisms = ["DENY", "CKM_MD5"]
+objects_dedup = "TrustOnly"
 
 [[slots]]
 slot = 2

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -628,6 +628,17 @@ impl Attribute {
     }
 }
 
+/// Wrapper to tie the lifetime of a removed CK_ATTRIBUTE to the CkAttrs it came from
+#[derive(Debug)]
+pub struct RemovedAttr<'a>(CK_ATTRIBUTE, std::marker::PhantomData<&'a ()>);
+
+impl<'a> std::ops::Deref for RemovedAttr<'a> {
+    type Target = CK_ATTRIBUTE;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// Helper object to represent managed arrays of CK_ATTRIBUTEs
 ///
 /// This object uses Cow memory to optimize keeping around arrays passed
@@ -701,6 +712,15 @@ impl<'a> CkAttrs<'a> {
             zeroize: false,
             br: Vec::new(),
         }
+    }
+
+    /// Creates a new static CkAttrs from a Vector of Attributes
+    pub fn from_attributes(attributes: &'a [Attribute]) -> Result<CkAttrs<'a>> {
+        let mut ck_attrs = CkAttrs::with_capacity(attributes.len());
+        for attr in attributes {
+            ck_attrs.add_slice(attr.ck_type, &attr.value)?;
+        }
+        Ok(ck_attrs)
     }
 
     fn attr_from_last(&self, typ: CK_ATTRIBUTE_TYPE) -> Result<CK_ATTRIBUTE> {
@@ -872,6 +892,20 @@ impl<'a> CkAttrs<'a> {
         match self.p.as_ref().iter().position(|a| a.type_ == typ) {
             Some(idx) => Ok(Some(self.p.to_mut().swap_remove(idx).to_ulong()?)),
             None => return Ok(None),
+        }
+    }
+
+    /// Removes an arbitrary attribute from the array and returns it if present
+    pub fn remove_attr(
+        &mut self,
+        typ: CK_ATTRIBUTE_TYPE,
+    ) -> Option<RemovedAttr<'a>> {
+        match self.p.as_ref().iter().position(|a| a.type_ == typ) {
+            Some(idx) => Some(RemovedAttr(
+                self.p.to_mut().swap_remove(idx),
+                std::marker::PhantomData,
+            )),
+            None => None,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,29 @@ const DEFAULT_CONF_DIR: &str = "test";
 /// The default token name (token.conf)
 pub const DEFAULT_CONF_NAME: &str = "token.conf";
 
+/// For compatibility with NSS softokn some or all objects can be
+/// deduplicated on insertion, upon match the original object is
+/// overridden with the attributes of the new object being created
+/// instead of creating a separate object.
+/// WARNING: this can lead to permanently losing private/secret keys
+/// if the "All" option is used
+///
+/// Defaults to None for configured database, defaults to "All" for
+/// NSS databases loaded via initialization string options
+///
+/// Example:
+/// \[\[slots\]\]
+/// ...
+/// objects_dedup = "TrustOnly"
+
+/// Types of objects to deduplicate
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ObjectsDedup {
+    TrustOnly,
+    TrustAndCertificates,
+    All,
+}
+
 /// Configuration for a slot
 ///
 /// The basic facility of a PKCS#11 is the slot. The slot represents an
@@ -94,6 +117,11 @@ pub struct Slot {
     /// Using "DENY" in any position but the first is not supported and
     /// will cause an error.
     pub mechanisms: Option<Vec<String>>,
+    /// Specifies which Objects to deduplicate on create
+    /// It is recommended to leave this empty, side effects may include
+    /// destroying key material irrecoverably
+    #[serde(default)]
+    pub objects_dedup: Option<ObjectsDedup>,
     /// The FIPS Behavior for the token
     #[cfg(feature = "fips")]
     #[serde(default)]
@@ -112,6 +140,7 @@ impl Slot {
             dbtype: None,
             dbargs: None,
             mechanisms: None,
+            objects_dedup: None,
             #[cfg(feature = "fips")]
             fips_behavior: FipsBehavior::default(),
         }
@@ -129,6 +158,7 @@ impl Slot {
             dbtype: Some(dbtype.to_string()),
             dbargs: dbargs,
             mechanisms: None,
+            objects_dedup: None,
             #[cfg(feature = "fips")]
             fips_behavior: FipsBehavior {
                 keys_always_sensitive: if dbtype == "nssdb" {
@@ -430,6 +460,7 @@ impl Config {
 
         slot.dbtype = Some(storage::nssdb::DBINFO.dbtype().to_string());
         slot.dbargs = Some(args.to_string());
+        slot.objects_dedup = Some(ObjectsDedup::All);
         #[cfg(feature = "fips")]
         {
             /* NSS generally marks all keys as sensitive and forbids

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -251,7 +251,12 @@ impl Object {
             self.class = a.to_ulong()?;
         }
         match self.attributes.iter().position(|r| r.get_type() == atype) {
-            Some(idx) => self.attributes[idx] = a,
+            Some(idx) => {
+                if self.zeroize {
+                    self.attributes[idx].zeroize();
+                }
+                self.attributes[idx] = a;
+            }
             None => self.attributes.push(a),
         }
         Ok(())

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -56,6 +56,7 @@ impl Slot {
                 token.set_mech_allow_list(mechs);
             }
         }
+        token.set_dedup(config.objects_dedup);
 
         let mut slot = Slot {
             slot_info: CK_SLOT_INFO {

--- a/src/tests/mechs.rs
+++ b/src/tests/mechs.rs
@@ -74,6 +74,7 @@ fn test_allow_mechs() {
     testtokn.make_config_file(
         &confname,
         Some(vec![String::from("CKM_AES_KEY_GEN")]),
+        None,
     );
 
     let mut args =
@@ -112,6 +113,7 @@ fn test_deny_mechs() {
     testtokn.make_config_file(
         &confname,
         Some(vec![String::from("DENY"), String::from("CKM_AES_KEY_GEN")]),
+        None,
     );
 
     let mut args =

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -75,6 +75,7 @@ struct TestToken<'a> {
     sync: Option<RwLockReadGuard<'a, u64>>,
     session: CK_SESSION_HANDLE,
     session_rw: bool,
+    dedup: Option<crate::config::ObjectsDedup>,
 }
 
 impl TestToken<'_> {
@@ -106,6 +107,7 @@ impl TestToken<'_> {
             sync: Some(SYNC.read().unwrap()),
             session: CK_INVALID_HANDLE,
             session_rw: false,
+            dedup: None,
         }
     }
 
@@ -144,12 +146,18 @@ impl TestToken<'_> {
         self.slot
     }
 
-    fn make_config_file(&self, confname: &str, mechs: Option<Vec<String>>) {
+    fn make_config_file(
+        &self,
+        confname: &str,
+        mechs: Option<Vec<String>>,
+        dedup: Option<crate::config::ObjectsDedup>,
+    ) {
         let mut conf = config::Config::new();
         let mut slot =
             config::Slot::with_db(&self.dbtype, Some(self.dbargs.clone()));
         slot.slot = u32::try_from(self.get_slot()).unwrap();
         slot.mechanisms = mechs;
+        slot.objects_dedup = dedup;
         conf.add_slot(slot).unwrap();
         let data = toml::to_string(&conf).unwrap();
         let mut file = OpenOptions::new()
@@ -158,12 +166,12 @@ impl TestToken<'_> {
             .truncate(true)
             .open(confname)
             .unwrap();
-        file.write(data.as_bytes()).unwrap();
+        file.write_all(data.as_bytes()).unwrap();
     }
 
     fn make_init_string(&self) -> String {
         let confname = format!("{}/{}.conf", TESTDIR, self.name);
-        self.make_config_file(&confname, None);
+        self.make_config_file(&confname, None, self.dedup);
         format!("kryoptic_conf={}", confname)
     }
 
@@ -221,11 +229,13 @@ impl TestToken<'_> {
         }
     }
 
-    fn initialized<'a>(
+    fn initialized_with_dedup<'a>(
         name: &'a str,
         import: Option<&'a str>,
+        dedup: Option<crate::config::ObjectsDedup>,
     ) -> TestToken<'a> {
         let mut td = Self::new(String::from(name));
+        td.dedup = dedup;
         td.setup_db(import);
 
         let mut args = Self::make_init_args(Some(td.make_init_string()));
@@ -244,6 +254,13 @@ impl TestToken<'_> {
         );
 
         td
+    }
+
+    fn initialized<'a>(
+        name: &'a str,
+        import: Option<&'a str>,
+    ) -> TestToken<'a> {
+        Self::initialized_with_dedup(name, import, None)
     }
 
     fn get_session(&mut self, rw: bool) -> CK_SESSION_HANDLE {

--- a/src/tests/objects.rs
+++ b/src/tests/objects.rs
@@ -445,12 +445,13 @@ fn test_create_trust_object() {
 
     for &attr in &trust_attributes {
         for &val in &trust_values {
+            let issuer = format!("Test Issuer {} {}", attr, val);
             let trust_obj = ret_or_panic!(import_object(
                 session,
                 CKO_TRUST,
                 &[(attr, val), (CKA_NAME_HASH_ALGORITHM, CKM_SHA256),],
                 &[
-                    (CKA_ISSUER, "Test Issuer".as_bytes()),
+                    (CKA_ISSUER, issuer.as_bytes()),
                     (CKA_SERIAL_NUMBER, &[0x01, 0x02, 0x03]),
                     (CKA_HASH_OF_CERTIFICATE, &[0; 32]), // dummy 256-bit hash
                 ],
@@ -767,4 +768,169 @@ fn test_modify_nss_trust_object() {
     assert_eq!(ret, CKR_OK);
 
     testtokn.finalize();
+}
+
+#[test]
+#[parallel]
+fn test_object_dedup() {
+    let dedup_options = [
+        (format!("test_object_dedup_none"), None),
+        (
+            format!("test_object_dedup_trust_only"),
+            Some(crate::config::ObjectsDedup::TrustOnly),
+        ),
+        (
+            format!("test_object_dedup_trust_and_certs"),
+            Some(crate::config::ObjectsDedup::TrustAndCertificates),
+        ),
+        (
+            format!("test_object_dedup_all"),
+            Some(crate::config::ObjectsDedup::All),
+        ),
+    ];
+
+    let mut tokens = Vec::new();
+
+    for dedup in dedup_options.iter() {
+        let td = TestToken::initialized_with_dedup(&dedup.0, None, dedup.1);
+        tokens.push(td);
+    }
+
+    for td in tokens.iter_mut() {
+        let session = td.get_session(true);
+        td.login();
+
+        let dedup = td.dedup;
+
+        // 1. Create a trust object
+        let trust_handle1 = ret_or_panic!(import_object(
+            session,
+            CKO_TRUST,
+            &[
+                (CKA_TRUST_SERVER_AUTH, CKT_TRUSTED),
+                (CKA_NAME_HASH_ALGORITHM, CKM_SHA256),
+            ],
+            &[
+                (CKA_ISSUER, b"Test Issuer"),
+                (CKA_SERIAL_NUMBER, &[0x01, 0x02, 0x03]),
+                (CKA_HASH_OF_CERTIFICATE, &[0; 32]),
+            ],
+            &[(CKA_TOKEN, true)],
+        ));
+
+        let trust_res2 = import_object(
+            session,
+            CKO_TRUST,
+            &[
+                (CKA_TRUST_SERVER_AUTH, CKT_NOT_TRUSTED),
+                (CKA_NAME_HASH_ALGORITHM, CKM_SHA256),
+            ],
+            &[
+                (CKA_ISSUER, b"Test Issuer"),
+                (CKA_SERIAL_NUMBER, &[0x01, 0x02, 0x03]),
+                (CKA_HASH_OF_CERTIFICATE, &[0; 32]),
+            ],
+            &[(CKA_TOKEN, true)],
+        );
+
+        match dedup {
+            None => {
+                assert_eq!(
+                    trust_res2.err().unwrap().rv(),
+                    CKR_ATTRIBUTE_VALUE_INVALID
+                );
+            }
+            _ => {
+                // TrustOnly, TrustAndCertificates, All
+                let trust_handle2 = trust_res2.unwrap();
+                assert_eq!(trust_handle1, trust_handle2);
+            }
+        }
+
+        // 2. Create a certificate object
+        let cert_handle1 = ret_or_panic!(import_object(
+            session,
+            CKO_CERTIFICATE,
+            &[(CKA_CERTIFICATE_TYPE, CKC_X_509)],
+            &[
+                (CKA_ISSUER, b"Test Issuer Cert"),
+                (CKA_SERIAL_NUMBER, &[0x04, 0x05, 0x06]),
+                (CKA_SUBJECT, b"Test Subject"),
+                (CKA_VALUE, b"cert_data"),
+            ],
+            &[(CKA_TOKEN, true), (CKA_TRUSTED, false)],
+        ));
+
+        let cert_res2 = import_object(
+            session,
+            CKO_CERTIFICATE,
+            &[(CKA_CERTIFICATE_TYPE, CKC_X_509)],
+            &[
+                (CKA_ISSUER, b"Test Issuer Cert"),
+                (CKA_SERIAL_NUMBER, &[0x04, 0x05, 0x06]),
+                (CKA_SUBJECT, b"Test Subject 2"),
+                (CKA_VALUE, b"cert_data2"),
+            ],
+            &[(CKA_TOKEN, true), (CKA_TRUSTED, false)],
+        );
+
+        match dedup {
+            Some(crate::config::ObjectsDedup::TrustAndCertificates)
+            | Some(crate::config::ObjectsDedup::All) => {
+                let cert_handle2 = cert_res2.unwrap();
+                assert_eq!(cert_handle1, cert_handle2);
+            }
+            _ => {
+                // None, TrustOnly
+                let cert_handle2 = cert_res2.unwrap();
+                assert_ne!(cert_handle1, cert_handle2);
+            }
+        }
+
+        // 3. Create a key object
+        let key_handle1 = ret_or_panic!(import_object(
+            session,
+            CKO_SECRET_KEY,
+            &[(CKA_KEY_TYPE, CKK_GENERIC_SECRET)],
+            &[
+                (CKA_ID, b"key_id"),
+                (CKA_VALUE, b"secret_value"),
+                (CKA_LABEL, b"Test Key"),
+            ],
+            &[(CKA_TOKEN, true)],
+        ));
+
+        let key_res2 = import_object(
+            session,
+            CKO_SECRET_KEY,
+            &[(CKA_KEY_TYPE, CKK_GENERIC_SECRET)],
+            &[
+                (CKA_ID, b"key_id"),
+                (CKA_VALUE, b"secret_value2"),
+                (CKA_LABEL, b"Test Key 2"),
+            ],
+            &[(CKA_TOKEN, true)],
+        );
+
+        match dedup {
+            Some(crate::config::ObjectsDedup::All) => {
+                let key_handle2 = key_res2.unwrap();
+                assert_eq!(key_handle1, key_handle2);
+            }
+            _ => {
+                // None, TrustOnly, TrustAndCertificates
+                let key_handle2 = key_res2.unwrap();
+                assert_ne!(key_handle1, key_handle2);
+            }
+        }
+
+        td.close_session();
+    }
+
+    for td in tokens.iter_mut() {
+        td.sync = None;
+    }
+    for mut td in tokens {
+        td.finalize();
+    }
 }

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -21,7 +21,7 @@ fn test_token_env(suffix: &str) {
     let dbname = format!("test_token_env{}", suffix);
     let mut testtokn = test_token_setup(&dbname);
     let confname = format!("{}/test_token_env{}.conf", TESTDIR, suffix);
-    testtokn.make_config_file(&confname, None);
+    testtokn.make_config_file(&confname, None, None);
 
     let mut plist: *mut CK_FUNCTION_LIST = std::ptr::null_mut();
     let pplist = &mut plist;
@@ -52,7 +52,7 @@ fn test_token_null_args(suffix: &str) {
     let dbname = format!("test_token_nullargs{}", suffix);
     let mut testtokn = test_token_setup(&dbname);
     let confname = format!("{}/test_token_nullargs{}.conf", TESTDIR, suffix);
-    testtokn.make_config_file(&confname, None);
+    testtokn.make_config_file(&confname, None, None);
 
     let mut plist: *mut CK_FUNCTION_LIST = std::ptr::null_mut();
     let pplist = &mut plist;
@@ -86,7 +86,7 @@ fn test_token_datadir() {
     std::fs::create_dir_all(confdir).unwrap();
 
     let mut testtokn = TestToken::new(dbname);
-    testtokn.make_config_file(&confname, None);
+    testtokn.make_config_file(&confname, None, None);
     testtokn.setup_db(None);
 
     let mut plist: *mut CK_FUNCTION_LIST = std::ptr::null_mut();

--- a/src/token.rs
+++ b/src/token.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 use std::vec::Vec;
 
 use crate::attribute::CkAttrs;
+use crate::config::ObjectsDedup;
 use crate::defaults;
 use crate::error::Result;
 #[cfg(feature = "fips")]
@@ -111,6 +112,7 @@ pub struct Token {
     logged: CK_USER_TYPE,
     /// Filtered list of mechanisms, if any
     filtermechs: Option<Mechanisms>,
+    dedup: Option<ObjectsDedup>,
 }
 
 impl Token {
@@ -150,6 +152,7 @@ impl Token {
             session_objects: HashMap::new(),
             logged: KRY_UNSPEC,
             filtermechs: None,
+            dedup: None,
         };
 
         /* register mechanisms and factories */
@@ -553,6 +556,11 @@ impl Token {
         Ok(obj)
     }
 
+    /// Sets dedup option
+    pub fn set_dedup(&mut self, dedup: Option<ObjectsDedup>) {
+        self.dedup = dedup;
+    }
+
     /// Inserts a new object into the token.
     ///
     /// If the object has `CKA_TOKEN=true`, it is stored persistently via the
@@ -583,6 +591,125 @@ impl Token {
         Ok(handle)
     }
 
+    /// Internal function to check for cert/trust object duplicates
+    fn _is_duplicate(
+        &mut self,
+        template: &[CK_ATTRIBUTE],
+    ) -> Result<Option<CK_OBJECT_HANDLE>> {
+        let r = self.storage.search(&mut self.facilities, template)?;
+        return match r.len() {
+            0 => Ok(None),
+            1 => Ok(Some(r[0])),
+            _ => Err(CKR_GENERAL_ERROR)?,
+        };
+    }
+
+    fn _is_cert_obj_duplicate(
+        &mut self,
+        obj: &Object,
+    ) -> Result<Option<CK_OBJECT_HANDLE>> {
+        if let (Some(issuer), Some(serial)) =
+            (obj.get_attr(CKA_ISSUER), obj.get_attr(CKA_SERIAL_NUMBER))
+        {
+            let class = obj.get_class();
+            let mut tmpl = CkAttrs::with_capacity(3);
+            tmpl.add_ulong(CKA_CLASS, &class);
+            tmpl.add_slice(CKA_ISSUER, issuer.get_value())?;
+            tmpl.add_slice(CKA_SERIAL_NUMBER, serial.get_value())?;
+
+            return self._is_duplicate(tmpl.as_slice());
+        }
+        return Ok(None);
+    }
+
+    /// Internal function to check for key object duplicates
+    fn _is_key_obj_duplicate(
+        &mut self,
+        obj: &Object,
+    ) -> Result<Option<CK_OBJECT_HANDLE>> {
+        if let (Some(id), Some(key_type)) =
+            (obj.get_attr(CKA_ID), obj.get_attr(CKA_KEY_TYPE))
+        {
+            let class = obj.get_class();
+            let mut tmpl = CkAttrs::with_capacity(3);
+            tmpl.add_ulong(CKA_CLASS, &class);
+            tmpl.add_slice(CKA_ID, id.get_value())?;
+            tmpl.add_slice(CKA_KEY_TYPE, key_type.get_value())?;
+
+            return self._is_duplicate(tmpl.as_slice());
+        }
+        return Ok(None);
+    }
+
+    /// The dedup option is set generally for softokn compatibility,
+    /// in which case if a "duplicate object" is added to the db,
+    /// the original object data is wiped and replaced with the
+    /// new object data.
+    /// if empty, only check that no duplicate trust object is
+    /// being created as the spec says tokens should not allow to
+    /// create multiple trust objects for the same certificate.
+    fn check_dedup(
+        &mut self,
+        obj: &Object,
+    ) -> Result<Option<CK_OBJECT_HANDLE>> {
+        let class = obj.get_class();
+        let is_cert = class == CKO_CERTIFICATE;
+        let is_key =
+            matches!(class, CKO_PUBLIC_KEY | CKO_PRIVATE_KEY | CKO_SECRET_KEY);
+        #[cfg(not(feature = "nssdb"))]
+        let is_trust = class == CKO_TRUST;
+        #[cfg(feature = "nssdb")]
+        let is_trust = matches!(
+            class,
+            CKO_TRUST | crate::pkcs11::vendor::nss::CKO_NSS_TRUST
+        );
+
+        if let Some(dedup) = self.dedup {
+            if let Some(handle) = match dedup {
+                ObjectsDedup::TrustOnly => {
+                    if is_trust {
+                        self._is_cert_obj_duplicate(obj)?
+                    } else {
+                        None
+                    }
+                }
+                ObjectsDedup::TrustAndCertificates => {
+                    if is_cert || is_trust {
+                        self._is_cert_obj_duplicate(obj)?
+                    } else {
+                        None
+                    }
+                }
+                ObjectsDedup::All => {
+                    if is_cert || is_trust {
+                        self._is_cert_obj_duplicate(obj)?
+                    } else if is_key {
+                        self._is_key_obj_duplicate(obj)?
+                    } else {
+                        None
+                    }
+                }
+            } {
+                let mut updt = CkAttrs::from_attributes(obj.get_attributes())?;
+                let _ = updt.remove_attr(CKA_UNIQUE_ID);
+                self.storage.update(
+                    &self.facilities,
+                    handle,
+                    updt.as_slice(),
+                )?;
+                return Ok(Some(handle));
+            }
+        } else {
+            if is_trust {
+                let found = self._is_cert_obj_duplicate(obj)?;
+                if found.is_some() {
+                    return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;
+                }
+            }
+        }
+        Ok(None)
+    }
+
     /// Creates a new object based on a template.
     ///
     /// Dispatches to the appropriate object factory via
@@ -596,6 +723,17 @@ impl Token {
         template: &[CK_ATTRIBUTE],
     ) -> Result<CK_OBJECT_HANDLE> {
         let object = self.facilities.factories.create(template)?;
+
+        if object.is_token() {
+            if !self.is_logged_in(KRY_UNSPEC) {
+                return Err(CKR_USER_NOT_LOGGED_IN)?;
+            }
+
+            if let Some(handle) = self.check_dedup(&object)? {
+                return Ok(handle);
+            }
+        }
+
         self.insert_object(s_handle, object)
     }
 


### PR DESCRIPTION
#### Description

Allow object deduplication for compatibility with NSS softoken.
This is disabled by default in regular configurations but enabled by default when kryoptic is initialized via init args via nssdb configuration compatibility.

Fixes #450 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite updated
- [x] Rustdoc string were added or updated
- [x] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
