### PR TITLE
Update quick-xml dependency to 0.41

### DIFF
--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -34,7 +34,7 @@ hex = "0.4.3"
 libc = "0.2.151"
 serde = { version = "1.0.180", features = ["derive"] }
 serde_json = "1.0.104"
-quick-xml = { version = "0.40", features = ["serialize"], optional = true }
+quick-xml = { version = "0.41", features = ["serialize"], optional = true }
 
 [features]
 default = ["kryoptic-lib/default"]


### PR DESCRIPTION
#### Description

<!--  The description should give a general overview of the goal of the PR.

Individual commit message should highlight important changes that people may
want to know about when looking at the commit years later
-->

Addresses [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194.html) and [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195.html). See also https://github.com/tafia/quick-xml/blob/v0.41.0/Changelog.md.

This `quick-xml` update has already landed downstream in Fedora Rawhide and is in testing repositories for stable releases, and the `kryopic` package was patched in https://src.fedoraproject.org/rpms/kryoptic/pull-request/5.

Similarly to https://github.com/latchset/kryoptic/pull/460, there don’t appear to be any relevant API changes.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] ~~Test suite updated~~
- [ ] ~~Rustdoc string were added or updated~~
- [ ] ~~CHANGELOG and/or other documentation added or updated~~
- [x] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
