### PR TITLE
Introduce new API to run in permissive FIPS mode

### DIFF
--- a/ossl/src/cipher.rs
+++ b/ossl/src/cipher.rs
@@ -22,7 +22,7 @@ struct EvpCipher {
 impl EvpCipher {
     fn new(ctx: &OsslContext, name: &CStr) -> Result<EvpCipher, Error> {
         let ptr = unsafe {
-            EVP_CIPHER_fetch(ctx.ptr(), name.as_ptr(), std::ptr::null_mut())
+            EVP_CIPHER_fetch(ctx.ptr(), name.as_ptr(), ctx.propq_ptr())
         };
         if ptr.is_null() {
             trace_ossl!("EVP_CIPHER_fetch()");

--- a/ossl/src/derive.rs
+++ b/ossl/src/derive.rs
@@ -25,9 +25,8 @@ struct EvpKdfCtx {
 impl EvpKdfCtx {
     /// Instantiates a new Kdf context
     fn new(ctx: &OsslContext, name: &CStr) -> Result<EvpKdfCtx, Error> {
-        let arg = unsafe {
-            EVP_KDF_fetch(ctx.ptr(), name.as_ptr(), std::ptr::null_mut())
-        };
+        let arg =
+            unsafe { EVP_KDF_fetch(ctx.ptr(), name.as_ptr(), ctx.propq_ptr()) };
         if arg.is_null() {
             trace_ossl!("EVP_KDF_fetch()");
             return Err(Error::new(ErrorKind::NullPtr));

--- a/ossl/src/digest.rs
+++ b/ossl/src/digest.rs
@@ -18,9 +18,8 @@ pub struct EvpMd {
 /// Methods for creating and accessing `EvpMd`.
 impl EvpMd {
     pub fn new(ctx: &OsslContext, name: &CStr) -> Result<EvpMd, Error> {
-        let ptr = unsafe {
-            EVP_MD_fetch(ctx.ptr(), name.as_ptr(), std::ptr::null_mut())
-        };
+        let ptr =
+            unsafe { EVP_MD_fetch(ctx.ptr(), name.as_ptr(), ctx.propq_ptr()) };
         if ptr.is_null() {
             trace_ossl!("EVP_MD_fetch()");
             return Err(Error::new(ErrorKind::NullPtr));
@@ -268,8 +267,7 @@ impl OsslDigest {
         let name = digest_to_string(digest);
         let arg = unsafe {
             ERR_set_mark();
-            let m =
-                EVP_MD_fetch(ctx.ptr(), name.as_ptr(), std::ptr::null_mut());
+            let m = EVP_MD_fetch(ctx.ptr(), name.as_ptr(), ctx.propq_ptr());
             ERR_pop_to_mark();
             m
         };

--- a/ossl/src/lib.rs
+++ b/ossl/src/lib.rs
@@ -235,18 +235,28 @@ pub(crate) use trace_ossl;
 pub struct OsslContext {
     context: *mut OSSL_LIB_CTX,
     providers: Vec<*mut OSSL_PROVIDER>,
+    propq: Option<&'static CStr>,
     #[cfg(feature = "fips")]
     is_fips: bool,
 }
 
 static LEGACY_PROVIDER_NAME: &CStr = c"legacy";
+static DEFAULT_PROVIDER_NAME: &CStr = c"default";
 static FIPS_PROVIDER_NAME: &CStr = c"fips";
 
+static FIPS_PROVIDER_PERMISIVE_PROPQ: &CStr = c"?fips=yes";
+
 impl OsslContext {
+    /// Creates a new empty OpenSSL library context.
+    ///
+    /// For most of the applications, its recommented to load the default
+    /// configuration file after this call to make sure the application
+    /// behaves as expected using `load_default_configuration()`.
     pub fn new_lib_ctx() -> OsslContext {
         OsslContext {
             context: unsafe { OSSL_LIB_CTX_new() },
             providers: Vec::new(),
+            propq: None,
             #[cfg(feature = "fips")]
             is_fips: false,
         }
@@ -257,6 +267,7 @@ impl OsslContext {
         OsslContext {
             context: ctx,
             providers: Vec::new(),
+            propq: None,
             #[cfg(feature = "fips")]
             is_fips: false,
         }
@@ -267,6 +278,7 @@ impl OsslContext {
         OsslContext {
             context: ctx,
             providers: vec![prov as *mut OSSL_PROVIDER],
+            propq: None,
             is_fips: true,
         }
     }
@@ -306,21 +318,15 @@ impl OsslContext {
         self.load_configuration_file(None)
     }
 
-    pub fn load_legacy_provider(&mut self) -> Result<(), Error> {
+    fn load_provider(&mut self, name: &CStr) -> Result<(), Error> {
         if cfg!(feature = "fips") {
             return Err(Error::new(ErrorKind::OsslError));
         }
-
-        if unsafe {
-            OSSL_PROVIDER_available(self.ptr(), LEGACY_PROVIDER_NAME.as_ptr())
-        } == 1
-        {
+        if unsafe { OSSL_PROVIDER_available(self.ptr(), name.as_ptr()) } == 1 {
             return Ok(());
         }
 
-        let provider = unsafe {
-            OSSL_PROVIDER_load(self.ptr(), LEGACY_PROVIDER_NAME.as_ptr())
-        };
+        let provider = unsafe { OSSL_PROVIDER_load(self.ptr(), name.as_ptr()) };
         if provider.is_null() {
             Err(Error::new(ErrorKind::OsslError))
         } else {
@@ -329,23 +335,39 @@ impl OsslContext {
         }
     }
 
+    pub fn load_legacy_provider(&mut self) -> Result<(), Error> {
+        self.load_provider(LEGACY_PROVIDER_NAME)
+    }
+
     pub fn load_fips_provider(&mut self) -> Result<(), Error> {
+        self.load_provider(FIPS_PROVIDER_NAME)
+    }
+
+    pub fn load_default_provider(&mut self) -> Result<(), Error> {
+        self.load_provider(DEFAULT_PROVIDER_NAME)
+    }
+
+    /// Sets the permissive FIPS mode context.
+    ///
+    /// In strict FIPS mode, the default property query rqeuires
+    /// all operations to go through the FIPS provider. But there
+    /// are some operations we might want to keep working even
+    /// though they are not available in the FIPS provider.
+    /// Due to the way how OpenSSL works, to make this working we
+    /// need to explicitly load the default provider and then
+    /// configure the property query to prefer fips provider, but
+    /// fall back to default one if the algorithm is not available.
+    ///
+    /// This is no-op when the FIPS provider is not loaded.
+    pub fn set_permissive_fips(&mut self) -> Result<(), Error> {
         if unsafe {
             OSSL_PROVIDER_available(self.ptr(), FIPS_PROVIDER_NAME.as_ptr())
         } == 1
         {
-            return Ok(());
+            self.load_default_provider()?;
+            self.propq = Some(FIPS_PROVIDER_PERMISIVE_PROPQ);
         }
-
-        let provider = unsafe {
-            OSSL_PROVIDER_load(self.ptr(), FIPS_PROVIDER_NAME.as_ptr())
-        };
-        if provider.is_null() {
-            Err(Error::new(ErrorKind::OsslError))
-        } else {
-            self.providers.push(provider);
-            Ok(())
-        }
+        Ok(())
     }
 
     pub fn enforce_fips(&mut self) -> Result<(), Error> {
@@ -363,6 +385,13 @@ impl OsslContext {
 
     pub fn ptr(&self) -> *mut OSSL_LIB_CTX {
         self.context
+    }
+
+    pub(crate) fn propq_ptr(&self) -> *const c_char {
+        match &self.propq {
+            Some(p) => p.as_ptr() as *const c_char,
+            None => std::ptr::null(),
+        }
     }
 }
 

--- a/ossl/src/mac.rs
+++ b/ossl/src/mac.rs
@@ -21,9 +21,8 @@ pub struct EvpMacCtx {
 /// Methods for creating (from a named MAC) and accessing `EvpMacCtx`.
 impl EvpMacCtx {
     fn new(ctx: &OsslContext, name: &CStr) -> Result<EvpMacCtx, Error> {
-        let arg = unsafe {
-            EVP_MAC_fetch(ctx.ptr(), name.as_ptr(), std::ptr::null_mut())
-        };
+        let arg =
+            unsafe { EVP_MAC_fetch(ctx.ptr(), name.as_ptr(), ctx.propq_ptr()) };
         if arg.is_null() {
             trace_ossl!("EVP_MAC_fetch()");
             return Err(Error::new(ErrorKind::NullPtr));
@@ -269,8 +268,7 @@ impl OsslMac {
         let (digest, name) = mac_to_digest_and_type(alg);
         let arg = unsafe {
             ERR_set_mark();
-            let m =
-                EVP_MAC_fetch(ctx.ptr(), name.as_ptr(), std::ptr::null_mut());
+            let m = EVP_MAC_fetch(ctx.ptr(), name.as_ptr(), ctx.propq_ptr());
             ERR_pop_to_mark();
             m
         };

--- a/ossl/src/pkey.rs
+++ b/ossl/src/pkey.rs
@@ -29,7 +29,7 @@ impl EvpPkeyCtx {
             EVP_PKEY_CTX_new_from_name(
                 ctx.ptr(),
                 name.as_ptr(),
-                std::ptr::null(),
+                ctx.propq_ptr(),
             )
         };
         if ptr.is_null() {
@@ -1330,7 +1330,7 @@ impl EvpPkey {
                 &mut pp,
                 der.len().try_into()?,
                 ctx.ptr(),
-                std::ptr::null(),
+                ctx.propq_ptr(),
             )
         };
         if pkey.is_null() {
@@ -1420,7 +1420,7 @@ impl EvpPkey {
             EVP_PKEY_CTX_new_from_name(
                 ctx.ptr(),
                 name.as_ptr(),
-                std::ptr::null(),
+                ctx.propq_ptr(),
             )
         };
         if !ptr.is_null() {
@@ -1506,7 +1506,7 @@ impl EvpPkey {
                 EVP_PKEY_CTX_new_from_pkey(
                     ctx.ptr(),
                     self.ptr,
-                    std::ptr::null_mut(),
+                    ctx.propq_ptr(),
                 ),
             )
         }

--- a/ossl/src/rand.rs
+++ b/ossl/src/rand.rs
@@ -65,7 +65,7 @@ impl EvpRandCtx {
         pers: &[u8],
     ) -> Result<EvpRandCtx, Error> {
         let rand = unsafe {
-            EVP_RAND_fetch(ctx.ptr(), c"HMAC-DRBG".as_ptr(), std::ptr::null())
+            EVP_RAND_fetch(ctx.ptr(), c"HMAC-DRBG".as_ptr(), ctx.propq_ptr())
         };
         if rand.is_null() {
             trace_ossl!("EVP_RAND_fetch()");

--- a/ossl/src/signature.rs
+++ b/ossl/src/signature.rs
@@ -31,7 +31,7 @@ impl EvpSignature {
     /// Creates a new `EvpSignature` instance by fetching it by name.
     pub fn new(ctx: &OsslContext, name: &CStr) -> Result<EvpSignature, Error> {
         let ptr: *mut EVP_SIGNATURE = unsafe {
-            EVP_SIGNATURE_fetch(ctx.ptr(), name.as_ptr(), std::ptr::null_mut())
+            EVP_SIGNATURE_fetch(ctx.ptr(), name.as_ptr(), ctx.propq_ptr())
         };
         if ptr.is_null() {
             trace_ossl!("EVP_SIGNATURE_fetch()");
@@ -420,7 +420,7 @@ pub fn available(ctx: &OsslContext, alg: SigAlg) -> bool {
     let name = sigalg_to_ossl_name(alg);
     let ptr = unsafe {
         ERR_set_mark();
-        let p = EVP_SIGNATURE_fetch(ctx.ptr(), name.as_ptr(), std::ptr::null());
+        let p = EVP_SIGNATURE_fetch(ctx.ptr(), name.as_ptr(), ctx.propq_ptr());
         ERR_pop_to_mark();
         p
     };
@@ -775,6 +775,12 @@ impl OsslSignature {
             #[cfg(not(feature = "fips"))]
             {
                 let mut lctx = EvpMdCtx::new()?;
+                unsafe {
+                    EVP_MD_CTX_set_pkey_ctx(
+                        lctx.as_mut_ptr(),
+                        ctx.pkey_ctx.as_mut_ptr(),
+                    )
+                }
                 let ret = unsafe {
                     match ctx.op {
                         SigOp::Sign => EVP_DigestSignInit_ex(
@@ -782,7 +788,7 @@ impl OsslSignature {
                             std::ptr::null_mut(),
                             digest_ptr,
                             libctx.ptr(),
-                            std::ptr::null(),
+                            libctx.propq_ptr(),
                             key.as_ptr() as *mut EVP_PKEY,
                             params_ptr,
                         ),
@@ -791,7 +797,7 @@ impl OsslSignature {
                             std::ptr::null_mut(),
                             digest_ptr,
                             libctx.ptr(),
-                            std::ptr::null(),
+                            libctx.propq_ptr(),
                             key.as_ptr() as *mut EVP_PKEY,
                             params_ptr,
                         ),


### PR DESCRIPTION
#### Description

This resolves the following:
 * The applications using ossl bindings with `ossl::OsslContext::new_lib_ctx()` were not inheriting the FIPS mode of the global context and were not loading FIPS provider where they should
 * If application loaded a FIPS provider using `OsslContext::load_fips_provider()`, the FIPS mode was enforced and it could not work for the algorithms that are not yet certified (but considered crucial = PQC)

This is done by few changes:
~ * Changing the API `new_lib_ctx()` to load default configuration file, which inherently brings the fips provider in FIPS mode~
~ * Changing kryoptic to explicitly not do this with `new_lib_ctx_raw()` otherwise we can very easily deadlock if we load a kryoptic into pkcs11-provider, that would be enabled in the openssl configuration~
 * Introducing a new API to use fips provider in permissive mode. This is done by loading default provider and setting a propq to the context, which is being passed down to any algorithm fetching and further context creation.

#### Checklist

- [~] Test suite updated
- [X] Rustdoc string were added or updated
- [~] CHANGELOG and/or other documentation added or updated

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
