### PR TITLE
Allow 65-byte P-521 EC private keys

### DIFF
--- a/src/ec/ecdsa.rs
+++ b/src/ec/ecdsa.rs
@@ -287,8 +287,14 @@ impl ObjectFactory for ECDSAPrivFactory {
          * ANSI X9.62 private value d */
         match obj.get_attr_as_bytes(CKA_VALUE) {
             Ok(v) => {
-                if v.len() != ec_key_size(&oid)? {
-                    return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;
+                let expected = ec_key_size(&oid)?;
+                if v.len() != expected {
+                    /* P521 keys can legitimately be 65 bytes long
+                     * because Big Integer representations are minimal
+                     * so a leading zero byte might be dropped */
+                    if !(oid == oid::EC_SECP521R1 && v.len() == 65) {
+                        return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;
+                    }
                 }
             }
             Err(e) => {

--- a/src/tests/ecc.rs
+++ b/src/tests/ecc.rs
@@ -59,6 +59,27 @@ fn test_create_ec_objects() {
         &[(CKA_SIGN, true)]
     ));
 
+    /* P-521 Private EC key with 65 bytes */
+    let value_p521 = hex::decode(
+        "EDA2EE113C1325AB0CF0B6376D0626CFFC3CAEBBD54430420A218CCA7E217D9E\
+         9A622DA48A18E150584F4ABD830FCA5A48B5294162EF2493B5E4CEBF7DD41B9E\
+         B5",
+    )
+    .expect("Failed to decode value");
+    let params_p521 =
+        hex::decode("06052B81040023").expect("Failed to decode hex params");
+    let _ = ret_or_panic!(import_object(
+        session,
+        CKO_PRIVATE_KEY,
+        &[(CKA_KEY_TYPE, CKK_EC)],
+        &[
+            (CKA_LABEL, "EC Private Signature Key P521".as_bytes()),
+            (CKA_VALUE, value_p521.as_slice()),
+            (CKA_EC_PARAMS, params_p521.as_slice()),
+        ],
+        &[(CKA_SIGN, true)]
+    ));
+
     testtokn.finalize();
 }
 


### PR DESCRIPTION
#### Description

Updates the ECDSA private key validation to accept 65-byte values for P-521 curves and adds a supporting test case. This change is necessary because minimal Big Integer representations may drop leading zero bytes, making 65 bytes a legitimate length for P-521 keys.

Fixes: #430 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite updated
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
