### PR TITLE
Deal with slightly broken Shake on older FIPS modules

### DIFF
--- a/ossl/src/digest.rs
+++ b/ossl/src/digest.rs
@@ -18,8 +18,9 @@ pub struct EvpMd {
 /// Methods for creating and accessing `EvpMd`.
 impl EvpMd {
     pub fn new(ctx: &OsslContext, name: &CStr) -> Result<EvpMd, Error> {
-        let ptr =
-            unsafe { EVP_MD_fetch(ctx.ptr(), name.as_ptr(), ctx.propq_ptr()) };
+        let ptr = unsafe {
+            EVP_MD_fetch(ctx.ptr(), name.as_ptr(), ctx.digest_propq_ptr(name))
+        };
         if ptr.is_null() {
             trace_ossl!("EVP_MD_fetch()");
             return Err(Error::new(ErrorKind::NullPtr));
@@ -273,7 +274,11 @@ impl OsslDigest {
         let name = digest_to_string(digest);
         let arg = unsafe {
             ERR_set_mark();
-            let m = EVP_MD_fetch(ctx.ptr(), name.as_ptr(), ctx.propq_ptr());
+            let m = EVP_MD_fetch(
+                ctx.ptr(),
+                name.as_ptr(),
+                ctx.digest_alg_propq_ptr(digest),
+            );
             ERR_pop_to_mark();
             m
         };

--- a/ossl/src/lib.rs
+++ b/ossl/src/lib.rs
@@ -238,6 +238,7 @@ pub struct OsslContext {
     propq: Option<&'static CStr>,
     #[cfg(feature = "fips")]
     is_fips: bool,
+    fips_permissive: bool,
     broken_shake: bool,
 }
 
@@ -246,6 +247,7 @@ static DEFAULT_PROVIDER_NAME: &CStr = c"default";
 static FIPS_PROVIDER_NAME: &CStr = c"fips";
 
 static FIPS_PROVIDER_PERMISIVE_PROPQ: &CStr = c"?fips=yes";
+pub(crate) static DEFAULT_NON_FIPS_PROPQ: &CStr = c"provider=default,fips=no";
 
 impl OsslContext {
     /// Creates a new empty OpenSSL library context.
@@ -260,6 +262,7 @@ impl OsslContext {
             propq: None,
             #[cfg(feature = "fips")]
             is_fips: false,
+            fips_permissive: false,
             broken_shake: false,
         }
     }
@@ -272,6 +275,7 @@ impl OsslContext {
             propq: None,
             #[cfg(feature = "fips")]
             is_fips: false,
+            fips_permissive: false,
             broken_shake: false,
         }
     }
@@ -283,6 +287,7 @@ impl OsslContext {
             providers: vec![prov as *mut OSSL_PROVIDER],
             propq: None,
             is_fips: true,
+            fips_permissive: false,
             broken_shake: false,
         }
     }
@@ -393,6 +398,7 @@ impl OsslContext {
             }
             self.load_default_provider()?;
             self.propq = Some(FIPS_PROVIDER_PERMISIVE_PROPQ);
+            self.fips_permissive = true;
         }
         Ok(())
     }
@@ -419,6 +425,77 @@ impl OsslContext {
             Some(p) => p.as_ptr() as *const c_char,
             None => std::ptr::null(),
         }
+    }
+
+    pub(crate) fn digest_propq_ptr(&self, name: &CStr) -> *const c_char {
+        if self.broken_shake && self.fips_permissive {
+            if let Ok(alg) = crate::digest::string_to_digest(name) {
+                return self.digest_alg_propq_ptr(alg);
+            }
+        }
+        self.propq_ptr()
+    }
+
+    pub(crate) fn digest_alg_propq_ptr(
+        &self,
+        digest: crate::digest::DigestAlg,
+    ) -> *const c_char {
+        if self.broken_shake && self.fips_permissive {
+            match digest {
+                crate::digest::DigestAlg::Shake128
+                | crate::digest::DigestAlg::Shake256 => {
+                    return DEFAULT_NON_FIPS_PROPQ.as_ptr();
+                }
+                _ => (),
+            }
+        }
+        self.propq_ptr()
+    }
+
+    pub(crate) fn sigalg_propq_ptr(
+        &self,
+        alg: crate::signature::SigAlg,
+    ) -> *const c_char {
+        if self.broken_shake && self.fips_permissive {
+            match alg {
+                crate::signature::SigAlg::Mldsa44
+                | crate::signature::SigAlg::Mldsa65
+                | crate::signature::SigAlg::Mldsa87 => {
+                    return DEFAULT_NON_FIPS_PROPQ.as_ptr();
+                }
+                _ => (),
+            }
+        }
+        self.propq_ptr()
+    }
+
+    pub(crate) fn pkey_type_propq_ptr(
+        &self,
+        pkey_type: &crate::pkey::EvpPkeyType,
+    ) -> *const c_char {
+        if self.broken_shake && self.fips_permissive {
+            match pkey_type {
+                crate::pkey::EvpPkeyType::Mldsa44
+                | crate::pkey::EvpPkeyType::Mldsa65
+                | crate::pkey::EvpPkeyType::Mldsa87 => {
+                    return DEFAULT_NON_FIPS_PROPQ.as_ptr();
+                }
+                _ => (),
+            }
+        }
+        self.propq_ptr()
+    }
+
+    pub(crate) fn pkey_name_propq_ptr(&self, name: &CStr) -> *const c_char {
+        if self.broken_shake && self.fips_permissive {
+            match name.to_bytes() {
+                b"ML-DSA-44" | b"ML-DSA-65" | b"ML-DSA-87" => {
+                    return DEFAULT_NON_FIPS_PROPQ.as_ptr();
+                }
+                _ => (),
+            }
+        }
+        self.propq_ptr()
     }
 }
 

--- a/ossl/src/lib.rs
+++ b/ossl/src/lib.rs
@@ -238,6 +238,7 @@ pub struct OsslContext {
     propq: Option<&'static CStr>,
     #[cfg(feature = "fips")]
     is_fips: bool,
+    broken_shake: bool,
 }
 
 static LEGACY_PROVIDER_NAME: &CStr = c"legacy";
@@ -259,6 +260,7 @@ impl OsslContext {
             propq: None,
             #[cfg(feature = "fips")]
             is_fips: false,
+            broken_shake: false,
         }
     }
 
@@ -270,6 +272,7 @@ impl OsslContext {
             propq: None,
             #[cfg(feature = "fips")]
             is_fips: false,
+            broken_shake: false,
         }
     }
 
@@ -280,6 +283,7 @@ impl OsslContext {
             providers: vec![prov as *mut OSSL_PROVIDER],
             propq: None,
             is_fips: true,
+            broken_shake: false,
         }
     }
 
@@ -364,6 +368,29 @@ impl OsslContext {
             OSSL_PROVIDER_available(self.ptr(), FIPS_PROVIDER_NAME.as_ptr())
         } == 1
         {
+            let prov = unsafe {
+                OSSL_PROVIDER_load(self.ptr(), FIPS_PROVIDER_NAME.as_ptr())
+            };
+            if prov.is_null() {
+                trace_ossl!("OSSL_PROVIDER_load()");
+                return Err(Error::new(ErrorKind::NullPtr));
+            }
+            let mut params_builder = OsslParamBuilder::with_capacity(1);
+            params_builder
+                .add_empty_utf8_ptr(cstr!(OSSL_PROV_PARAM_VERSION))?;
+            let mut params = params_builder.finalize();
+            let ret =
+                unsafe { OSSL_PROVIDER_get_params(prov, params.as_mut_ptr()) };
+            unsafe { OSSL_PROVIDER_unload(prov) };
+            if ret != 1 {
+                trace_ossl!("OSSL_PROVIDER_get_params()");
+                return Err(Error::new(ErrorKind::OsslError));
+            }
+            let version =
+                params.get_utf8_string(cstr!(OSSL_PROV_PARAM_VERSION))?;
+            if version == c"3.0.7" {
+                self.broken_shake = true;
+            }
             self.load_default_provider()?;
             self.propq = Some(FIPS_PROVIDER_PERMISIVE_PROPQ);
         }
@@ -688,6 +715,22 @@ impl<'a> OsslParamBuilder<'a> {
                 key.as_ptr(),
                 void_ptr!(v.as_mut_ptr()) as *mut c_char,
                 len,
+            )
+        };
+        self.v.push(v);
+        self.p.to_mut().push(param);
+        Ok(())
+    }
+
+    /// Adds an empty sized pointer to receive string pointer values from queries
+    /// like get_params()
+    pub fn add_empty_utf8_ptr(&mut self, key: &CStr) -> Result<(), Error> {
+        let mut v = vec![0u8; std::mem::size_of::<*const c_char>()];
+        let param = unsafe {
+            OSSL_PARAM_construct_utf8_ptr(
+                key.as_ptr(),
+                v.as_mut_ptr() as *mut *mut c_char,
+                0,
             )
         };
         self.v.push(v);

--- a/ossl/src/non-openssl-sys-bindings.rs
+++ b/ossl/src/non-openssl-sys-bindings.rs
@@ -2,6 +2,9 @@
 
 pub const OSSL_PARAM_UTF8_STRING: u32 = 4;
 
+// Provider
+pub const OSSL_PROV_PARAM_VERSION: &[u8; 8] = b"version\0";
+
 // Signature + AsymCipher
 pub const OSSL_SIGNATURE_PARAM_CONTEXT_STRING: &[u8; 15] = b"context-string\0";
 pub const OSSL_SIGNATURE_PARAM_DETERMINISTIC: &[u8; 14] = b"deterministic\0";

--- a/ossl/src/pkey.rs
+++ b/ossl/src/pkey.rs
@@ -29,7 +29,7 @@ impl EvpPkeyCtx {
             EVP_PKEY_CTX_new_from_name(
                 ctx.ptr(),
                 name.as_ptr(),
-                ctx.propq_ptr(),
+                ctx.pkey_name_propq_ptr(name),
             )
         };
         if ptr.is_null() {
@@ -1415,13 +1415,10 @@ impl EvpPkey {
 
     /// Checks if the specific key type is available in the current context.
     pub fn available(ctx: &OsslContext, pkey_type: EvpPkeyType) -> bool {
+        let propq = ctx.pkey_type_propq_ptr(&pkey_type);
         let name = pkey_type_to_name(pkey_type);
         let ptr = unsafe {
-            EVP_PKEY_CTX_new_from_name(
-                ctx.ptr(),
-                name.as_ptr(),
-                ctx.propq_ptr(),
-            )
+            EVP_PKEY_CTX_new_from_name(ctx.ptr(), name.as_ptr(), propq)
         };
         if !ptr.is_null() {
             unsafe {
@@ -1497,17 +1494,18 @@ impl EvpPkey {
     ///
     /// Used to prepare for operations using this specific key.
     pub fn new_ctx(&self, ctx: &OsslContext) -> Result<EvpPkeyCtx, Error> {
+        let propq = match self.get_type() {
+            Ok(t) => ctx.pkey_type_propq_ptr(&t),
+            Err(_) => ctx.propq_ptr(),
+        };
+
         /* this function takes care of checking for NULL */
         unsafe {
             EvpPkeyCtx::from_ptr(
                 /* this function will use refcounting to keep EVP_PKEY
                  * alive for the lifetime of the context, so it is ok
                  * to not use rust lifetimes here */
-                EVP_PKEY_CTX_new_from_pkey(
-                    ctx.ptr(),
-                    self.ptr,
-                    ctx.propq_ptr(),
-                ),
+                EVP_PKEY_CTX_new_from_pkey(ctx.ptr(), self.ptr, propq),
             )
         }
     }

--- a/ossl/src/signature.rs
+++ b/ossl/src/signature.rs
@@ -31,7 +31,11 @@ impl EvpSignature {
     /// Creates a new `EvpSignature` instance by fetching it by name.
     pub fn new(ctx: &OsslContext, name: &CStr) -> Result<EvpSignature, Error> {
         let ptr: *mut EVP_SIGNATURE = unsafe {
-            EVP_SIGNATURE_fetch(ctx.ptr(), name.as_ptr(), ctx.propq_ptr())
+            EVP_SIGNATURE_fetch(
+                ctx.ptr(),
+                name.as_ptr(),
+                ctx.pkey_name_propq_ptr(name),
+            )
         };
         if ptr.is_null() {
             trace_ossl!("EVP_SIGNATURE_fetch()");
@@ -420,7 +424,11 @@ pub fn available(ctx: &OsslContext, alg: SigAlg) -> bool {
     let name = sigalg_to_ossl_name(alg);
     let ptr = unsafe {
         ERR_set_mark();
-        let p = EVP_SIGNATURE_fetch(ctx.ptr(), name.as_ptr(), ctx.propq_ptr());
+        let p = EVP_SIGNATURE_fetch(
+            ctx.ptr(),
+            name.as_ptr(),
+            ctx.sigalg_propq_ptr(alg),
+        );
         ERR_pop_to_mark();
         p
     };

--- a/ossl/src/tests/mod.rs
+++ b/ossl/src/tests/mod.rs
@@ -51,3 +51,41 @@ mod digest;
 
 #[cfg(all(ossl_v350, not(feature = "fips")))]
 mod mldsa;
+
+#[cfg(feature = "dynamic")]
+#[test]
+fn test_permissive_fips() {
+    let mut ctx = crate::OsslContext::new_lib_ctx();
+    ctx.load_default_configuration().unwrap();
+    let res = ctx.set_permissive_fips();
+    assert!(res.is_ok());
+}
+
+#[cfg(feature = "dynamic")]
+#[test]
+fn test_provider_version() {
+    let mut ctx = crate::OsslContext::new_lib_ctx();
+    ctx.load_default_provider().unwrap();
+    let prov = unsafe {
+        crate::bindings::OSSL_PROVIDER_load(
+            ctx.ptr(),
+            crate::DEFAULT_PROVIDER_NAME.as_ptr(),
+        )
+    };
+    assert!(!prov.is_null());
+    let mut pb = crate::OsslParamBuilder::with_capacity(1);
+    pb.add_empty_utf8_ptr(crate::cstr!(
+        crate::bindings::OSSL_PROV_PARAM_VERSION
+    ))
+    .unwrap();
+    let mut params = pb.finalize();
+    let ret = unsafe {
+        crate::bindings::OSSL_PROVIDER_get_params(prov, params.as_mut_ptr())
+    };
+    unsafe { crate::bindings::OSSL_PROVIDER_unload(prov) };
+    assert_eq!(ret, 1);
+    let ver = params
+        .get_utf8_string(crate::cstr!(crate::bindings::OSSL_PROV_PARAM_VERSION))
+        .unwrap();
+    assert!(!ver.to_bytes().is_empty());
+}

--- a/ossl/src/tests/mod.rs
+++ b/ossl/src/tests/mod.rs
@@ -57,8 +57,10 @@ mod mldsa;
 fn test_permissive_fips() {
     let mut ctx = crate::OsslContext::new_lib_ctx();
     ctx.load_default_configuration().unwrap();
-    let res = ctx.set_permissive_fips();
-    assert!(res.is_ok());
+    if ctx.fips_is_enabled() {
+        let res = ctx.set_permissive_fips();
+        assert!(res.is_ok());
+    }
 }
 
 #[cfg(feature = "dynamic")]
@@ -88,4 +90,25 @@ fn test_provider_version() {
         .get_utf8_string(crate::cstr!(crate::bindings::OSSL_PROV_PARAM_VERSION))
         .unwrap();
     assert!(!ver.to_bytes().is_empty());
+}
+
+#[cfg(all(ossl_v350, feature = "dynamic"))]
+#[test]
+fn test_shake_digest_with_broken_shake_context() {
+    let mut ctx = crate::OsslContext::new_lib_ctx();
+    ctx.load_default_provider().unwrap();
+    ctx.broken_shake = true;
+    ctx.fips_permissive = true;
+
+    let seed = vec![0x42u8; 32];
+    let key = crate::pkey::EvpPkey::import(
+        &ctx,
+        crate::pkey::EvpPkeyType::Mldsa44,
+        crate::pkey::PkeyData::Mlkey(crate::pkey::MlkeyData {
+            pubkey: None,
+            prikey: None,
+            seed: Some(crate::OsslSecret::from_vec(seed)),
+        }),
+    );
+    assert!(key.is_ok());
 }


### PR DESCRIPTION
#### Description

This patchset tries to handle dealing with slightly broken shake with 3.0.7 based fips modules.

Depends on https://github.com/openssl/openssl/pull/32636

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (strike not applicable items with ~~ around the text) -->

- [x] Test suite updated
- [x] Rustdoc string were added or updated
- [ ] CHANGELOG and/or other documentation added or updated
- [ ] This is not a code change

#### Reviewer's checklist:

- [ ] Any issues marked for closing are fully addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] A changelog entry is added if the change is significant
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible text
- [ ] Doc string are properly updated
