### PR TITLE
Fix CKM_AES_CCM one-shot C_EncryptMessage/C_DecryptMessage length probe

### DIFF
--- a/src/fns/encryption.rs
+++ b/src/fns/encryption.rs
@@ -668,8 +668,14 @@ fn encrypt_message(
     }
 
     if ciphertext.is_null() {
+        // A one-step C_EncryptMessage call is, by the msg_encryption_len
+        // contract (see MsgEncryption::msg_encryption_len), equivalent to
+        // a multi-part finalization -- pass final=true so mechanisms whose
+        // output length depends on it (e.g. CKM_AES_CCM, which buffers and
+        // writes nothing until the whole message is available) report the
+        // length the subsequent real call will actually produce.
         let retlen =
-            CK_ULONG::try_from(operation.msg_encryption_len(plen, false)?)
+            CK_ULONG::try_from(operation.msg_encryption_len(plen, true)?)
                 .map_err(|_| CKR_GENERAL_ERROR)?;
         unsafe {
             *pul_ciphertext_len = retlen;
@@ -1062,8 +1068,11 @@ fn decrypt_message(
     }
 
     if plaintext.is_null() {
+        // See the identical comment in encrypt_message: a one-step
+        // C_DecryptMessage call is equivalent to a multi-part
+        // finalization for the msg_decryption_len contract.
         let retlen =
-            CK_ULONG::try_from(operation.msg_decryption_len(clen, false)?)
+            CK_ULONG::try_from(operation.msg_decryption_len(clen, true)?)
                 .map_err(|_| CKR_GENERAL_ERROR)?;
         unsafe {
             *pul_plaintext_len = retlen;

--- a/src/ossl/aes.rs
+++ b/src/ossl/aes.rs
@@ -2189,13 +2189,31 @@ impl MsgEncryption for AesOperation {
     fn msg_encryption_len(
         &mut self,
         data_len: usize,
-        _fin: bool,
+        fin: bool,
     ) -> Result<usize> {
         if self.finalized {
             return Err(CKR_OPERATION_NOT_INITIALIZED)?;
         }
         match self.mech {
-            CKM_AES_CCM => Ok(self.params.datalen),
+            CKM_AES_CCM => {
+                if fin {
+                    /* CCM is one-shot in OpenSSL: nothing is written to the
+                     * cipher buffer until the whole message (whatever was
+                     * already buffered by prior msg_encrypt_next calls, plus
+                     * this final chunk) has been accumulated. Using
+                     * self.params.datalen here would be wrong (and, for the
+                     * one-step msg_encrypt entry point, simply unset) before
+                     * the per-message CK_CCM_MESSAGE_PARAMS have been parsed
+                     * by msg_encrypt_begin/msg_encrypt_new -- buffer.len() +
+                     * data_len is always the correct total regardless of
+                     * whether that has happened yet. */
+                    Ok(self.buffer.len() + data_len)
+                } else {
+                    /* Intermediate (non-final) chunks are only buffered;
+                     * msg_encrypt_next never writes any output for CCM. */
+                    Ok(0)
+                }
+            }
             CKM_AES_GCM => Ok(data_len),
             _ => Err(self.op_err(CKR_GENERAL_ERROR)),
         }
@@ -2393,13 +2411,26 @@ impl MsgDecryption for AesOperation {
     fn msg_decryption_len(
         &mut self,
         data_len: usize,
-        _fin: bool,
+        fin: bool,
     ) -> Result<usize> {
         if self.finalized {
             return Err(CKR_OPERATION_NOT_INITIALIZED)?;
         }
         match self.mech {
-            CKM_AES_CCM => Ok(self.params.datalen),
+            CKM_AES_CCM => {
+                // See the identical comment in msg_encryption_len: CCM is
+                // one-shot in OpenSSL, nothing is written to the plaintext
+                // buffer until the whole message is available, and
+                // self.params.datalen is unset until msg_decrypt_begin has
+                // parsed the per-message CK_CCM_MESSAGE_PARAMS -- which,
+                // for the one-step msg_decrypt entry point, hasn't happened
+                // yet when this is called to probe the required length.
+                if fin {
+                    Ok(self.buffer.len() + data_len)
+                } else {
+                    Ok(0)
+                }
+            }
             CKM_AES_GCM => Ok(data_len),
             _ => Err(self.op_err(CKR_GENERAL_ERROR)),
         }

--- a/src/tests/aes.rs
+++ b/src/tests/aes.rs
@@ -2083,3 +2083,128 @@ fn test_aes_iv_generators() {
 
     testtokn.finalize();
 }
+
+/// Regression test for the null-buffer length-probe of the one-shot
+/// C_EncryptMessage/C_DecryptMessage functions on CKM_AES_CCM: calling
+/// either with a NULL output pointer (to learn the required buffer size,
+/// per PKCS#11's usual "call once with NULL to get the length" idiom) must
+/// report the real length rather than 0. Before the fix, self.params
+/// (populated only by msg_encrypt_new/msg_decrypt_new, which the one-shot
+/// entry point only reaches on the *second*, real call) hadn't been set
+/// yet at probe time, so CCM's msg_encryption_len/msg_decryption_len read
+/// a stale/default datalen of 0.
+#[test]
+#[parallel]
+fn test_aes_ccm_message_one_shot_length_probe() {
+    let mut testtokn = TestToken::initialized(
+        "test_aes_ccm_message_one_shot_length_probe",
+        None,
+    );
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let handle = ret_or_panic!(generate_key(
+        session,
+        CKM_AES_KEY_GEN,
+        std::ptr::null_mut(),
+        0,
+        &[(CKA_VALUE_LEN, 16),],
+        &[],
+        &[(CKA_ENCRYPT, true), (CKA_DECRYPT, true),],
+    ));
+
+    let nonce = b"BA0987654321".to_vec();
+    let aad = b"AUTH ME".to_vec();
+    let plaintext = b"01234567".to_vec();
+
+    let mut mechanism: CK_MECHANISM = CK_MECHANISM {
+        mechanism: CKM_AES_CCM,
+        pParameter: std::ptr::null_mut(),
+        ulParameterLen: 0,
+    };
+
+    /* --- Encrypt: probe, then the real call --- */
+    let ret = fn_message_encrypt_init(session, &mut mechanism, handle);
+    assert_eq!(ret, CKR_OK);
+
+    let mut nonce_buf = nonce.clone();
+    let mut tag = [0u8; 8];
+    let mut params = CK_CCM_MESSAGE_PARAMS {
+        ulDataLen: plaintext.len() as CK_ULONG,
+        pNonce: nonce_buf.as_mut_ptr(),
+        ulNonceLen: nonce_buf.len() as CK_ULONG,
+        ulNonceFixedBits: 0,
+        nonceGenerator: CKG_NO_GENERATE,
+        pMAC: tag.as_mut_ptr(),
+        ulMACLen: tag.len() as CK_ULONG,
+    };
+
+    let mut probed_len: CK_ULONG = 0;
+    let ret = fn_encrypt_message(
+        session,
+        void_ptr!(&mut params),
+        sizeof!(CK_CCM_MESSAGE_PARAMS),
+        byte_ptr!(aad.as_ptr()),
+        aad.len() as CK_ULONG,
+        plaintext.as_ptr() as *mut CK_BYTE,
+        plaintext.len() as CK_ULONG,
+        std::ptr::null_mut(),
+        &mut probed_len,
+    );
+    assert_eq!(ret, CKR_OK);
+    assert_eq!(probed_len as usize, plaintext.len());
+
+    let mut enc = vec![0u8; probed_len as usize];
+    let mut enc_len = enc.len() as CK_ULONG;
+    let ret = fn_encrypt_message(
+        session,
+        void_ptr!(&mut params),
+        sizeof!(CK_CCM_MESSAGE_PARAMS),
+        byte_ptr!(aad.as_ptr()),
+        aad.len() as CK_ULONG,
+        plaintext.as_ptr() as *mut CK_BYTE,
+        plaintext.len() as CK_ULONG,
+        enc.as_mut_ptr(),
+        &mut enc_len,
+    );
+    assert_eq!(ret, CKR_OK);
+    assert_eq!(enc_len as usize, plaintext.len());
+
+    /* --- Decrypt: probe, then the real call, and check the round-trip --- */
+    let ret = fn_message_decrypt_init(session, &mut mechanism, handle);
+    assert_eq!(ret, CKR_OK);
+
+    let mut probed_len: CK_ULONG = 0;
+    let ret = fn_decrypt_message(
+        session,
+        void_ptr!(&mut params),
+        sizeof!(CK_CCM_MESSAGE_PARAMS),
+        byte_ptr!(aad.as_ptr()),
+        aad.len() as CK_ULONG,
+        enc.as_ptr() as *mut CK_BYTE,
+        enc_len,
+        std::ptr::null_mut(),
+        &mut probed_len,
+    );
+    assert_eq!(ret, CKR_OK);
+    assert_eq!(probed_len as usize, plaintext.len());
+
+    let mut dec = vec![0u8; probed_len as usize];
+    let mut dec_len = dec.len() as CK_ULONG;
+    let ret = fn_decrypt_message(
+        session,
+        void_ptr!(&mut params),
+        sizeof!(CK_CCM_MESSAGE_PARAMS),
+        byte_ptr!(aad.as_ptr()),
+        aad.len() as CK_ULONG,
+        enc.as_ptr() as *mut CK_BYTE,
+        enc_len,
+        dec.as_mut_ptr(),
+        &mut dec_len,
+    );
+    assert_eq!(ret, CKR_OK);
+    assert_eq!(dec_len as usize, plaintext.len());
+    assert_eq!(dec, plaintext);
+
+    testtokn.finalize();
+}


### PR DESCRIPTION
## Summary

Fixes #491.

A one-step `C_EncryptMessage`/`C_DecryptMessage` call with a NULL output buffer (the standard
PKCS#11 "probe the required length" idiom) reported `0` for `CKM_AES_CCM` instead of the real
length, because `msg_encryption_len`/`msg_decryption_len` read `self.params.datalen` — which is
only populated once `msg_encrypt_begin`/`msg_decrypt_begin` has parsed the per-message
`CK_CCM_MESSAGE_PARAMS`, i.e. never, on the probe call of the one-shot entry point (only the
real, second call reaches that code path). A caller that (correctly) allocates a buffer sized to
the reported `0` and calls again ends up encrypting/decrypting into an empty buffer.

`MsgEncryption::msg_encryption_len`'s own doc comment already specifies that `final=true` means
"the next operation is either msg_encrypt or msg_encrypt_final" — i.e. the one-shot call is
supposed to be treated as final. `encrypt_message()`/`decrypt_message()` were instead hardcoding
`false` for it.

- Pass `final=true` (not `false`) from the one-shot `C_EncryptMessage`/`C_DecryptMessage` handlers.
- Make CCM's `msg_encryption_len`/`msg_decryption_len` report `self.buffer.len() + data_len` when
  `final` is true (matching what the real call will actually write, whether or not
  `msg_*_begin` has already run) and `0` otherwise (intermediate chunks are only buffered).
- Add a regression test exercising the exact reported scenario: probe, then the real one-shot
  encrypt call, then the same for decrypt, checking the round-trip.

## Test plan

- [x] New regression test `test_aes_ccm_message_one_shot_length_probe` confirmed to fail
      (reports length 0) against the unfixed code, and to pass with the fix.
- [x] `cargo test --release --features pqc -p kryoptic-lib --lib` — all 122 pre-existing unit
      tests plus the new one pass.
- [x] `cargo test --release --features pqc,integration_tests -p kryoptic` — all cdylib
      integration tests (`rc_ecdh`, `rc_eddsa_compat`, `rc_login`, `rc_re_initialize`,
      `rust_cryptoki`) still pass.
- [x] `make check-format` clean.