### PR TITLE
Allow shorter EC private key lengths

### DIFF
--- a/misc/ec_gen_test.sh
+++ b/misc/ec_gen_test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+TOKDIR=/tmp/ec_gen_test
+SLOTID=42
+PINVALUE="S3cr37-4-m3-bu7-n07-4-7h33"
+
+rm -fr "${TOKDIR}"
+mkdir -p "${TOKDIR}"
+
+# Kryoptic configuration
+cat << EOF > "${TOKDIR}/kryoptic.conf"
+[[slots]]
+slot = ${SLOTID}
+dbtype = "sqlite"
+dbargs = "${TOKDIR}/kryoptic.sql"
+#mechanisms
+EOF
+export KRYOPTIC_CONF="${KRYOPTIC_CONF:-$TOKDIR/kryoptic.conf}"
+
+export TOKENLABEL="${TOKENLABEL:-Kryoptic Token}"
+export TOKENLABELURI="${TOKENLABELURI:-Kryoptic%20Token}"
+
+# init token
+pkcs11-tool --module target/debug/libkryoptic_pkcs11.so --init-token \
+    --slot "${SLOTID}" --label "${TOKENLABEL}" --so-pin "${PINVALUE}" 2>&1
+# set user pin
+pkcs11-tool --module target/debug/libkryoptic_pkcs11.so \
+    --slot "${SLOTID}" --so-pin "${PINVALUE}" --slot "${SLOTID}" \
+    --login --login-type so --init-pin --pin "${PINVALUE}" 2>&1
+
+LOGFILE=${TOKDIR}/ec_gen_test.log
+
+echo `date` > ${LOGFILE}
+
+for i in $(seq 1 65535); do
+    ID=$(printf "%04x" "$i")
+    PRIVKEYFILE="${TOKDIR}/private_ec_key_${i}.der"
+    PUBKEYFILE="${TOKDIR}/public_ec_key_${i}.der"
+
+    openssl genpkey -algorithm EC -outform DER -pkeyopt ec_paramgen_curve:P-256 \
+        -out "${PRIVKEYFILE}" >>${LOGFILE} 2>&1
+
+    pkcs11-tool --module target/debug/libkryoptic_pkcs11.so --slot "${SLOTID}" \
+        --pin "${PINVALUE}" --write-object "${PRIVKEYFILE}" \
+        --id "${ID}" --type privkey --label "EC private key ${ID}" \
+    >>${LOGFILE} 2>&1 || {
+        echo "Failed to import private key from ${PRIVKEYFILE}"
+        continue
+    }
+
+    openssl pkey -pubout -inform DER -outform DER -in "${PRIVKEYFILE}" \
+        -out "${PUBKEYFILE}" >>${LOGFILE} 2>&1
+
+
+    pkcs11-tool --module target/debug/libkryoptic_pkcs11.so --slot "${SLOTID}" \
+        --pin "${PINVALUE}" --write-object "${PUBKEYFILE}" \
+        --id "${ID}" --type pubkey --label "EC public key ${ID}" \
+    >>${LOGFILE} 2>&1 || {
+        echo "Failed to import public key from ${PUBKEYFILE}"
+        continue
+    }
+done

--- a/src/ec/ecdsa.rs
+++ b/src/ec/ecdsa.rs
@@ -287,14 +287,8 @@ impl ObjectFactory for ECDSAPrivFactory {
          * ANSI X9.62 private value d */
         match obj.get_attr_as_bytes(CKA_VALUE) {
             Ok(v) => {
-                let expected = ec_key_size(&oid)?;
-                if v.len() != expected {
-                    /* P521 keys can legitimately be 65 bytes long
-                     * because Big Integer representations are minimal
-                     * so a leading zero byte might be dropped */
-                    if !(oid == oid::EC_SECP521R1 && v.len() == 65) {
-                        return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;
-                    }
+                if v.len() > ec_key_size(&oid)? {
+                    return Err(CKR_ATTRIBUTE_VALUE_INVALID)?;
                 }
             }
             Err(e) => {


### PR DESCRIPTION
#### Description

Update CKA_VALUE validation for ECDSA, EDDSA, and Montgomery private keys to accept lengths up to the expected curve size, rather than requiring an exact match. This prevents the rejection of valid keys that have minimal byte representations (where leading zeros are dropped).

Additionally, a new test script is included to verify the bulk generation and importation of EC keys into the token.

Fixes #468

NOTE: this is needed because upon re-reading the spec I realized that my initial interpretation that minimal integers was not allowed (ie you needed leading zeros to be explicitly provide) was wrong.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] Test suite updated
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
