### PR TITLE
Report the real required length on CKR_BUFFER_TOO_SMALL

### DIFF
--- a/src/fns/encryption.rs
+++ b/src/fns/encryption.rs
@@ -13,6 +13,7 @@ use crate::error::Result;
 use crate::log_debug;
 use crate::mechanism::{Decryption, Encryption, MsgDecryption, MsgEncryption};
 use crate::pkcs11::*;
+use crate::report_reqsize;
 use crate::session::Session;
 use crate::STATE;
 
@@ -109,7 +110,10 @@ fn encrypt(
     let enclen = usize::try_from(penclen).map_err(|_| CKR_ARGUMENTS_BAD)?;
     let encdata: &mut [u8] =
         unsafe { std::slice::from_raw_parts_mut(encrypted_data, enclen) };
-    let outlen = operation.encrypt(data, encdata)?;
+    let outlen = report_reqsize(
+        operation.encrypt(data, encdata),
+        pul_encrypted_data_len,
+    )?;
     let retlen = CK_ULONG::try_from(outlen).map_err(|_| CKR_GENERAL_ERROR)?;
     unsafe { *pul_encrypted_data_len = retlen };
 
@@ -173,7 +177,10 @@ pub(crate) fn internal_encrypt_update(
         let enclen = usize::try_from(penclen).map_err(|_| CKR_ARGUMENTS_BAD)?;
         let encpart: &mut [u8] =
             unsafe { std::slice::from_raw_parts_mut(encrypted_part, enclen) };
-        operation.encrypt_update(data, encpart)?
+        report_reqsize(
+            operation.encrypt_update(data, encpart),
+            pul_encrypted_part_len,
+        )?
     };
     let cklen = CK_ULONG::try_from(len).map_err(|_| CKR_ARGUMENTS_BAD)?;
     unsafe { *pul_encrypted_part_len = cklen };
@@ -260,7 +267,10 @@ fn encrypt_final(
     let enclen = usize::try_from(penclen).map_err(|_| CKR_ARGUMENTS_BAD)?;
     let enclast: &mut [u8] =
         unsafe { std::slice::from_raw_parts_mut(last_encrypted_part, enclen) };
-    let outlen = operation.encrypt_final(enclast)?;
+    let outlen = report_reqsize(
+        operation.encrypt_final(enclast),
+        pul_last_encrypted_part_len,
+    )?;
     let retlen = CK_ULONG::try_from(outlen).map_err(|_| CKR_GENERAL_ERROR)?;
     unsafe { *pul_last_encrypted_part_len = retlen };
 
@@ -388,7 +398,7 @@ fn decrypt(
     let dlen = usize::try_from(pdlen).map_err(|_| CKR_ARGUMENTS_BAD)?;
     let ddata: &mut [u8] =
         unsafe { std::slice::from_raw_parts_mut(data, dlen) };
-    let outlen = operation.decrypt(enc, ddata)?;
+    let outlen = report_reqsize(operation.decrypt(enc, ddata), pul_data_len)?;
     let retlen = CK_ULONG::try_from(outlen).map_err(|_| CKR_GENERAL_ERROR)?;
     unsafe { *pul_data_len = retlen };
 
@@ -454,7 +464,7 @@ pub(crate) fn internal_decrypt_update(
         let plen = usize::try_from(pplen).map_err(|_| CKR_ARGUMENTS_BAD)?;
         let dpart: &mut [u8] =
             unsafe { std::slice::from_raw_parts_mut(part, plen) };
-        operation.decrypt_update(enc, dpart)?
+        report_reqsize(operation.decrypt_update(enc, dpart), pul_part_len)?
     };
     let cklen = CK_ULONG::try_from(len).map_err(|_| CKR_ARGUMENTS_BAD)?;
     unsafe { *pul_part_len = cklen };
@@ -541,7 +551,8 @@ fn decrypt_final(
     let plen = usize::try_from(pplen).map_err(|_| CKR_ARGUMENTS_BAD)?;
     let dlast: &mut [u8] =
         unsafe { std::slice::from_raw_parts_mut(last_part, plen) };
-    let outlen = operation.decrypt_final(dlast)?;
+    let outlen =
+        report_reqsize(operation.decrypt_final(dlast), pul_last_part_len)?;
     let retlen = CK_ULONG::try_from(outlen).map_err(|_| CKR_GENERAL_ERROR)?;
     unsafe { *pul_last_part_len = retlen };
 
@@ -692,12 +703,9 @@ fn encrypt_message(
     let cipher: &mut [u8] =
         unsafe { std::slice::from_raw_parts_mut(ciphertext, clen) };
 
-    let outlen = operation.msg_encrypt(
-        parameter,
-        parameter_len,
-        adata,
-        plain,
-        cipher,
+    let outlen = report_reqsize(
+        operation.msg_encrypt(parameter, parameter_len, adata, plain, cipher),
+        pul_ciphertext_len,
     )?;
     let retlen = CK_ULONG::try_from(outlen).map_err(|_| CKR_GENERAL_ERROR)?;
     unsafe { *pul_ciphertext_len = retlen };
@@ -883,20 +891,23 @@ fn encrypt_message_next(
     let cipher: &mut [u8] =
         unsafe { std::slice::from_raw_parts_mut(ciphertext_part, clen) };
 
-    let outlen = match fin {
-        false => operation.msg_encrypt_next(
-            parameter,
-            parameter_len,
-            plain,
-            cipher,
-        )?,
-        true => operation.msg_encrypt_final(
-            parameter,
-            parameter_len,
-            plain,
-            cipher,
-        )?,
-    };
+    let outlen = report_reqsize(
+        match fin {
+            false => operation.msg_encrypt_next(
+                parameter,
+                parameter_len,
+                plain,
+                cipher,
+            ),
+            true => operation.msg_encrypt_final(
+                parameter,
+                parameter_len,
+                plain,
+                cipher,
+            ),
+        },
+        pul_ciphertext_part_len,
+    )?;
     let retlen = CK_ULONG::try_from(outlen).map_err(|_| CKR_GENERAL_ERROR)?;
     unsafe { *pul_ciphertext_part_len = retlen };
 
@@ -1089,12 +1100,9 @@ fn decrypt_message(
     let plain: &mut [u8] =
         unsafe { std::slice::from_raw_parts_mut(plaintext, plen) };
 
-    let outlen = operation.msg_decrypt(
-        parameter,
-        parameter_len,
-        adata,
-        cipher,
-        plain,
+    let outlen = report_reqsize(
+        operation.msg_decrypt(parameter, parameter_len, adata, cipher, plain),
+        pul_plaintext_len,
     )?;
     let retlen = CK_ULONG::try_from(outlen).map_err(|_| CKR_GENERAL_ERROR)?;
     unsafe { *pul_plaintext_len = retlen };
@@ -1280,20 +1288,23 @@ fn decrypt_message_next(
     let plain: &mut [u8] =
         unsafe { std::slice::from_raw_parts_mut(plaintext_part, plen) };
 
-    let outlen = match fin {
-        false => operation.msg_decrypt_next(
-            parameter,
-            parameter_len,
-            cipher,
-            plain,
-        )?,
-        true => operation.msg_decrypt_final(
-            parameter,
-            parameter_len,
-            cipher,
-            plain,
-        )?,
-    };
+    let outlen = report_reqsize(
+        match fin {
+            false => operation.msg_decrypt_next(
+                parameter,
+                parameter_len,
+                cipher,
+                plain,
+            ),
+            true => operation.msg_decrypt_final(
+                parameter,
+                parameter_len,
+                cipher,
+                plain,
+            ),
+        },
+        pul_plaintext_part_len,
+    )?;
     let retlen = CK_ULONG::try_from(outlen).map_err(|_| CKR_GENERAL_ERROR)?;
     unsafe { *pul_plaintext_part_len = retlen };
 

--- a/src/fns/general.rs
+++ b/src/fns/general.rs
@@ -202,6 +202,7 @@ fn get_interface_list(
     }
     unsafe {
         if *count < iflen {
+            *count = iflen;
             return Err(CKR_BUFFER_TOO_SMALL)?;
         }
     }

--- a/src/fns/keymgmt.rs
+++ b/src/fns/keymgmt.rs
@@ -12,7 +12,7 @@ use crate::log_debug;
 use crate::misc::bytes_to_slice;
 use crate::object;
 use crate::pkcs11::*;
-use crate::{fail_if_cka_token_true, STATE};
+use crate::{fail_if_cka_token_true, report_reqsize, STATE};
 
 #[cfg(feature = "fips")]
 use crate::fips;
@@ -312,8 +312,10 @@ fn wrap_key(
             usize::try_from(pwraplen).map_err(|_| CKR_ARGUMENTS_BAD)?;
         unsafe { std::slice::from_raw_parts_mut(wrapped_key, wraplen) }
     };
-    let outlen = match mech.wrap_key(&mechanism, &wkey, &key, wrapped, factory)
-    {
+    let outlen = match report_reqsize(
+        mech.wrap_key(&mechanism, &wkey, &key, wrapped, factory),
+        pul_wrapped_key_len,
+    ) {
         Ok(len) => {
             #[cfg(feature = "fips")]
             session.set_fips_indicator(fips::indicators::is_approved(
@@ -864,6 +866,9 @@ fn encapsulate_key(
         return Ok(());
     }
     if ciphertext_len > enclen {
+        unsafe {
+            *encrypted_part_len = ctext_len;
+        }
         return Err(CKR_BUFFER_TOO_SMALL)?;
     }
 

--- a/src/fns/mod.rs
+++ b/src/fns/mod.rs
@@ -6,7 +6,7 @@
 //! This module and its submodules contain the implementation of the various
 //! PKCS#11 functions exported via the Function List.
 
-use crate::error::Result;
+use crate::error::{ErrorKind, Result};
 use crate::pkcs11::*;
 use crate::{get_random_data, random_add_seed, STATE};
 
@@ -37,6 +37,30 @@ pub(crate) fn fail_if_cka_token_true(template: &[CK_ATTRIBUTE]) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// If `result` failed with CKR_BUFFER_TOO_SMALL, writes the error's required size into
+/// `out_len` before returning it unchanged. PKCS#11 v3.2 5.2 requires a function returning
+/// CKR_BUFFER_TOO_SMALL to report the real required length so a caller can retry with a
+/// correctly-sized buffer; every `extern "C" fn_*` wrapper's `Err(e) => e.rv()` conversion
+/// discards `e.reqsize()` (the field `Error::buf_too_small` exists specifically to carry this
+/// value) otherwise, leaving the output-length pointer at whatever the caller originally
+/// passed in. `out_len` may be null (some call sites have none to report through); a null
+/// pointer, or a `reqsize` that doesn't fit in a `CK_ULONG`, makes this a no-op.
+pub(crate) fn report_reqsize<T>(
+    result: Result<T>,
+    out_len: CK_ULONG_PTR,
+) -> Result<T> {
+    if let Err(ref e) = result {
+        if e.kind() == ErrorKind::BufferTooSmall && !out_len.is_null() {
+            if let Ok(reqsize) = CK_ULONG::try_from(e.reqsize()) {
+                unsafe {
+                    *out_len = reqsize;
+                }
+            }
+        }
+    }
+    result
 }
 
 #[inline(always)]

--- a/src/fns/signing.rs
+++ b/src/fns/signing.rs
@@ -104,6 +104,7 @@ fn sign(
     }
     unsafe {
         if *pul_signature_len < sig_len {
+            *pul_signature_len = sig_len;
             return Err(CKR_BUFFER_TOO_SMALL)?;
         }
     }
@@ -235,6 +236,7 @@ fn sign_final(
     }
     unsafe {
         if *pul_signature_len < sig_len {
+            *pul_signature_len = sig_len;
             return Err(CKR_BUFFER_TOO_SMALL)?;
         }
     }

--- a/src/fns/stmgmt.rs
+++ b/src/fns/stmgmt.rs
@@ -36,6 +36,7 @@ fn get_slot_list(
     unsafe {
         let num: CK_ULONG = *count;
         if num < silen {
+            *count = silen;
             return Err(CKR_BUFFER_TOO_SMALL)?;
         }
     }
@@ -157,6 +158,10 @@ fn get_mechanism_list(
     let mechs = token.get_mechs_list();
     let num = unsafe { *count };
     if (num as usize) < mechs.len() {
+        unsafe {
+            *count = CK_ULONG::try_from(mechs.len())
+                .map_err(|_| CKR_GENERAL_ERROR)?;
+        }
         return Err(CKR_BUFFER_TOO_SMALL)?;
     }
     for (udx, mech) in mechs.iter().enumerate() {

--- a/src/hotp.rs
+++ b/src/hotp.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use std::sync::LazyLock;
 
 use crate::attribute::{Attribute, CkAttrs};
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::hash::{HASH_LEN_SHA1, HASH_LEN_SHA256, HASH_LEN_SHA512};
 use crate::mechanism::{
     Mac, MechOperation, Mechanism, Mechanisms, Sign, Verify,
@@ -546,7 +546,7 @@ impl Sign for HOTPOperation {
         let total_size = struct_size + param_size + self.length;
 
         if signature.len() < total_size {
-            return Err(CKR_BUFFER_TOO_SMALL)?;
+            return Err(Error::buf_too_small(total_size));
         }
 
         self.finalized = true;

--- a/src/ossl/rsa.rs
+++ b/src/ossl/rsa.rs
@@ -647,7 +647,7 @@ impl Decryption for RsaPKCSOperation {
             }
 
             if plain.len() < outlen && plain.len() < self.output_len {
-                return Err(CKR_BUFFER_TOO_SMALL)?;
+                return Err(Error::buf_too_small(outlen));
             }
             self.finalized = true;
 

--- a/src/tests/aes.rs
+++ b/src/tests/aes.rs
@@ -2208,3 +2208,349 @@ fn test_aes_ccm_message_one_shot_length_probe() {
 
     testtokn.finalize();
 }
+
+/// Regression test for the streaming C_EncryptUpdate call site (fns/encryption.rs
+/// internal_encrypt_update, a distinct place the CKR_BUFFER_TOO_SMALL reqsize fix could have
+/// been missed vs. the one-shot C_Encrypt / C_Decrypt call sites).
+#[test]
+#[parallel]
+fn test_aes_encrypt_update_buffer_too_small_reports_required_len() {
+    let mut testtokn = TestToken::initialized(
+        "test_aes_encrypt_update_buffer_too_small_reports_required_len",
+        None,
+    );
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let handle = ret_or_panic!(generate_key(
+        session,
+        CKM_AES_KEY_GEN,
+        std::ptr::null_mut(),
+        0,
+        &[(CKA_VALUE_LEN, 32),],
+        &[],
+        &[(CKA_ENCRYPT, true), (CKA_DECRYPT, true),],
+    ));
+
+    let iv = "FEDCBA0987654321";
+    let mut mechanism = CK_MECHANISM {
+        mechanism: CKM_AES_CBC,
+        pParameter: void_ptr!(iv.as_bytes()),
+        ulParameterLen: iv.len() as CK_ULONG,
+    };
+    let ret = fn_encrypt_init(session, &mut mechanism, handle);
+    assert_eq!(ret, CKR_OK);
+
+    /* Exactly one block: CBC (no padding) always emits AES_BLOCK_SIZE bytes for it. */
+    let data = "0123456789ABCDEF";
+    let mut enc: [u8; 4] = [0; 4];
+    let mut enc_len: CK_ULONG = enc.len() as CK_ULONG;
+    let ret = fn_encrypt_update(
+        session,
+        data.as_ptr() as *mut u8,
+        data.len() as CK_ULONG,
+        enc.as_mut_ptr(),
+        &mut enc_len,
+    );
+    assert_eq!(ret, CKR_BUFFER_TOO_SMALL);
+    assert_eq!(
+        enc_len, AES_BLOCK_SIZE as CK_ULONG,
+        "CKR_BUFFER_TOO_SMALL must report the real required length ({} \
+         bytes), not leave *pulEncryptedPartLen at whatever the caller \
+         originally passed in (4)",
+        AES_BLOCK_SIZE
+    );
+
+    let mut enc2 = vec![0u8; enc_len as usize];
+    let mut enc2_len = enc2.len() as CK_ULONG;
+    let ret = fn_encrypt_update(
+        session,
+        data.as_ptr() as *mut u8,
+        data.len() as CK_ULONG,
+        enc2.as_mut_ptr(),
+        &mut enc2_len,
+    );
+    assert_eq!(ret, CKR_OK);
+    assert_eq!(enc2_len, AES_BLOCK_SIZE as CK_ULONG);
+
+    testtokn.finalize();
+}
+
+/// Regression test for the streaming C_EncryptFinal call site (fns/encryption.rs
+/// encrypt_final), distinct from C_EncryptUpdate above -- CBC_PAD's finalize path has its own
+/// buf_too_small(AES_BLOCK_SIZE) check for the padding block.
+#[test]
+#[parallel]
+fn test_aes_encrypt_final_buffer_too_small_reports_required_len() {
+    let mut testtokn = TestToken::initialized(
+        "test_aes_encrypt_final_buffer_too_small_reports_required_len",
+        None,
+    );
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let handle = ret_or_panic!(generate_key(
+        session,
+        CKM_AES_KEY_GEN,
+        std::ptr::null_mut(),
+        0,
+        &[(CKA_VALUE_LEN, 32),],
+        &[],
+        &[(CKA_ENCRYPT, true), (CKA_DECRYPT, true),],
+    ));
+
+    let iv = "FEDCBA0987654321";
+    let mut mechanism = CK_MECHANISM {
+        mechanism: CKM_AES_CBC_PAD,
+        pParameter: void_ptr!(iv.as_bytes()),
+        ulParameterLen: iv.len() as CK_ULONG,
+    };
+    let ret = fn_encrypt_init(session, &mut mechanism, handle);
+    assert_eq!(ret, CKR_OK);
+
+    /* One full block via the safe null-probe helper (unaffected by the bug); CBC_PAD always
+     * adds a full dummy padding block on Final for block-aligned input. */
+    let data = vec![0x0Au8; AES_BLOCK_SIZE];
+    let enc = ret_or_panic!(encrypt_update(session, &data));
+    assert_eq!(enc.len(), AES_BLOCK_SIZE);
+
+    let mut fin: [u8; 4] = [0; 4];
+    let mut fin_len: CK_ULONG = fin.len() as CK_ULONG;
+    let ret = fn_encrypt_final(session, fin.as_mut_ptr(), &mut fin_len);
+    assert_eq!(ret, CKR_BUFFER_TOO_SMALL);
+    assert_eq!(
+        fin_len, AES_BLOCK_SIZE as CK_ULONG,
+        "CKR_BUFFER_TOO_SMALL must report the real required length ({} \
+         bytes), not leave *pulLastEncryptedPartLen at whatever the \
+         caller originally passed in (4)",
+        AES_BLOCK_SIZE
+    );
+
+    let mut fin2 = vec![0u8; fin_len as usize];
+    let mut fin2_len = fin2.len() as CK_ULONG;
+    let ret = fn_encrypt_final(session, fin2.as_mut_ptr(), &mut fin2_len);
+    assert_eq!(ret, CKR_OK);
+    assert_eq!(fin2_len, AES_BLOCK_SIZE as CK_ULONG);
+
+    testtokn.finalize();
+}
+
+/// Regression test for the one-shot C_EncryptMessage call site (fns/encryption.rs
+/// encrypt_message -> operation.msg_encrypt, which for CKM_AES_GCM delegates internally to
+/// msg_encrypt_next's own buf_too_small(plain.len()) check).
+#[test]
+#[parallel]
+fn test_aes_gcm_encrypt_message_buffer_too_small_reports_required_len() {
+    let mut testtokn = TestToken::initialized(
+        "test_aes_gcm_encrypt_message_buffer_too_small_reports_required_len",
+        None,
+    );
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let handle = ret_or_panic!(generate_key(
+        session,
+        CKM_AES_KEY_GEN,
+        std::ptr::null_mut(),
+        0,
+        &[(CKA_VALUE_LEN, 32),],
+        &[],
+        &[(CKA_ENCRYPT, true), (CKA_DECRYPT, true),],
+    ));
+
+    let mut mechanism: CK_MECHANISM = CK_MECHANISM {
+        mechanism: CKM_AES_GCM,
+        pParameter: std::ptr::null_mut(),
+        ulParameterLen: 0,
+    };
+    let ret = fn_message_encrypt_init(session, &mut mechanism, handle);
+    assert_eq!(ret, CKR_OK);
+
+    let mut iv = [0u8; 12];
+    let mut tag = [0u8; 16];
+    let mut params = CK_GCM_MESSAGE_PARAMS {
+        pIv: iv.as_mut_ptr(),
+        ulIvLen: iv.len() as CK_ULONG,
+        ulIvFixedBits: 0,
+        ivGenerator: CKG_NO_GENERATE,
+        pTag: tag.as_mut_ptr(),
+        ulTagBits: (tag.len() * 8) as CK_ULONG,
+    };
+    let plaintext = b"Hello world!";
+    let mut enc: [u8; 4] = [0; 4];
+    let mut enc_len: CK_ULONG = enc.len() as CK_ULONG;
+    let ret = fn_encrypt_message(
+        session,
+        void_ptr!(&mut params),
+        sizeof!(CK_GCM_MESSAGE_PARAMS),
+        std::ptr::null_mut(),
+        0,
+        plaintext.as_ptr() as *mut CK_BYTE,
+        plaintext.len() as CK_ULONG,
+        enc.as_mut_ptr(),
+        &mut enc_len,
+    );
+    assert_eq!(ret, CKR_BUFFER_TOO_SMALL);
+    assert_eq!(
+        enc_len,
+        plaintext.len() as CK_ULONG,
+        "CKR_BUFFER_TOO_SMALL must report the real required length ({} \
+         bytes), not leave *pulCiphertextLen at whatever the caller \
+         originally passed in (4)",
+        plaintext.len()
+    );
+
+    testtokn.finalize();
+}
+
+/// Regression test for the streaming C_EncryptMessageNext call site (fns/encryption.rs
+/// encrypt_message_next -> operation.msg_encrypt_next), distinct from the one-shot
+/// C_EncryptMessage above -- reached only through the explicit Begin/Next API, never through
+/// the one-shot entry point.
+#[test]
+#[parallel]
+fn test_aes_gcm_encrypt_message_next_buffer_too_small_reports_required_len() {
+    let mut testtokn = TestToken::initialized(
+        "test_aes_gcm_encrypt_message_next_buffer_too_small_reports_required_len",
+        None,
+    );
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let handle = ret_or_panic!(generate_key(
+        session,
+        CKM_AES_KEY_GEN,
+        std::ptr::null_mut(),
+        0,
+        &[(CKA_VALUE_LEN, 32),],
+        &[],
+        &[(CKA_ENCRYPT, true), (CKA_DECRYPT, true),],
+    ));
+
+    let mut mechanism: CK_MECHANISM = CK_MECHANISM {
+        mechanism: CKM_AES_GCM,
+        pParameter: std::ptr::null_mut(),
+        ulParameterLen: 0,
+    };
+    let ret = fn_message_encrypt_init(session, &mut mechanism, handle);
+    assert_eq!(ret, CKR_OK);
+
+    let mut iv = [0u8; 12];
+    let mut tag = [0u8; 16];
+    let mut params = CK_GCM_MESSAGE_PARAMS {
+        pIv: iv.as_mut_ptr(),
+        ulIvLen: iv.len() as CK_ULONG,
+        ulIvFixedBits: 0,
+        ivGenerator: CKG_NO_GENERATE,
+        pTag: tag.as_mut_ptr(),
+        ulTagBits: (tag.len() * 8) as CK_ULONG,
+    };
+
+    let ret = fn_encrypt_message_begin(
+        session,
+        void_ptr!(&mut params),
+        sizeof!(CK_GCM_MESSAGE_PARAMS),
+        std::ptr::null_mut(),
+        0,
+    );
+    assert_eq!(ret, CKR_OK);
+
+    let plaintext = b"Hello world!";
+    let mut enc: [u8; 4] = [0; 4];
+    let mut enc_len: CK_ULONG = enc.len() as CK_ULONG;
+    let ret = fn_encrypt_message_next(
+        session,
+        void_ptr!(&mut params),
+        sizeof!(CK_GCM_MESSAGE_PARAMS),
+        plaintext.as_ptr() as *mut CK_BYTE,
+        plaintext.len() as CK_ULONG,
+        enc.as_mut_ptr(),
+        &mut enc_len,
+        0, /* not CKF_END_OF_MESSAGE */
+    );
+    assert_eq!(ret, CKR_BUFFER_TOO_SMALL);
+    assert_eq!(
+        enc_len,
+        plaintext.len() as CK_ULONG,
+        "CKR_BUFFER_TOO_SMALL must report the real required length ({} \
+         bytes), not leave *pulCiphertextPartLen at whatever the caller \
+         originally passed in (4)",
+        plaintext.len()
+    );
+
+    testtokn.finalize();
+}
+
+/// Regression test for the C_WrapKey call site (fns/keymgmt.rs wrap_key), the only affected
+/// site outside fns/encryption.rs -- it converts its Result via a bare
+/// `Err(e) => return Err(e)?` (not even `Err(e) => e.rv()`, but the same effect: the
+/// output-length pointer is never written to on this path either).
+#[test]
+#[parallel]
+fn test_aes_wrap_key_buffer_too_small_reports_required_len() {
+    let mut testtokn = TestToken::initialized(
+        "test_aes_wrap_key_buffer_too_small_reports_required_len",
+        None,
+    );
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let wrapping_handle = ret_or_panic!(generate_key(
+        session,
+        CKM_AES_KEY_GEN,
+        std::ptr::null_mut(),
+        0,
+        &[(CKA_VALUE_LEN, 32),],
+        &[],
+        &[(CKA_WRAP, true), (CKA_UNWRAP, true),],
+    ));
+    let target_handle = ret_or_panic!(generate_key(
+        session,
+        CKM_AES_KEY_GEN,
+        std::ptr::null_mut(),
+        0,
+        &[(CKA_VALUE_LEN, 32),],
+        &[],
+        &[(CKA_EXTRACTABLE, true),],
+    ));
+
+    let mut mechanism: CK_MECHANISM = CK_MECHANISM {
+        mechanism: CKM_AES_KEY_WRAP_KWP,
+        pParameter: std::ptr::null_mut(),
+        ulParameterLen: 0,
+    };
+
+    let mut wrapped: [u8; 4] = [0; 4];
+    let mut wrapped_len: CK_ULONG = wrapped.len() as CK_ULONG;
+    let ret = fn_wrap_key(
+        session,
+        &mut mechanism,
+        wrapping_handle,
+        target_handle,
+        wrapped.as_mut_ptr(),
+        &mut wrapped_len,
+    );
+    assert_eq!(ret, CKR_BUFFER_TOO_SMALL);
+    /* AES-KWP wraps a 32-byte key into 40 bytes (two 8-byte overhead blocks). */
+    assert_eq!(
+        wrapped_len, 40,
+        "CKR_BUFFER_TOO_SMALL must report the real required length (40 \
+         bytes), not leave *pulWrappedKeyLen at whatever the caller \
+         originally passed in (4)"
+    );
+
+    let mut wrapped2 = vec![0u8; wrapped_len as usize];
+    let mut wrapped2_len = wrapped2.len() as CK_ULONG;
+    let ret = fn_wrap_key(
+        session,
+        &mut mechanism,
+        wrapping_handle,
+        target_handle,
+        wrapped2.as_mut_ptr(),
+        &mut wrapped2_len,
+    );
+    assert_eq!(ret, CKR_OK);
+    assert_eq!(wrapped2_len, 40);
+
+    testtokn.finalize();
+}

--- a/src/tests/mechs.rs
+++ b/src/tests/mechs.rs
@@ -205,3 +205,106 @@ fn test_mechanism_objects() {
 
     testtokn.finalize();
 }
+
+/// Regression test: C_GetMechanismList with a too-small list buffer must return
+/// CKR_BUFFER_TOO_SMALL *and* report the real mechanism count in *pulCount (PKCS#11 v3.2 5.2),
+/// not leave it at whatever the caller originally passed in.
+#[test]
+#[parallel]
+fn test_get_mechanism_list_buffer_too_small_reports_required_len() {
+    let mut testtokn = TestToken::initialized(
+        "test_get_mechanism_list_buffer_too_small_reports_required_len",
+        None,
+    );
+
+    let mut real_count: CK_ULONG = 0;
+    let ret = fn_get_mechanism_list(
+        testtokn.get_slot(),
+        std::ptr::null_mut(),
+        &mut real_count,
+    );
+    assert_eq!(ret, CKR_OK);
+    assert!(real_count > 1);
+
+    let mut mechs: Vec<CK_MECHANISM_TYPE> = vec![0; 1];
+    let mut count: CK_ULONG = 1;
+    let ret = fn_get_mechanism_list(
+        testtokn.get_slot(),
+        mechs.as_mut_ptr() as CK_MECHANISM_TYPE_PTR,
+        &mut count,
+    );
+    assert_eq!(ret, CKR_BUFFER_TOO_SMALL);
+    assert_eq!(
+        count, real_count,
+        "CKR_BUFFER_TOO_SMALL must report the real mechanism count ({}), \
+         not leave *pulCount at whatever the caller originally passed in (1)",
+        real_count
+    );
+
+    testtokn.finalize();
+}
+
+/// Regression test: C_GetSlotList with a too-small slot-list buffer must return
+/// CKR_BUFFER_TOO_SMALL *and* report the real slot count in *pulCount.
+#[test]
+#[parallel]
+fn test_get_slot_list_buffer_too_small_reports_required_len() {
+    let mut testtokn = TestToken::initialized(
+        "test_get_slot_list_buffer_too_small_reports_required_len",
+        None,
+    );
+
+    let mut real_count: CK_ULONG = 0;
+    let ret = fn_get_slot_list(CK_FALSE, std::ptr::null_mut(), &mut real_count);
+    assert_eq!(ret, CKR_OK);
+    assert!(real_count > 0);
+
+    if real_count > 1 {
+        let mut slots: Vec<CK_SLOT_ID> = vec![0; 1];
+        let mut count: CK_ULONG = 1;
+        let ret = fn_get_slot_list(
+            CK_FALSE,
+            slots.as_mut_ptr() as CK_SLOT_ID_PTR,
+            &mut count,
+        );
+        assert_eq!(ret, CKR_BUFFER_TOO_SMALL);
+        assert_eq!(
+            count, real_count,
+            "CKR_BUFFER_TOO_SMALL must report the real slot count ({}), \
+             not leave *pulCount at whatever the caller originally passed in (1)",
+            real_count
+        );
+    }
+
+    testtokn.finalize();
+}
+
+/// Regression test: C_GetInterfaceList with a too-small interface-list buffer must return
+/// CKR_BUFFER_TOO_SMALL *and* report the real interface count in *pulCount.
+#[test]
+#[parallel]
+fn test_get_interface_list_buffer_too_small_reports_required_len() {
+    let mut testtokn = TestToken::initialized(
+        "test_get_interface_list_buffer_too_small_reports_required_len",
+        None,
+    );
+
+    let mut real_count: CK_ULONG = 0;
+    let ret = fn_get_interface_list(std::ptr::null_mut(), &mut real_count);
+    assert_eq!(ret, CKR_OK);
+    assert!(real_count > 1);
+
+    let mut ifaces: Vec<CK_INTERFACE> = Vec::with_capacity(1);
+    unsafe { ifaces.set_len(1) };
+    let mut count: CK_ULONG = 1;
+    let ret = fn_get_interface_list(ifaces.as_mut_ptr(), &mut count);
+    assert_eq!(ret, CKR_BUFFER_TOO_SMALL);
+    assert_eq!(
+        count, real_count,
+        "CKR_BUFFER_TOO_SMALL must report the real interface count ({}), \
+         not leave *pulCount at whatever the caller originally passed in (1)",
+        real_count
+    );
+
+    testtokn.finalize();
+}

--- a/src/tests/mlkem.rs
+++ b/src/tests/mlkem.rs
@@ -453,6 +453,94 @@ fn test_groups(session: CK_SESSION_HANDLE, data: Value) {
     }
 }
 
+/// Regression test: C_EncapsulateKey with a too-small ciphertext buffer must return
+/// CKR_BUFFER_TOO_SMALL *and* report the real ciphertext length in *pulCiphertextLen (PKCS#11
+/// v3.2 5.2), not leave it at whatever the caller originally passed in.
+#[test]
+#[parallel]
+fn test_mlkem_encapsulate_buffer_too_small_reports_required_len() {
+    let mut testtokn = TestToken::initialized(
+        "test_mlkem_encapsulate_buffer_too_small_reports_required_len",
+        None,
+    );
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let (pub_handle, _priv_handle) = ret_or_panic!(generate_key_pair(
+        session,
+        CKM_ML_KEM_KEY_PAIR_GEN,
+        &[
+            (CKA_CLASS, CKO_PUBLIC_KEY),
+            (CKA_KEY_TYPE, CKK_ML_KEM),
+            (CKA_PARAMETER_SET, CKP_ML_KEM_512)
+        ],
+        &[],
+        &[(CKA_ENCAPSULATE, true)],
+        &[(CKA_CLASS, CKO_PRIVATE_KEY), (CKA_KEY_TYPE, CKK_ML_KEM),],
+        &[],
+        &[(CKA_DECAPSULATE, true),],
+    ));
+
+    let key_template = make_attr_template(
+        &[
+            (CKA_CLASS, CKO_SECRET_KEY),
+            (CKA_KEY_TYPE, CKK_AES),
+            (CKA_VALUE_LEN, 16),
+        ],
+        &[],
+        &[
+            (CKA_ENCRYPT, true),
+            (CKA_DECRYPT, true),
+            (CKA_SENSITIVE, false),
+            (CKA_EXTRACTABLE, true),
+        ],
+    );
+    let mut mechanism: CK_MECHANISM = CK_MECHANISM {
+        mechanism: CKM_ML_KEM,
+        pParameter: std::ptr::null_mut(),
+        ulParameterLen: 0,
+    };
+
+    /* ML-KEM-512's ciphertext is exactly 768 bytes. */
+    let mut ciphertext: [u8; 4] = [0; 4];
+    let mut outlen: CK_ULONG = ciphertext.len() as CK_ULONG;
+    let mut handle_enc = CK_INVALID_HANDLE;
+    let ret = fn_encapsulate_key(
+        session,
+        &mut mechanism,
+        pub_handle,
+        key_template.as_ptr() as *mut _,
+        key_template.len() as CK_ULONG,
+        ciphertext.as_mut_ptr(),
+        &mut outlen,
+        &mut handle_enc,
+    );
+    assert_eq!(ret, CKR_BUFFER_TOO_SMALL);
+    assert_eq!(
+        outlen, 768,
+        "CKR_BUFFER_TOO_SMALL must report the real required length (768 \
+         for ML-KEM-512), not leave *pulCiphertextLen at whatever the \
+         caller originally passed in (4)"
+    );
+
+    let mut ciphertext2 = vec![0u8; outlen as usize];
+    let mut outlen2 = ciphertext2.len() as CK_ULONG;
+    let ret = fn_encapsulate_key(
+        session,
+        &mut mechanism,
+        pub_handle,
+        key_template.as_ptr() as *mut _,
+        key_template.len() as CK_ULONG,
+        ciphertext2.as_mut_ptr(),
+        &mut outlen2,
+        &mut handle_enc,
+    );
+    assert_eq!(ret, CKR_OK);
+    assert_eq!(outlen2, 768);
+
+    testtokn.finalize();
+}
+
 #[test]
 #[parallel]
 fn test_mlkem_decap_vector() {

--- a/src/tests/rsa.rs
+++ b/src/tests/rsa.rs
@@ -798,3 +798,185 @@ fn test_rsa_public_key_info() {
 
     testtokn.finalize();
 }
+
+/// Regression test: C_Encrypt with a too-small output buffer must return
+/// CKR_BUFFER_TOO_SMALL *and* report the real required length in
+/// pulEncryptedDataLen (PKCS#11 v3.2 5.2), so a caller can retry with a
+/// correctly-sized buffer. Every existing RSA encrypt test either
+/// pre-allocates an already-large-enough buffer or probes with a NULL
+/// buffer first (see tests::util::encrypt) -- neither exercises this path,
+/// which is why this went unnoticed: on a too-small non-NULL buffer,
+/// encrypt() in ossl/rsa.rs returns Err(Error::buf_too_small(outlen)), but
+/// the CK_RV conversion in fns/encryption.rs (`Err(e) => e.rv()`) discarded
+/// e.reqsize() and never wrote it back into *pul_encrypted_data_len --
+/// which was left holding whatever the caller originally passed in.
+#[test]
+#[parallel]
+fn test_rsa_encrypt_buffer_too_small_reports_required_len() {
+    let mut testtokn = TestToken::initialized(
+        "test_rsa_encrypt_buffer_too_small_reports_required_len",
+        None,
+    );
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let (hpub, _hpri) = ret_or_panic!(generate_key_pair(
+        session,
+        CKM_RSA_PKCS_KEY_PAIR_GEN,
+        &[(CKA_MODULUS_BITS, 2048)],
+        &[],
+        &[(CKA_TOKEN, false), (CKA_ENCRYPT, true),],
+        &[(CKA_CLASS, CKO_PRIVATE_KEY), (CKA_KEY_TYPE, CKK_RSA),],
+        &[],
+        &[
+            (CKA_TOKEN, false),
+            (CKA_SENSITIVE, true),
+            (CKA_DECRYPT, true),
+        ],
+    ));
+
+    /* OAEP, not classic RSA_PKCS v1.5 encryption: raw PKCS#1v1.5 encryption
+     * is denied in FIPS-mode builds, and this test must pass there too. */
+    let params = CK_RSA_PKCS_OAEP_PARAMS {
+        hashAlg: CKM_SHA256,
+        mgf: CKG_MGF1_SHA256,
+        source: CKZ_DATA_SPECIFIED,
+        pSourceData: std::ptr::null_mut(),
+        ulSourceDataLen: 0,
+    };
+    let mut mechanism: CK_MECHANISM = CK_MECHANISM {
+        mechanism: CKM_RSA_PKCS_OAEP,
+        pParameter: &params as *const _ as CK_VOID_PTR,
+        ulParameterLen: sizeof!(CK_RSA_PKCS_OAEP_PARAMS),
+    };
+    let ret = fn_encrypt_init(session, &mut mechanism, hpub);
+    assert_eq!(ret, CKR_OK);
+
+    /* Deliberately too small: a 2048-bit key's RSA_PKCS_OAEP ciphertext is
+     * exactly 256 bytes. */
+    let data = "plaintext";
+    let mut enc: [u8; 8] = [0; 8];
+    let mut enc_len: CK_ULONG = enc.len() as CK_ULONG;
+    let ret = fn_encrypt(
+        session,
+        data.as_ptr() as *mut u8,
+        data.len() as CK_ULONG,
+        enc.as_mut_ptr(),
+        &mut enc_len,
+    );
+    assert_eq!(ret, CKR_BUFFER_TOO_SMALL);
+    assert_eq!(
+        enc_len, 256,
+        "CKR_BUFFER_TOO_SMALL must report the real required length (256 \
+         for a 2048-bit RSA_PKCS_OAEP ciphertext), not leave \
+         *pulEncryptedDataLen at whatever the caller originally passed in (8)"
+    );
+
+    /* Retry with a correctly-sized buffer, exactly as a real caller would;
+     * confirm the operation is still active and produces real output. */
+    let mut enc2 = vec![0u8; enc_len as usize];
+    let mut enc2_len = enc2.len() as CK_ULONG;
+    let ret = fn_encrypt(
+        session,
+        data.as_ptr() as *mut u8,
+        data.len() as CK_ULONG,
+        enc2.as_mut_ptr(),
+        &mut enc2_len,
+    );
+    assert_eq!(ret, CKR_OK);
+    assert_eq!(enc2_len, 256);
+
+    testtokn.finalize();
+}
+
+/// Same as test_rsa_encrypt_buffer_too_small_reports_required_len, but for the mirror
+/// C_Decrypt call site (a distinct fn_encrypt/fn_decrypt pair in fns/encryption.rs, so a
+/// distinct place the fix could have been missed).
+#[test]
+#[parallel]
+fn test_rsa_decrypt_buffer_too_small_reports_required_len() {
+    let mut testtokn = TestToken::initialized(
+        "test_rsa_decrypt_buffer_too_small_reports_required_len",
+        None,
+    );
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let (hpub, hpri) = ret_or_panic!(generate_key_pair(
+        session,
+        CKM_RSA_PKCS_KEY_PAIR_GEN,
+        &[(CKA_MODULUS_BITS, 2048)],
+        &[],
+        &[(CKA_TOKEN, false), (CKA_ENCRYPT, true),],
+        &[(CKA_CLASS, CKO_PRIVATE_KEY), (CKA_KEY_TYPE, CKK_RSA),],
+        &[],
+        &[
+            (CKA_TOKEN, false),
+            (CKA_SENSITIVE, true),
+            (CKA_DECRYPT, true),
+        ],
+    ));
+
+    /* OAEP, not classic RSA_PKCS v1.5 encryption: raw PKCS#1v1.5 encryption
+     * is denied in FIPS-mode builds, and this test must pass there too. */
+    let params = CK_RSA_PKCS_OAEP_PARAMS {
+        hashAlg: CKM_SHA256,
+        mgf: CKG_MGF1_SHA256,
+        source: CKZ_DATA_SPECIFIED,
+        pSourceData: std::ptr::null_mut(),
+        ulSourceDataLen: 0,
+    };
+    let mechanism: CK_MECHANISM = CK_MECHANISM {
+        mechanism: CKM_RSA_PKCS_OAEP,
+        pParameter: &params as *const _ as CK_VOID_PTR,
+        ulParameterLen: sizeof!(CK_RSA_PKCS_OAEP_PARAMS),
+    };
+    let data = "plaintext";
+    /* the safe null-probe idiom (tests::util::encrypt) is unaffected by the bug -- use it to
+     * produce a real ciphertext to decrypt */
+    let enc =
+        ret_or_panic!(encrypt(session, hpub, data.as_bytes(), &mechanism));
+    assert_eq!(enc.len(), 256);
+
+    let mut mechanism = mechanism;
+    let ret = fn_decrypt_init(session, &mut mechanism, hpri);
+    assert_eq!(ret, CKR_OK);
+
+    /* Deliberately too small. Unlike encrypt (whose ciphertext length is always exactly
+     * the modulus size), RSA_PKCS_OAEP decrypt cannot know the exact unpadded plaintext
+     * length without fully performing the decryption (that's what the tmp-buffer bridging
+     * further down in ossl/rsa.rs::decrypt is for) -- so, consistent with what the
+     * null-buffer probe (decryption_len(), used by C_Decrypt's NULL-output path) already
+     * reports, the required length here is the conservative modulus-size upper bound (256),
+     * not the eventual 9-byte plaintext. */
+    let mut dec: [u8; 2] = [0; 2];
+    let mut dec_len: CK_ULONG = dec.len() as CK_ULONG;
+    let ret = fn_decrypt(
+        session,
+        enc.as_ptr() as *mut u8,
+        enc.len() as CK_ULONG,
+        dec.as_mut_ptr(),
+        &mut dec_len,
+    );
+    assert_eq!(ret, CKR_BUFFER_TOO_SMALL);
+    assert_eq!(
+        dec_len, 256,
+        "CKR_BUFFER_TOO_SMALL must report the modulus-size upper bound \
+         (256, matching decryption_len()'s own null-probe answer), not \
+         leave *pulDataLen at whatever the caller originally passed in (2)"
+    );
+
+    let mut dec2 = vec![0u8; dec_len as usize];
+    let mut dec2_len = dec2.len() as CK_ULONG;
+    let ret = fn_decrypt(
+        session,
+        enc.as_ptr() as *mut u8,
+        enc.len() as CK_ULONG,
+        dec2.as_mut_ptr(),
+        &mut dec2_len,
+    );
+    assert_eq!(ret, CKR_OK);
+    assert_eq!(&dec2[..dec2_len as usize], data.as_bytes());
+
+    testtokn.finalize();
+}

--- a/src/tests/signatures.rs
+++ b/src/tests/signatures.rs
@@ -598,3 +598,128 @@ fn test_hmac_save_restore() {
 
     testtokn.finalize();
 }
+
+/// Regression test: C_Sign with a too-small signature buffer must return CKR_BUFFER_TOO_SMALL
+/// *and* report the real signature length in *pulSignatureLen (PKCS#11 v3.2 5.2). Our own
+/// wrapper always probes with a NULL buffer first (the other, already-correct branch), so this
+/// specific too-small-non-NULL-buffer path had no coverage anywhere.
+#[test]
+#[parallel]
+fn test_sign_buffer_too_small_reports_required_len() {
+    let mut testtokn = TestToken::initialized(
+        "test_sign_buffer_too_small_reports_required_len",
+        None,
+    );
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let (_hpub, hpri) = ret_or_panic!(generate_key_pair(
+        session,
+        CKM_RSA_PKCS_KEY_PAIR_GEN,
+        &[(CKA_MODULUS_BITS, 2048)],
+        &[],
+        &[(CKA_TOKEN, false), (CKA_VERIFY, true),],
+        &[(CKA_CLASS, CKO_PRIVATE_KEY), (CKA_KEY_TYPE, CKK_RSA),],
+        &[],
+        &[(CKA_TOKEN, false), (CKA_SENSITIVE, true), (CKA_SIGN, true),],
+    ));
+
+    let mut mechanism: CK_MECHANISM = CK_MECHANISM {
+        mechanism: CKM_SHA256_RSA_PKCS,
+        pParameter: std::ptr::null_mut(),
+        ulParameterLen: 0,
+    };
+    let ret = fn_sign_init(session, &mut mechanism, hpri);
+    assert_eq!(ret, CKR_OK);
+
+    let data = "data to sign";
+    let mut sig: [u8; 4] = [0; 4];
+    let mut sig_len: CK_ULONG = sig.len() as CK_ULONG;
+    let ret = fn_sign(
+        session,
+        data.as_ptr() as *mut u8,
+        data.len() as CK_ULONG,
+        sig.as_mut_ptr(),
+        &mut sig_len,
+    );
+    assert_eq!(ret, CKR_BUFFER_TOO_SMALL);
+    assert_eq!(
+        sig_len, 256,
+        "CKR_BUFFER_TOO_SMALL must report the real required length (256 \
+         for a 2048-bit RSA signature), not leave *pulSignatureLen at \
+         whatever the caller originally passed in (4)"
+    );
+
+    let mut sig2 = vec![0u8; sig_len as usize];
+    let mut sig2_len = sig2.len() as CK_ULONG;
+    let ret = fn_sign(
+        session,
+        data.as_ptr() as *mut u8,
+        data.len() as CK_ULONG,
+        sig2.as_mut_ptr(),
+        &mut sig2_len,
+    );
+    assert_eq!(ret, CKR_OK);
+    assert_eq!(sig2_len, 256);
+
+    testtokn.finalize();
+}
+
+/// Same as test_sign_buffer_too_small_reports_required_len, but for the C_SignFinal call site
+/// (fns/signing.rs sign_final, a distinct place the fix could have been missed).
+#[test]
+#[parallel]
+fn test_sign_final_buffer_too_small_reports_required_len() {
+    let mut testtokn = TestToken::initialized(
+        "test_sign_final_buffer_too_small_reports_required_len",
+        None,
+    );
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let (_hpub, hpri) = ret_or_panic!(generate_key_pair(
+        session,
+        CKM_RSA_PKCS_KEY_PAIR_GEN,
+        &[(CKA_MODULUS_BITS, 2048)],
+        &[],
+        &[(CKA_TOKEN, false), (CKA_VERIFY, true),],
+        &[(CKA_CLASS, CKO_PRIVATE_KEY), (CKA_KEY_TYPE, CKK_RSA),],
+        &[],
+        &[(CKA_TOKEN, false), (CKA_SENSITIVE, true), (CKA_SIGN, true),],
+    ));
+
+    let mut mechanism: CK_MECHANISM = CK_MECHANISM {
+        mechanism: CKM_SHA256_RSA_PKCS,
+        pParameter: std::ptr::null_mut(),
+        ulParameterLen: 0,
+    };
+    let ret = fn_sign_init(session, &mut mechanism, hpri);
+    assert_eq!(ret, CKR_OK);
+
+    let data = "data to sign";
+    let ret = fn_sign_update(
+        session,
+        data.as_ptr() as *mut u8,
+        data.len() as CK_ULONG,
+    );
+    assert_eq!(ret, CKR_OK);
+
+    let mut sig: [u8; 4] = [0; 4];
+    let mut sig_len: CK_ULONG = sig.len() as CK_ULONG;
+    let ret = fn_sign_final(session, sig.as_mut_ptr(), &mut sig_len);
+    assert_eq!(ret, CKR_BUFFER_TOO_SMALL);
+    assert_eq!(
+        sig_len, 256,
+        "CKR_BUFFER_TOO_SMALL must report the real required length (256 \
+         for a 2048-bit RSA signature), not leave *pulSignatureLen at \
+         whatever the caller originally passed in (4)"
+    );
+
+    let mut sig2 = vec![0u8; sig_len as usize];
+    let mut sig2_len = sig2.len() as CK_ULONG;
+    let ret = fn_sign_final(session, sig2.as_mut_ptr(), &mut sig2_len);
+    assert_eq!(ret, CKR_OK);
+    assert_eq!(sig2_len, 256);
+
+    testtokn.finalize();
+}


### PR DESCRIPTION
## Summary

Fixes #494.

PKCS#11 v3.2 §5.2 requires a function returning `CKR_BUFFER_TOO_SMALL` to write the actual
required size into the output-length parameter, so a caller can retry with a correctly-sized
buffer. A caller following that standard "try a buffer, retry on `CKR_BUFFER_TOO_SMALL` with the
reported size" idiom instead got stuck retrying with the same wrong size forever, across 18 call
sites, via two related but distinct instances of the same defect:

- `Error::buf_too_small(n)` carries the required size in its `reqsize` field, but every
  `extern "C" fn_*` wrapper's `Err(e) => e.rv()` conversion discarded it. Affected: `C_Encrypt`/
  `C_Decrypt`, their `Update`/`Final` streaming variants, `C_Encrypt(Decrypt)Message(Next)`
  message-mode variants, and `C_WrapKey` (11 sites spanning RSA and AES) — plus
  `RsaPKCSOperation::decrypt`, which used a bare `Err(CKR_BUFFER_TOO_SMALL)?` (via `Error::ck_rv`,
  which always zeroes `reqsize`) instead of `Error::buf_too_small`, so it needed its own fix even
  after the shared helper existed.
- A grep for that same bare `Err(CKR_BUFFER_TOO_SMALL)?` idiom outside the encrypt/decrypt/wrap
  paths found 7 more instances of the identical defect — a real, already-computed required size
  sits right there in scope and is silently dropped: `C_Sign`/`C_SignFinal`, `C_GetSlotList`/
  `C_GetMechanismList`, `C_GetInterfaceList`, `C_EncapsulateKey`/ML-KEM, and HOTP's
  `Sign::sign_final` (unreachable via the C ABI in practice, fixed anyway for consistency). Two
  sites with the same surface pattern — `C_Digest`/`C_DigestFinal` — were already correct and
  needed no change.

Left alone: `ossl/mlkem.rs`'s own `ErrorKind::BufferSize` handling inside `encapsulate()` can't be
fixed the same way — the underlying `ossl::Error` type carries no size field at all, so there's
nothing to propagate without extending the `ossl` crate itself. Its only caller
(`fns/keymgmt.rs::encapsulate_key`, fixed here) already checks the size before calling in, so this
looks unreachable today.

## Fix

- A shared `report_reqsize()` helper (`fns/mod.rs`, following the same crate-wide-visible pattern
  as the existing `fail_if_cka_token_true`) that writes `reqsize()` back into the output-length
  pointer when the error is `BufferTooSmall`, applied at the 11 sites sharing that shape.
- The remaining sites (RSA decrypt, `C_Sign`/enumeration/HOTP) each get the size written back
  directly at their own call site, matching what `C_Digest` already did correctly.

`C_Sign` and `C_GetSlotList`/`C_GetMechanismList` in particular had no test coverage anywhere
despite being among the most commonly used PKCS#11 functions: the standard caller pattern is
either to probe with a `NULL` buffer first (a different, already-correct branch) or supply an
already-large-enough buffer, so the too-small-non-`NULL`-buffer path went completely unexercised.

## Test plan

- [x] 13 new regression tests, one per distinct call-site shape (not one per algorithm — the bug
      and fix are in the mechanism-agnostic wrapper layer): RSA encrypt/decrypt one-shot, AES
      streaming `Update`/`Final`, AES-GCM message-mode one-shot/`Next`, `C_WrapKey`,
      `C_Sign`/`C_SignFinal`, `C_GetSlotList`/`C_GetMechanismList`/`C_GetInterfaceList`, and
      `C_EncapsulateKey` (ML-KEM). Each confirms the exact real-world required size (e.g. 256
      bytes for a 2048-bit RSA operation, 768 for ML-KEM-512's ciphertext).
- [x] All 136 unit tests (`cargo test --features pqc -p kryoptic-lib --lib`) pass.
- [x] All cdylib integration tests (`cargo test --features pqc,integration_tests -p kryoptic`)
      pass.
- [x] Cross-checked against a real-world caller (the KerckhoffsLabs.Security.Cryptography.Pkcs11
      .NET wrapper, which uses exactly the size-then-retry idiom for encrypt/decrypt): all 6 RSA
      OAEP/PKCS1 round-trip failures this caused are fixed, with no regressions.