### PR TITLE
Add RIPEMD-160 digest algorithm support under RFC 9580 feature

### DIFF
--- a/ossl/src/digest.rs
+++ b/ossl/src/digest.rs
@@ -179,6 +179,8 @@ pub enum DigestAlg {
     Sha3_512,
     #[cfg(feature = "rfc9580")]
     Md5,
+    #[cfg(feature = "rfc9580")]
+    RipeMd160,
 }
 
 pub(crate) fn digest_to_string(digest: DigestAlg) -> &'static CStr {
@@ -196,6 +198,8 @@ pub(crate) fn digest_to_string(digest: DigestAlg) -> &'static CStr {
         DigestAlg::Sha3_512 => cstr!(OSSL_DIGEST_NAME_SHA3_512),
         #[cfg(feature = "rfc9580")]
         DigestAlg::Md5 => cstr!(OSSL_DIGEST_NAME_MD5),
+        #[cfg(feature = "rfc9580")]
+        DigestAlg::RipeMd160 => cstr!(OSSL_DIGEST_NAME_RIPEMD160),
     }
 }
 
@@ -214,6 +218,8 @@ pub(crate) fn string_to_digest(digest: &CStr) -> Result<DigestAlg, Error> {
         b"SHA3-512" => Ok(DigestAlg::Sha3_512),
         #[cfg(feature = "rfc9580")]
         b"MD5" => Ok(DigestAlg::Md5),
+        #[cfg(feature = "rfc9580")]
+        b"RIPEMD160" => Ok(DigestAlg::RipeMd160),
         _ => Err(Error::new(ErrorKind::WrapperError)),
     }
 }

--- a/ossl/src/tests/digest.rs
+++ b/ossl/src/tests/digest.rs
@@ -1,4 +1,3 @@
-// Copyright 2025 Jakub Jelen
 // See LICENSE.txt file for terms
 
 use hex;
@@ -36,6 +35,44 @@ fn test_md5() {
         hex::decode("d41d8cd98f00b204e9800998ecf8427e").unwrap();
     let mut ctx =
         OsslDigest::new(test_ossl_context(), DigestAlg::Md5, None).unwrap();
+    ctx.update(b"").unwrap();
+    let mut digest = vec![0u8; ctx.size()];
+    ctx.finalize(&mut digest).unwrap();
+    assert_eq!(digest, expect_digest);
+}
+
+#[test]
+#[parallel]
+fn test_ripemd160() {
+    // the test vectors from wikipedia
+    // https://en.wikipedia.org/wiki/RIPEMD#RIPEMD-160_hashes
+    let expect_digest =
+        hex::decode("37f332f68db77bd9d7edd4969571ad671cf9dd3b").unwrap();
+    let mut ctx =
+        OsslDigest::new(test_ossl_context(), DigestAlg::RipeMd160, None)
+            .unwrap();
+    ctx.update(b"The quick brown fox jumps over the lazy dog")
+        .unwrap();
+    let mut digest = vec![0u8; ctx.size()];
+    ctx.finalize(&mut digest).unwrap();
+    assert_eq!(digest, expect_digest);
+
+    let expect_digest =
+        hex::decode("132072df690933835eb8b6ad0b77e7b6f14acad7").unwrap();
+    let mut ctx =
+        OsslDigest::new(test_ossl_context(), DigestAlg::RipeMd160, None)
+            .unwrap();
+    ctx.update(b"The quick brown fox jumps over the lazy cog")
+        .unwrap();
+    let mut digest = vec![0u8; ctx.size()];
+    ctx.finalize(&mut digest).unwrap();
+    assert_eq!(digest, expect_digest);
+
+    let expect_digest =
+        hex::decode("9c1185a5c5e9fc54612808977ee8f548b2258d31").unwrap();
+    let mut ctx =
+        OsslDigest::new(test_ossl_context(), DigestAlg::RipeMd160, None)
+            .unwrap();
     ctx.update(b"").unwrap();
     let mut digest = vec![0u8; ctx.size()];
     ctx.finalize(&mut digest).unwrap();


### PR DESCRIPTION
#### Description

Adds the RIPEMD-160 algorithm to the supported digest algorithms under the `rfc9580` feature flag, along with corresponding C-string conversions. This expands algorithm support for RFC 9580 compliance. Standard test vectors from Wikipedia are included to verify correctness.

Fixes: #477

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite updated
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
