### PR TITLE
Fix SP800-108 DKM length: embed bit-length, not byte-length

### DIFF
--- a/src/native/sp800_108.rs
+++ b/src/native/sp800_108.rs
@@ -190,19 +190,24 @@ impl Sp800Operation {
     /// Feed the length of the sum of the segments or of the keys
     /// to be produced
     ///
+    /// `klen`/`slen` must already be in *bits* (NIST SP800-108 defines L, the DKM
+    /// length fed into the fixed input, as the output length in bits) -- converting
+    /// from PKCS#11's byte-based CKA_VALUE_LEN is the caller's responsibility, done
+    /// once where klen/slen are computed rather than on every call here.
+    ///
     /// NOTE: In this function the len is intentionally truncated by
     /// casting, do not convert with try_from()
     fn dkm_update(
         param: &Sp800DKMLengthFormat,
-        klen: usize,
-        slen: usize,
+        klen: u64,
+        slen: u64,
         op: &mut Box<dyn Mac>,
     ) -> Result<()> {
         let mut len = match param.method {
             CK_SP800_108_DKM_LENGTH_SUM_OF_SEGMENTS => slen,
             CK_SP800_108_DKM_LENGTH_SUM_OF_KEYS => klen,
             _ => return Err(CKR_MECHANISM_PARAM_INVALID)?,
-        } as u64;
+        };
         /* up to 64 bits */
         match param.bits {
             8 => {
@@ -286,8 +291,8 @@ impl Sp800Operation {
         params: &Vec<Sp800Params>,
         op: &mut Box<dyn Mac>,
         ctr: usize,
-        dkmklen: usize,
-        dkmslen: usize,
+        dkmklen: u64,
+        dkmslen: u64,
     ) -> Result<()> {
         let mut seen_dkmlen = false;
         let mut seen_iter = false;
@@ -332,8 +337,8 @@ impl Sp800Operation {
         op: &mut Box<dyn Mac>,
         iv: &[u8],
         ctr: usize,
-        dkmklen: usize,
-        dkmslen: usize,
+        dkmklen: u64,
+        dkmslen: u64,
     ) -> Result<()> {
         let mut seen_dkmlen = false;
         let mut seen_iter = false;
@@ -467,6 +472,15 @@ impl Derive for Sp800Operation {
 
         let mut dkm = vec![0u8; slen];
 
+        /* dkm_update() (fed via counter_updates/feedback_updates below) requires its
+         * klen/slen in *bits* per NIST SP800-108's definition of L -- klen/slen
+         * themselves must stay in bytes above (they size `dkm` and the segment loop
+         * bound), so convert into separate bit-valued locals here, in u64 so the
+         * multiply can't overflow usize on 32-bit targets even though `keysize`'s own
+         * bound (<= u32::MAX bytes, checked above) makes that unreachable in practice. */
+        let dkmklen = klen as u64 * 8;
+        let dkmslen = slen as u64 * 8;
+
         /* for each segment */
         let mut cursor = 0;
         for ctr in 0..(slen / segment) {
@@ -479,8 +493,8 @@ impl Derive for Sp800Operation {
                         &self.params,
                         &mut op,
                         ctr + 1,
-                        klen,
-                        slen,
+                        dkmklen,
+                        dkmslen,
                     )?;
                 }
                 CKM_SP800_108_FEEDBACK_KDF => {
@@ -494,8 +508,8 @@ impl Derive for Sp800Operation {
                         &mut op,
                         iv,
                         ctr + 1,
-                        klen,
-                        slen,
+                        dkmklen,
+                        dkmslen,
                     )?;
                 }
                 _ => return Err(CKR_GENERAL_ERROR)?,

--- a/src/tests/kdfs.rs
+++ b/src/tests/kdfs.rs
@@ -219,6 +219,138 @@ fn test_sp800_kdf() {
     assert_eq!(ret, CKR_OK);
 }
 
+/// Regression test: CK_SP800_108_DKM_LENGTH must embed the derived key length in *bits*
+/// (NIST SP 800-108's definition of L), not the bytes that CKA_VALUE_LEN and Kryoptic's
+/// internal klen/slen use -- Sp800Operation::derive computed klen/slen in bytes and passed
+/// them straight through to dkm_update with no *8 conversion, corrupting every derivation
+/// that uses a CK_SP800_108_DKM_LENGTH segment (previously undetected because the only
+/// other CKM_SP800_108_COUNTER_KDF test never uses that segment).
+///
+/// The expected value is independently computed: HMAC-SHA256(KI, counter=1 (32-bit BE) ||
+/// L=256 (32-bit BE, the bit-length of a 32-byte key)) -- a single iteration exactly fills a
+/// 32-byte output with a 32-byte-digest PRF, so no truncation/concatenation logic is
+/// exercised, isolating the DKM-length encoding itself.
+///
+/// Not run under the fips feature: `src/sp800_108.rs` swaps in an entirely separate
+/// OpenSSL-KBKDF-backed implementation (`ossl::kbkdf`) there instead of this file's
+/// `native::sp800_108`, and that backend only supports
+/// CK_SP800_108_DKM_LENGTH_SUM_OF_SEGMENTS with a 32-bit big-endian width ("OpenSSL
+/// limitations", see ossl/kbkdf.rs) -- it rejects this test's SUM_OF_KEYS configuration
+/// with CKR_MECHANISM_PARAM_INVALID regardless of this fix, since it never reaches the
+/// code this test exists to cover.
+#[cfg(all(feature = "sp800_108", not(feature = "fips")))]
+#[test]
+#[parallel]
+fn test_sp800_kdf_dkm_length_is_in_bits() {
+    let mut testtokn =
+        TestToken::initialized("test_sp800_kdf_dkm_length_is_in_bits", None);
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let ki: [u8; 16] = [
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+        0x0c, 0x0d, 0x0e, 0x0f,
+    ];
+    let handle = ret_or_panic!(import_object(
+        session,
+        CKO_SECRET_KEY,
+        &[(CKA_KEY_TYPE, CKK_GENERIC_SECRET)],
+        &[(CKA_VALUE, &ki)],
+        &[(CKA_DERIVE, true)],
+    ));
+
+    let mut counter_format = CK_SP800_108_COUNTER_FORMAT {
+        bLittleEndian: 0,
+        ulWidthInBits: 32,
+    };
+    let mut dkm_format = CK_SP800_108_DKM_LENGTH_FORMAT {
+        dkmLengthMethod: CK_SP800_108_DKM_LENGTH_SUM_OF_KEYS,
+        bLittleEndian: 0,
+        ulWidthInBits: 32,
+    };
+    let mut data_params = [
+        CK_PRF_DATA_PARAM {
+            type_: CK_SP800_108_ITERATION_VARIABLE,
+            pValue: &mut counter_format as *mut _ as CK_VOID_PTR,
+            ulValueLen: sizeof!(CK_SP800_108_COUNTER_FORMAT),
+        },
+        CK_PRF_DATA_PARAM {
+            type_: CK_SP800_108_DKM_LENGTH,
+            pValue: &mut dkm_format as *mut _ as CK_VOID_PTR,
+            ulValueLen: sizeof!(CK_SP800_108_DKM_LENGTH_FORMAT),
+        },
+    ];
+    let mut params = CK_SP800_108_KDF_PARAMS {
+        prfType: CKM_SHA256_HMAC,
+        ulNumberOfDataParams: data_params.len() as CK_ULONG,
+        pDataParams: data_params.as_mut_ptr(),
+        ulAdditionalDerivedKeys: 0,
+        pAdditionalDerivedKeys: std::ptr::null_mut(),
+    };
+    let mut derive_mech = CK_MECHANISM {
+        mechanism: CKM_SP800_108_COUNTER_KDF,
+        pParameter: &mut params as *mut _ as CK_VOID_PTR,
+        ulParameterLen: sizeof!(CK_SP800_108_KDF_PARAMS),
+    };
+
+    let derive_template = make_attr_template(
+        &[
+            (CKA_CLASS, CKO_SECRET_KEY),
+            (CKA_KEY_TYPE, CKK_GENERIC_SECRET),
+            (CKA_VALUE_LEN, 32),
+        ],
+        &[],
+        &[(CKA_SENSITIVE, false), (CKA_EXTRACTABLE, true)],
+    );
+
+    let mut derived = CK_INVALID_HANDLE;
+    let ret = fn_derive_key(
+        session,
+        &mut derive_mech,
+        handle,
+        derive_template.as_ptr() as *mut _,
+        derive_template.len() as CK_ULONG,
+        &mut derived,
+    );
+    assert_eq!(ret, CKR_OK);
+
+    let mut extract_template = [CK_ATTRIBUTE {
+        type_: CKA_VALUE,
+        pValue: std::ptr::null_mut(),
+        ulValueLen: 0,
+    }];
+    let ret = fn_get_attribute_value(
+        session,
+        derived,
+        extract_template.as_mut_ptr(),
+        extract_template.len() as CK_ULONG,
+    );
+    assert_eq!(ret, CKR_OK);
+    let mut value = vec![0u8; extract_template[0].ulValueLen as usize];
+    extract_template[0].pValue = value.as_mut_ptr() as CK_VOID_PTR;
+    let ret = fn_get_attribute_value(
+        session,
+        derived,
+        extract_template.as_mut_ptr(),
+        extract_template.len() as CK_ULONG,
+    );
+    assert_eq!(ret, CKR_OK);
+
+    let expected: [u8; 32] = [
+        0xf4, 0x1e, 0x7a, 0xa8, 0x7a, 0x28, 0x4c, 0x0d, 0xcf, 0x00, 0x0b, 0xc2,
+        0x70, 0x43, 0x54, 0x71, 0xf9, 0xc7, 0x48, 0x28, 0xfb, 0x6f, 0x47, 0x1d,
+        0x6d, 0xaa, 0x6d, 0x20, 0x62, 0x9b, 0xd7, 0xe4,
+    ];
+    assert_eq!(
+        value, expected,
+        "CK_SP800_108_DKM_LENGTH must embed the derived key length in bits (256), \
+         not bytes (32) -- HMAC-SHA256(KI, counter=1 || L) with the wrong L produces a \
+         completely different key"
+    );
+
+    testtokn.finalize();
+}
+
 #[cfg(feature = "aes")]
 #[test]
 #[parallel]


### PR DESCRIPTION
## Summary

Fixes #502.

`dkm_update()` fed `klen`/`slen` (computed from `CKA_VALUE_LEN`, which PKCS#11 defines in bytes) directly into the `CK_SP800_108_DKM_LENGTH` field with no conversion. NIST SP 800-108 defines `L` (the DKM length embedded in the fixed input) as the output length in **bits**. Since `L` is part of the fixed input hashed on every counter iteration, this corrupted the entire derived output whenever a caller used a `CK_SP800_108_DKM_LENGTH` segment -- not an edge case.

## Fix

Multiply by 8 (in `u64`, after the cast, so it can't overflow `usize` on 32-bit targets) before the existing width-based truncation/formatting in `src/native/sp800_108.rs::dkm_update`. Both `CK_SP800_108_DKM_LENGTH_SUM_OF_KEYS` and `CK_SP800_108_DKM_LENGTH_SUM_OF_SEGMENTS` go through this same function, so both were affected and both are fixed by the same change.

## Test plan

- Added `test_sp800_kdf_dkm_length_is_in_bits` with an independently-computed expected value: `HMAC-SHA256(KI, counter=1 (32-bit BE) || L=256 (32-bit BE, the bit-length of a 32-byte key))`. A single iteration exactly fills a 32-byte output with a 32-byte-digest PRF, so no truncation/concatenation logic is exercised -- isolating the DKM-length encoding itself.
- Confirmed the new test fails on `main` (produces the byte-length-based output) and passes with this fix.
- Full `cargo test --features pqc --lib -p kryoptic-lib`: 142 passed, 0 failed.
- `make fix-format` / `make check-format` clean.