### PR TITLE
keymgmt: fix HKDF salt parameter validation per PKCS#11 spec

### DIFF
--- a/src/fns/keymgmt.rs
+++ b/src/fns/keymgmt.rs
@@ -553,10 +553,20 @@ fn derive_key(
                     return Err(CKR_MECHANISM_PARAM_INVALID)?;
                 }
                 /* 3. A non-null salt must be provided */
-                if params.ulSaltType == CKF_HKDF_SALT_NULL
-                    || params.pSalt.is_null()
-                {
-                    return Err(CKR_MECHANISM_PARAM_INVALID)?;
+                match params.ulSaltType {
+                    CKF_HKDF_SALT_DATA => {
+                        if params.pSalt.is_null() || params.ulSaltLen == 0 {
+                            return Err(CKR_MECHANISM_PARAM_INVALID)?;
+                        }
+                    }
+                    CKF_HKDF_SALT_KEY => {
+                        if params.hSaltKey == CK_INVALID_HANDLE {
+                            return Err(CKR_MECHANISM_PARAM_INVALID)?;
+                        }
+                    }
+                    _ => {
+                        return Err(CKR_MECHANISM_PARAM_INVALID)?;
+                    }
                 }
             } else if !key.get_attr_as_bool(CKA_DERIVE)? {
                 return Err(CKR_KEY_FUNCTION_NOT_PERMITTED)?;


### PR DESCRIPTION
The previous version blocked the usage of CKF_HKDF_KEY which is not blocked by pkcs#11 standard and was causing issues.

Replace the null-salt check in CKM_HKDF_DERIVE with proper per-type validation of CK_HKDF_PARAMS.ulSaltType as defined in PKCS#11 v3.0 §2.30.2:

- CKF_HKDF_SALT_DATA: require non-null pSalt with ulSaltLen > 0
- CKF_HKDF_SALT_KEY: require a valid hSaltKey handle
- All other salt types (including CKF_HKDF_SALT_NULL): reject with CKR_MECHANISM_PARAM_INVALID

#### Description

<!--  The description should give a general overview of the goal of the PR.

Individual commit message should highlight important changes that people may
want to know about when looking at the commit years later
-->

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [ ] Test suite updated
- [ ] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
