### PR TITLE
Prevent test deadlocks in synchronization

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -5,6 +5,8 @@ use std::ffi::CString;
 use std::fs::{create_dir_all, remove_dir_all, OpenOptions};
 use std::io::Write;
 use std::sync::Once;
+use std::thread;
+use std::time::Duration;
 
 #[cfg(feature = "log")]
 use crate::log;
@@ -198,8 +200,22 @@ impl TestToken<'_> {
             drop(FINI.read().unwrap());
         } else {
             self.sync = None;
+
             /* wait for all others to complete */
-            drop(SYNC.write().unwrap());
+            loop {
+                /* This needs to use try_write() because a queued write lock
+                 * may actually block read() attempts, which would cause
+                 * tests to deadlock, sleeps between attempts. */
+                thread::sleep(Duration::from_millis(5));
+                match SYNC.try_write() {
+                    Ok(lock) => {
+                        drop(lock);
+                        break;
+                    }
+                    Err(_) => (),
+                }
+            }
+
             let ret = fn_finalize(std::ptr::null_mut());
             assert_eq!(ret, CKR_OK);
             /* winner finalized and completed the tests */


### PR DESCRIPTION
#### Description

Replaced the blocking `write()` lock acquisition on the SYNC primitive with a polling loop using `try_write()` and a short sleep. A queued write lock could block incoming `read()` attempts, leading to deadlocks during test finalization. Using `try_write()` ensures that pending reads can complete safely.

Fixes #473 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite updated
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [x] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
