### PR TITLE
Fix potential deadlock by resetting config before finalizing state

### DIFF
--- a/src/fns/general.rs
+++ b/src/fns/general.rs
@@ -97,9 +97,9 @@ pub extern "C" fn fn_initialize(init_args: CK_VOID_PTR) -> CK_RV {
 
 #[inline(always)]
 fn finalize(_reserved: CK_VOID_PTR) -> Result<()> {
-    let ret = STATE.wlock()?.finalize();
     let mut conf = crate::CONFIG.wlock()?;
     *conf = Config::new();
+    let ret = STATE.wlock()?.finalize();
     if ret != CKR_OK {
         return Err(ret)?;
     }


### PR DESCRIPTION
#### Description

This PR swaps the order of operations in the finalize function to ensure the global configuration is reset before the state is finalized. Although the write lock on STATE is supposed to be released before the CONFIG lock is acquired, we have observed deadlocks in some builds, likely because STATE does not immediately go out of scope.

By ensuring the CONFIG lock is always acquired prior to the STATE lock, we align with the locking order used throughout the rest of the codebase and eliminate this potential deadlock.

NOTE: this happens only when tests are run with high parallelization where they repeately initialize and tear down tokens for now, it is very unlikely to happen in a real application.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] Test suite updated
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
