### PR TITLE
Update quick-xml from 0.39 to 0.40

### DIFF
--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -34,7 +34,7 @@ hex = "0.4.3"
 libc = "0.2.151"
 serde = { version = "1.0.180", features = ["derive"] }
 serde_json = "1.0.104"
-quick-xml = { version = "0.39", features = ["serialize"], optional = true }
+quick-xml = { version = "0.40", features = ["serialize"], optional = true }
 
 [features]
 default = ["kryoptic-lib/default"]


### PR DESCRIPTION
#### Description

<!--  The description should give a general overview of the goal of the PR.

Individual commit message should highlight important changes that people may
want to know about when looking at the commit years later
-->
I’m working on updating the `rust-quick-xml` package in Fedora from 0.39.x to 0.40.x without a compat package. This PR offers that work upstream.

See https://github.com/tafia/quick-xml/blob/v0.40.1/Changelog.md#0400----2026-05-11 for a list of changes, including potentially-breaking ones, for the 0.40 release. It doesn’t look like anything here requires source-code changes in Kryoptic, so this PR simply bumps the dependency. I confirmed that `cargo test -F profiles` still passes in the `tools/` directory.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] ~~Test suite updated~~
- [ ] ~~Rustdoc string were added or updated~~
- [ ] ~~CHANGELOG and/or other documentation added or updated~~
- [x] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
