### PR TITLE
CI: Add xxd missing dependency

### DIFF
--- a/.github/workflows/pkcs11-provider.yml
+++ b/.github/workflows/pkcs11-provider.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
             dnf -y install clang git meson cargo expect pkgconf-pkg-config \
               openssl-devel openssl opensc p11-kit-devel gnutls-utils \
-              gcc g++ sqlite-devel python3-six which
+              gcc g++ sqlite-devel python3-six which xxd
 
       - name: Checkout Repository
         uses: actions/checkout@v6


### PR DESCRIPTION
xxd - hex dump utility used by "pkcs11-provider tests" in the CI is was previously missing causing `kryoptic - pkcs11-provider:hkdf` and `kryoptic.nss - pkcs11-provider:hkdf` with err code 127

#### Description

<!--  The description should give a general overview of the goal of the PR.

Individual commit message should highlight important changes that people may
want to know about when looking at the commit years later
-->

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

~~- [ ] Test suite updated~~
~~- [ ] Rustdoc string were added or updated~~
~~- [ ] CHANGELOG and/or other documentation added or updated~~
~~- [ ] This is not a code change~~

#### Reviewer's checklist:

~~- [ ] Any issues marked for closing are fully addressed~~
~~- [ ] There is a test suite reasonably covering new functionality or modifications~~
~~- [ ] This feature/change has adequate documentation added~~
~~- [ ] A changelog entry is added if the change is significant~~
~~- [ ] Code conform to coding style that today cannot yet be enforced via the check style test~~
- [ ] Commits have short titles and sensible text~~
~~- [ ] Doc string are properly updated~~
