### PR TITLE
Add HOTP feature to standard build

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -52,7 +52,7 @@ jobs:
                 'crate(clap)' 'crate(clap/cargo)' 'crate(clap/derive)' 'crate(clap/help)' \
                 'crate(clap/std)' 'crate(clap/usage)' 'crate(constant_time_eq/default)' \
                 'crate(data-encoding/default)' 'crate(hex/default)' \
-                'crate(itertools/default)' 'crate(libc/default)' 'crate(num-bigint/default)' \
+                'crate(itertools/default) >= 0.15.0' 'crate(libc/default)' 'crate(num-bigint/default)' \
                 'crate(num-integer/default)' 'crate(num-traits/default)' \
                 'crate(pkg-config/default)' 'crate(rusqlite/default)' \
                 'crate(serde/default)' 'crate(serde/derive)' 'crate(serde_json/default)' \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project should be documented in this file.
 
 ## [Unreleased]
 
+* Added support for HOTP mechanism and OTP tokens
+  - [Add support fot CKM_HOTP and OTP key
+    factory](https://github.com/latchset/kryoptic/pull/461)
+  - [Add HOTP feature to standard
+    build](https://github.com/latchset/kryoptic/pull/465)
+
 ## [1.5.1]
 ## 2026-06-04
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ ecc_all = ["ecc_min", "ec_montgomery", "eddsa"]
 hash_all = ["hash", "hmac"]
 kdf_all = ["hkdf", "pbkdf2", "sp800_108", "sshkdf", "tlskdf", "simplekdf"]
 
-standard = ["sqlitedb", "ecc_all", "ffdh", "hash_all", "kdf_all", "rsa"]
+standard = ["sqlitedb", "ecc_all", "ffdh", "hash_all", "kdf_all", "rsa", "hotp"]
 
 fips = ["ossl/fips", "sqlitedb", "rusqlite/bundled", "aes", "ecc_all", "ffdh",
 "hash_all", "kdf_all", "rsa", "pqc", "dep:vsprintf"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ bitflags = "2.4.1"
 constant_time_eq = "0.4.2"
 data-encoding = "2.4.0"
 hex = "0.4.3"
-itertools = "0.14.0"
+itertools = "0.15.0"
 libc = "0.2.151"
 log = { version = "0.4.27", default-features = false, features = ["std"], optional = true }
 num-bigint = "0.4.4"

--- a/src/tests/hotp.rs
+++ b/src/tests/hotp.rs
@@ -115,6 +115,7 @@ fn test_hotp() {
     testtokn.finalize();
 }
 
+#[cfg(not(feature = "no_sha1"))]
 #[test]
 #[parallel]
 fn test_hotp_vectors() {


### PR DESCRIPTION
#### Description

Adds the hotp feature to the standard feature list in Cargo.toml, enabling CKM_HOTP and OTP token support by default. The changelog is also updated to document these newly added mechanisms.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] Test suite updated
- [ ] Rustdoc string were added or updated
- [x] CHANGELOG and/or other documentation added or updated
- [x] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
