### PR TITLE
Add openssl links attribute to Cargo.toml

### DIFF
--- a/ossl/Cargo.toml
+++ b/ossl/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "ossl"
+links = "openssl"
 version.workspace = true
 edition.workspace = true
 description = "OpenSSL version 3+ bindings to modern EVP APIs"


### PR DESCRIPTION
#### Description

Adds the links = "openssl" key to the package manifest. This tells Cargo that the crate links to the native OpenSSL library, helping to prevent linkage conflicts and allowing proper coordination of native dependencies across the dependency graph.

Fixes #463 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] Test suite updated
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [x] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
