### PR TITLE
Map a failed signature/MAC verification to CKR_SIGNATURE_INVALID

### DIFF
--- a/cdylib/tests/bug490_verify_signature_invalid.rs
+++ b/cdylib/tests/bug490_verify_signature_invalid.rs
@@ -1,0 +1,50 @@
+// Regression test for https://github.com/latchset/kryoptic/issues/490:
+// C_Verify on a tampered signature must return CKR_SIGNATURE_INVALID, not CKR_DEVICE_ERROR.
+mod rc_common;
+
+#[test]
+#[cfg(feature = "integration_tests")]
+fn verify_of_tampered_data_returns_signature_invalid(
+) -> Result<(), Box<dyn std::error::Error>> {
+    use cryptoki::error::{Error as CkError, RvError};
+    use cryptoki::mechanism::Mechanism;
+    use cryptoki::object::Attribute;
+    use cryptoki::session::UserType;
+    use cryptoki::types::AuthPin;
+
+    let (pkcs11, slot) = rc_common::setup_token("bug490_repro", &[]);
+    let user_pin = AuthPin::new("12345678".into());
+    let session = pkcs11.open_rw_session(slot)?;
+    session.login(UserType::User, Some(&user_pin))?;
+
+    let pub_tpl = vec![
+        Attribute::Verify(true),
+        Attribute::ModulusBits(2048.into()),
+        Attribute::PublicExponent(vec![0x01, 0x00, 0x01]),
+    ];
+    let priv_tpl = vec![Attribute::Sensitive(true), Attribute::Sign(true)];
+    let (public, private) = session.generate_key_pair(
+        &Mechanism::RsaPkcsKeyPairGen,
+        &pub_tpl,
+        &priv_tpl,
+    )?;
+
+    let data = b"hello pkcs11";
+    let signature = session.sign(&Mechanism::Sha256RsaPkcs, private, data)?;
+
+    // Correct data must still verify (guards against a fix that just always returns invalid).
+    session.verify(&Mechanism::Sha256RsaPkcs, public, data, &signature)?;
+
+    let mut tampered = data.to_vec();
+    tampered[0] ^= 0xFF;
+
+    match session.verify(
+        &Mechanism::Sha256RsaPkcs,
+        public,
+        &tampered,
+        &signature,
+    ) {
+        Err(CkError::Pkcs11(RvError::SignatureInvalid, _)) => Ok(()),
+        other => panic!("expected CKR_SIGNATURE_INVALID, got: {other:?}"),
+    }
+}

--- a/ossl/src/fips.rs
+++ b/ossl/src/fips.rs
@@ -273,12 +273,17 @@ impl ProviderSignatureCtx {
         unsafe {
             match (*self.vtable).digest_verify_final {
                 Some(f) => {
-                    if f(
+                    let ret = f(
                         self.ctx,
                         signature.as_ptr() as *const c_uchar,
                         signature.len(),
-                    ) != 1
-                    {
+                    );
+                    // 1 = valid signature, 0 = the signature does not
+                    // verify (not an error condition), < 0 = the
+                    // verification operation itself failed.
+                    if ret == 0 {
+                        return Err(Error::new(ErrorKind::VerifyFailed));
+                    } else if ret != 1 {
                         return Err(Error::new(ErrorKind::OsslError));
                     }
                 }
@@ -296,14 +301,19 @@ impl ProviderSignatureCtx {
         unsafe {
             match (*self.vtable).digest_verify {
                 Some(f) => {
-                    if f(
+                    let ret = f(
                         self.ctx,
                         signature.as_ptr() as *const c_uchar,
                         signature.len(),
                         tbs.as_ptr() as *const c_uchar,
                         tbs.len(),
-                    ) != 1
-                    {
+                    );
+                    // 1 = valid signature, 0 = the signature does not
+                    // verify (not an error condition), < 0 = the
+                    // verification operation itself failed.
+                    if ret == 0 {
+                        return Err(Error::new(ErrorKind::VerifyFailed));
+                    } else if ret != 1 {
                         return Err(Error::new(ErrorKind::OsslError));
                     }
                 }

--- a/ossl/src/lib.rs
+++ b/ossl/src/lib.rs
@@ -111,6 +111,10 @@ pub enum ErrorKind {
     BufferSize,
     /// An optional argument is required or has a bad value
     BadArg,
+    /// A signature/MAC verification operation completed normally but the
+    /// signature did not match — distinct from OsslError, which indicates
+    /// the verification operation itself could not be completed
+    VerifyFailed,
 }
 
 impl std::fmt::Display for ErrorKind {
@@ -124,6 +128,7 @@ impl std::fmt::Display for ErrorKind {
             ErrorKind::BadArg => {
                 "An optional argument is required or has a bad value"
             }
+            ErrorKind::VerifyFailed => "The signature or MAC did not verify",
         })
     }
 }

--- a/ossl/src/signature.rs
+++ b/ossl/src/signature.rs
@@ -1193,7 +1193,14 @@ impl OsslSignature {
                 };
                 if ret != 1 {
                     trace_ossl!("EVP_DigestVerify()");
-                    return Err(Error::new(ErrorKind::OsslError));
+                    // EVP_DigestVerify(): 1 = valid signature, 0 = the
+                    // signature does not verify (not an error condition),
+                    // < 0 = the verification operation itself failed.
+                    return Err(Error::new(if ret == 0 {
+                        ErrorKind::VerifyFailed
+                    } else {
+                        ErrorKind::OsslError
+                    }));
                 }
             }
             #[cfg(feature = "fips")]
@@ -1212,7 +1219,14 @@ impl OsslSignature {
             };
             if ret != 1 {
                 trace_ossl!("EVP_PKEY_verify()");
-                return Err(Error::new(ErrorKind::OsslError));
+                // EVP_PKEY_verify(): 1 = valid signature, 0 = the signature
+                // does not verify (not an error condition), < 0 = the
+                // verification operation itself failed.
+                return Err(Error::new(if ret == 0 {
+                    ErrorKind::VerifyFailed
+                } else {
+                    ErrorKind::OsslError
+                }));
             }
         }
         Ok(())
@@ -1432,7 +1446,14 @@ impl OsslSignature {
                 };
                 if ret != 1 {
                     trace_ossl!("EVP_DigestVerifyFinal()");
-                    return Err(Error::new(ErrorKind::OsslError));
+                    // EVP_DigestVerifyFinal(): 1 = valid signature, 0 = the
+                    // signature does not verify (not an error condition),
+                    // < 0 = the verification operation itself failed.
+                    return Err(Error::new(if ret == 0 {
+                        ErrorKind::VerifyFailed
+                    } else {
+                        ErrorKind::OsslError
+                    }));
                 } else {
                     return Ok(());
                 }
@@ -1455,7 +1476,15 @@ impl OsslSignature {
             };
             if ret != 1 {
                 trace_ossl!("EVP_PKEY_verify_message_final()");
-                return Err(Error::new(ErrorKind::OsslError));
+                // EVP_PKEY_verify_message_final(): 1 = valid signature,
+                // 0 = the signature does not verify (not an error
+                // condition), < 0 = the verification operation itself
+                // failed.
+                return Err(Error::new(if ret == 0 {
+                    ErrorKind::VerifyFailed
+                } else {
+                    ErrorKind::OsslError
+                }));
             }
 
             return Ok(());

--- a/src/error.rs
+++ b/src/error.rs
@@ -278,6 +278,12 @@ impl From<ossl::Error> for Error {
         match error.kind() {
             ossl::ErrorKind::KeyError => Error::ck_rv(CKR_KEY_INDIGESTIBLE),
             ossl::ErrorKind::WrapperError => Error::ck_rv(CKR_GENERAL_ERROR),
+            // The verification operation completed normally but the
+            // signature/MAC did not match — PKCS#11 v3.2 5.1 mandates
+            // CKR_SIGNATURE_INVALID for this, not a device/general error.
+            ossl::ErrorKind::VerifyFailed => {
+                Error::ck_rv(CKR_SIGNATURE_INVALID)
+            }
             _ => Error::ck_rv(CKR_DEVICE_ERROR),
         }
     }


### PR DESCRIPTION
## Summary

Fixes #490.

`EVP_PKEY_verify`/`EVP_DigestVerify`/`EVP_PKEY_verify_message_final` (and the FIPS provider vtable
equivalents) return `1` for a valid signature, `0` when the signature simply does not verify, and
a negative value when the verification operation itself failed. Every call site collapsed the `0`
and negative cases into the same `ossl::ErrorKind::OsslError`, which the PKCS#11 layer's generic
fallback then mapped to `CKR_DEVICE_ERROR` instead of the spec-mandated `CKR_SIGNATURE_INVALID`
(PKCS#11 v3.2 §5.1) — so a caller verifying tampered/forged data (the normal, expected case) gets
an error it has to special-case instead of a clean negative result.

- Add `ossl::ErrorKind::VerifyFailed` for "the operation completed, the signature didn't match" —
  distinct from `OsslError` ("the operation itself couldn't be completed").
- Use it at all 6 affected call sites: `verify()`/`verify_final()` in `ossl/src/signature.rs`
  (`EVP_DigestVerify`, `EVP_PKEY_verify`, `EVP_DigestVerifyFinal`, `EVP_PKEY_verify_message_final`)
  and the FIPS provider vtable's `digest_verify`/`digest_verify_final` in `ossl/src/fips.rs`.
- Map `VerifyFailed` to `CKR_SIGNATURE_INVALID` in `src/error.rs`'s `From<ossl::Error>`.
- Add a regression test (`cdylib/tests/bug490_verify_signature_invalid.rs`) reproducing the exact
  scenario from #490: sign, verify correct data (must still succeed), tamper one byte, verify
  again and assert `CKR_SIGNATURE_INVALID` rather than the previous `CKR_DEVICE_ERROR`.

## Test plan

- [x] `cargo test --release --features pqc -p kryoptic-lib --lib` — all 122 existing internal
      unit tests still pass (no regression).
- [x] `cargo test --release --features pqc,integration_tests -p kryoptic` — all existing cdylib
      integration tests (`rc_ecdh`, `rc_eddsa_compat`, `rc_login`, `rc_re_initialize`,
      `rust_cryptoki`) still pass.
- [x] New regression test `bug490_verify_signature_invalid` passes against the fix and was
      confirmed to fail (with `CKR_DEVICE_ERROR`) against `main` before the fix.