### PR TITLE
Add support for CKM_CHACHA20 and CKM_CHACHA20_POLY1305

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ ossl.workspace = true
 
 [features]
 aes = []
+chacha20 = []
 ecc = []
 ecdsa = ["ecc"]
 ecdh = ["ecc"]
@@ -106,7 +107,7 @@ ecc_all = ["ecc_min", "ec_montgomery", "eddsa"]
 hash_all = ["hash", "hmac"]
 kdf_all = ["hkdf", "pbkdf2", "sp800_108", "sshkdf", "tlskdf", "simplekdf"]
 
-standard = ["sqlitedb", "ecc_all", "ffdh", "hash_all", "kdf_all", "rsa", "hotp"]
+standard = ["sqlitedb", "ecc_all", "ffdh", "hash_all", "kdf_all", "rsa", "hotp", "chacha20"]
 
 fips = ["ossl/fips", "sqlitedb", "rusqlite/bundled", "aes", "ecc_all", "ffdh",
 "hash_all", "kdf_all", "rsa", "pqc", "dep:vsprintf"]

--- a/src/chacha20.rs
+++ b/src/chacha20.rs
@@ -1,0 +1,287 @@
+// Copyright 2026 Alexandre Laroche
+// See LICENSE.txt file for terms
+
+//! This module implements the PKCS#11 mechanisms for ChaCha20 and
+//! ChaCha20-Poly1305 as defined in
+//! [RFC 8439](https://www.rfc-editor.org/rfc/rfc8439): _ChaCha20 and
+//! Poly1305 for IETF Protocols_.
+//!
+//! Only the IETF parameter layout is supported: a 96-bit nonce (and, for
+//! `CKM_CHACHA20`, a 32-bit block counter) -- the shape OpenSSL's
+//! `EncAlg::ChaCha20`/`EncAlg::ChaCha20Poly1305` ciphers expect. PKCS#11
+//! v3.0's alternative, original (64-bit-nonce/64-bit-counter) layout for
+//! `CKM_CHACHA20` is not implemented.
+//!
+//! `CKM_CHACHA20_POLY1305` also implements message-mode
+//! (`C_MessageEncryptInit`/`C_EncryptMessage`/`C_EncryptMessageNext`/
+//! `C_MessageEncryptFinal` and their decrypt counterparts), since that is
+//! how real-world consumers (e.g. pkcs11-provider, for TLS record
+//! encryption) actually drive it.
+//!
+//! Neither mechanism is included in the `fips` feature bundle: ChaCha20
+//! and ChaCha20-Poly1305 are not NIST/FIPS-approved algorithms (unlike
+//! AES-GCM/CCM), so they are excluded the same way `hotp` already is --
+//! by simply never appearing in the `fips` feature's dependency list,
+//! rather than needing a `#[cfg(not(feature = "fips"))]` guard on top of
+//! that (a FIPS build never combines extra, non-approved features on
+//! its own).
+
+use std::fmt::Debug;
+use std::sync::LazyLock;
+
+use crate::attribute::Attribute;
+use crate::error::Result;
+use crate::mechanism::*;
+use crate::object::*;
+use crate::ossl::chacha20::*;
+use crate::pkcs11::*;
+
+/// ChaCha20 key size (256 bits), fixed by RFC 8439.
+pub const CHACHA20_KEY_SIZE: usize = 32;
+
+/// Object that holds ChaCha20 Mechanisms
+///
+/// `CKM_CHACHA20_POLY1305` gets its own entry, with the extra
+/// `CKF_MESSAGE_ENCRYPT`/`CKF_MESSAGE_DECRYPT`/`CKF_MULTI_MESSAGE` flags:
+/// message-mode (`C_MessageEncryptInit`/`C_EncryptMessage`/...) is how
+/// real-world PKCS#11 consumers (e.g. pkcs11-provider, for TLS record
+/// encryption) actually drive AEAD ciphers, reusing one initialized cipher
+/// context across many independently-nonced messages -- mirroring how
+/// `CKM_AES_GCM`/`CKM_AES_CCM` get a separate, message-flagged entry from
+/// AES's other, non-AEAD modes. Plain `CKM_CHACHA20` has no such use case
+/// and keeps classic `CKF_ENCRYPT`/`CKF_DECRYPT` only.
+pub(crate) static CHACHA20_MECHS: LazyLock<[Box<dyn Mechanism>; 3]> =
+    LazyLock::new(|| {
+        [
+            Box::new(ChaCha20Mechanism::new(CKF_ENCRYPT | CKF_DECRYPT)),
+            Box::new(ChaCha20Mechanism::new(
+                CKF_ENCRYPT
+                    | CKF_DECRYPT
+                    | CKF_MESSAGE_ENCRYPT
+                    | CKF_MESSAGE_DECRYPT
+                    | CKF_MULTI_MESSAGE,
+            )),
+            Box::new(ChaCha20Mechanism::new(CKF_GENERATE)),
+        ]
+    });
+
+/// The ChaCha20 Key Factory facility.
+static CHACHA20_KEY_FACTORY: LazyLock<Box<dyn ObjectFactory>> =
+    LazyLock::new(|| Box::new(ChaCha20KeyFactory::new()));
+
+/// Registers all implemented ChaCha20 Mechanisms and Factories
+pub fn register(mechs: &mut Mechanisms, ot: &mut ObjectFactories) {
+    ChaChaOperation::register_mechanisms(mechs);
+
+    ot.add_factory(
+        ObjectType::new(CKO_SECRET_KEY, CKK_CHACHA20),
+        &(*CHACHA20_KEY_FACTORY),
+    );
+}
+
+/// Specialized factory for objects of class `CKO_SECRET_KEY` and
+/// `CKA_KEY_TYPE` of value `CKK_CHACHA20`.
+///
+/// [ChaCha20 secret key objects](https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/os/pkcs11-spec-v3.1-os.html#_Toc111203478)
+/// (Version 3.1)
+///
+/// Unlike AES, ChaCha20 has a single fixed key size (256 bits), so this
+/// factory rejects any other length rather than selecting among several.
+#[derive(Debug)]
+pub struct ChaCha20KeyFactory {
+    data: ObjectFactoryData,
+}
+
+impl ChaCha20KeyFactory {
+    fn new() -> ChaCha20KeyFactory {
+        let mut factory: ChaCha20KeyFactory = ChaCha20KeyFactory {
+            data: ObjectFactoryData::new(CKO_SECRET_KEY),
+        };
+
+        factory.add_common_secret_key_attrs();
+
+        let attributes = factory.data.get_attributes_mut();
+
+        attributes.push(attr_element!(
+            CKA_VALUE; OAFlags::Defval | OAFlags::Sensitive
+            | OAFlags::RequiredOnCreate | OAFlags::SettableOnlyOnCreate;
+            Attribute::from_bytes; val Vec::new()));
+        attributes.push(attr_element!(
+            CKA_VALUE_LEN; OAFlags::RequiredOnGenerate;
+            Attribute::from_bytes; val Vec::new()));
+
+        factory.data.finalize();
+
+        factory
+    }
+}
+
+impl ObjectFactory for ChaCha20KeyFactory {
+    /// Creation of ChaCha20 keys uses the default generic secret creation
+    /// code and additionally ensures the key is exactly 256 bits.
+    fn create(&self, template: &[CK_ATTRIBUTE]) -> Result<Object> {
+        let mut obj = self.key_create(template)?;
+        let len = self.get_key_buffer_len(&obj)?;
+        if len != CHACHA20_KEY_SIZE {
+            return Err(CKR_KEY_SIZE_RANGE)?;
+        }
+        obj.ensure_ulong(CKA_VALUE_LEN, CK_ULONG::try_from(len)?)?;
+
+        Ok(obj)
+    }
+
+    fn get_data(&self) -> &ObjectFactoryData {
+        &self.data
+    }
+    fn get_data_mut(&mut self) -> &mut ObjectFactoryData {
+        &mut self.data
+    }
+
+    fn as_key_factory(&self) -> Result<&dyn KeyFactory> {
+        Ok(self)
+    }
+
+    fn as_secret_key_factory(&self) -> Result<&dyn SecretKeyFactory> {
+        Ok(self)
+    }
+}
+
+impl KeyFactory for ChaCha20KeyFactory {
+    fn export_for_wrapping(&self, key: &Object) -> Result<Vec<u8>> {
+        SecretKeyFactory::default_export_for_wrapping(self, key)
+    }
+
+    fn import_from_wrapped(
+        &self,
+        data: Vec<u8>,
+        template: &[CK_ATTRIBUTE],
+    ) -> Result<Object> {
+        if data.len() != CHACHA20_KEY_SIZE {
+            return Err(CKR_KEY_SIZE_RANGE)?;
+        }
+        SecretKeyFactory::default_import_from_wrapped(self, data, template)
+    }
+}
+
+impl SecretKeyFactory for ChaCha20KeyFactory {
+    /// Helper that checks the key is correctly formed for a ChaCha20 key
+    /// object (exactly 256 bits).
+    fn set_key(&self, obj: &mut Object, key: Vec<u8>) -> Result<()> {
+        if key.len() != CHACHA20_KEY_SIZE {
+            return Err(CKR_KEY_SIZE_RANGE)?;
+        }
+        obj.set_attr(Attribute::from_bytes(CKA_VALUE, key))?;
+        self.set_key_len(obj, CHACHA20_KEY_SIZE)?;
+        Ok(())
+    }
+
+    /// ChaCha20 has a single fixed key size (256 bits).
+    fn recommend_key_size(&self, max: usize) -> Result<usize> {
+        if max >= CHACHA20_KEY_SIZE {
+            Ok(CHACHA20_KEY_SIZE)
+        } else {
+            Err(CKR_KEY_SIZE_RANGE)?
+        }
+    }
+}
+
+/// The Generic ChaCha20 Mechanism object
+///
+/// Implements access to the Mechanisms functions applicable to ChaCha20
+/// and ChaCha20-Poly1305. The mechanism function returns an allocated
+/// [ChaChaOperation] object for operations that need to keep data around
+/// until they complete.
+#[derive(Debug)]
+pub(crate) struct ChaCha20Mechanism {
+    info: CK_MECHANISM_INFO,
+}
+
+impl ChaCha20Mechanism {
+    pub fn new(flags: CK_FLAGS) -> ChaCha20Mechanism {
+        ChaCha20Mechanism {
+            info: CK_MECHANISM_INFO {
+                ulMinKeySize: CK_ULONG::try_from(CHACHA20_KEY_SIZE).unwrap(),
+                ulMaxKeySize: CK_ULONG::try_from(CHACHA20_KEY_SIZE).unwrap(),
+                flags: flags,
+            },
+        }
+    }
+}
+
+impl Mechanism for ChaCha20Mechanism {
+    fn info(&self) -> &CK_MECHANISM_INFO {
+        &self.info
+    }
+
+    fn encryption_new(
+        &self,
+        mech: &CK_MECHANISM,
+        key: &Object,
+    ) -> Result<Box<dyn Encryption>> {
+        if self.info.flags & CKF_ENCRYPT != CKF_ENCRYPT {
+            return Err(CKR_MECHANISM_INVALID)?;
+        }
+        key.check_key_ops(CKO_SECRET_KEY, CKK_CHACHA20, CKA_ENCRYPT)?;
+        Ok(Box::new(ChaChaOperation::encrypt_new(mech, key)?))
+    }
+
+    fn decryption_new(
+        &self,
+        mech: &CK_MECHANISM,
+        key: &Object,
+    ) -> Result<Box<dyn Decryption>> {
+        if self.info.flags & CKF_DECRYPT != CKF_DECRYPT {
+            return Err(CKR_MECHANISM_INVALID)?;
+        }
+        key.check_key_ops(CKO_SECRET_KEY, CKK_CHACHA20, CKA_DECRYPT)?;
+        Ok(Box::new(ChaChaOperation::decrypt_new(mech, key)?))
+    }
+
+    /// Implements the ChaCha20 Key generation mechanism (`CKM_CHACHA20_KEY_GEN`)
+    fn generate_key(
+        &self,
+        mech: &CK_MECHANISM,
+        template: &[CK_ATTRIBUTE],
+        _: &Mechanisms,
+        _: &ObjectFactories,
+    ) -> Result<Object> {
+        if mech.mechanism != CKM_CHACHA20_KEY_GEN {
+            return Err(CKR_MECHANISM_INVALID)?;
+        }
+        let mut key = CHACHA20_KEY_FACTORY
+            .as_key_factory()?
+            .key_generate(template)?;
+        key.ensure_ulong(CKA_CLASS, CKO_SECRET_KEY)
+            .map_err(|_| CKR_TEMPLATE_INCONSISTENT)?;
+        key.ensure_ulong(CKA_KEY_TYPE, CKK_CHACHA20)
+            .map_err(|_| CKR_TEMPLATE_INCONSISTENT)?;
+
+        default_secret_key_generate(&mut key)?;
+        default_key_attributes(&mut key, mech.mechanism)?;
+        Ok(key)
+    }
+
+    fn msg_encryption_op(
+        &self,
+        mech: &CK_MECHANISM,
+        key: &Object,
+    ) -> Result<Box<dyn MsgEncryption>> {
+        if self.info.flags & CKF_MESSAGE_ENCRYPT == 0 {
+            return Err(CKR_MECHANISM_INVALID)?;
+        }
+        key.check_key_ops(CKO_SECRET_KEY, CKK_CHACHA20, CKA_ENCRYPT)?;
+        Ok(Box::new(ChaChaOperation::msg_encrypt_init(mech, key)?))
+    }
+
+    fn msg_decryption_op(
+        &self,
+        mech: &CK_MECHANISM,
+        key: &Object,
+    ) -> Result<Box<dyn MsgDecryption>> {
+        if self.info.flags & CKF_MESSAGE_DECRYPT == 0 {
+            return Err(CKR_MECHANISM_INVALID)?;
+        }
+        key.check_key_ops(CKO_SECRET_KEY, CKK_CHACHA20, CKA_DECRYPT)?;
+        Ok(Box::new(ChaChaOperation::msg_decrypt_init(mech, key)?))
+    }
+}

--- a/src/enabled.rs
+++ b/src/enabled.rs
@@ -4,6 +4,9 @@
 #[cfg(feature = "aes")]
 mod aes;
 
+#[cfg(feature = "chacha20")]
+mod chacha20;
+
 #[cfg(feature = "ecc")]
 mod ec;
 
@@ -66,6 +69,9 @@ fn register_all(mechs: &mut Mechanisms, ot: &mut ObjectFactories) {
 
     #[cfg(feature = "aes")]
     aes::register(mechs, ot);
+
+    #[cfg(feature = "chacha20")]
+    chacha20::register(mechs, ot);
 
     #[cfg(feature = "ecdsa")]
     ec::ecdsa::register(mechs, ot);

--- a/src/ossl/chacha20.rs
+++ b/src/ossl/chacha20.rs
@@ -1,0 +1,936 @@
+// Copyright 2026 Alexandre Laroche
+// See LICENSE.txt file for terms
+
+//! This module implements access to the OpenSSL implementation of ChaCha20
+//! and ChaCha20-Poly1305, as defined in
+//! [RFC 8439](https://www.rfc-editor.org/rfc/rfc8439): _ChaCha20 and
+//! Poly1305 for IETF Protocols_.
+
+use crate::chacha20::*;
+use crate::error;
+use crate::error::Result;
+use crate::mechanism::*;
+use crate::misc::{bytes_to_slice, bytes_to_slice_mut, bytes_to_vec, zeromem};
+use crate::object::Object;
+use crate::ossl::common::osslctx;
+use crate::pkcs11::*;
+
+use ossl::cipher::{AeadParams, EncAlg, OsslCipher};
+use ossl::OsslSecret;
+
+/// IETF ChaCha20 nonce size (96 bits) -- the layout OpenSSL's "ChaCha20"
+/// and "ChaCha20-Poly1305" ciphers expect. PKCS#11 v3.0's alternative,
+/// original (64-bit-nonce/64-bit-counter) layout is not supported.
+const CHACHA20_NONCE_SIZE: usize = 12;
+/// IETF ChaCha20 block-counter size (32 bits).
+const CHACHA20_COUNTER_SIZE: usize = 4;
+/// Poly1305 tag size (128 bits), fixed by RFC 8439.
+const POLY1305_TAG_SIZE: usize = 16;
+
+/// Convenience function to cast mechanism parameters passed as separate
+/// pointer/length variables into the structure they represent.
+///
+/// A length check on len is performed to validate that the correct
+/// parameter structure is being casted. No other validation is performed,
+/// this is an UNSAFE operation that requires further content validation.
+unsafe fn cast_params<T: Copy + Clone>(
+    ptr: CK_VOID_PTR,
+    len: CK_ULONG,
+) -> Result<T> {
+    let Ok(len) = usize::try_from(len) else {
+        return Err(CKR_ARGUMENTS_BAD)?;
+    };
+    if len != std::mem::size_of::<T>() {
+        return Err(CKR_ARGUMENTS_BAD)?;
+    }
+    Ok(unsafe { std::ptr::read_unaligned(ptr as *const T) })
+}
+
+/// Extracts the raw key bytes from a PKCS#11 `Object` into a ChaCha20 key.
+/// Validates the key length.
+fn object_to_raw_key(key: &Object) -> Result<OsslSecret> {
+    let val = key.get_attr_as_bytes(CKA_VALUE)?;
+    if val.len() != CHACHA20_KEY_SIZE {
+        return Err(CKR_KEY_INDIGESTIBLE)?;
+    }
+    Ok(OsslSecret::from_slice(&val))
+}
+
+/// Parameters for the active ChaCha20 / ChaCha20-Poly1305 operation.
+#[derive(Debug)]
+struct ChaChaParams {
+    /// The IV passed to OpenSSL: 16 bytes (4-byte block counter || 12-byte
+    /// nonce) for plain ChaCha20, or 12 bytes (the nonce alone) for
+    /// ChaCha20-Poly1305, whose counter always starts at 1 internally.
+    iv: Vec<u8>,
+    /// Additional Authenticated Data, ChaCha20-Poly1305 only.
+    aad: Vec<u8>,
+}
+
+/// Parses the PKCS#11 mechanism parameters (`CK_MECHANISM`) and initializes
+/// a `ChaChaParams` struct based on the specific mechanism type: either
+/// `CK_CHACHA20_PARAMS` (`CKM_CHACHA20`) or
+/// `CK_SALSA20_CHACHA20_POLY1305_PARAMS` (`CKM_CHACHA20_POLY1305`).
+fn init_params(mech: &CK_MECHANISM) -> Result<ChaChaParams> {
+    match mech.mechanism {
+        CKM_CHACHA20 => {
+            let params = mech.get_parameters::<CK_CHACHA20_PARAMS>()?;
+            if params.blockCounterBits != 32 || params.ulNonceBits != 96 {
+                return Err(CKR_MECHANISM_PARAM_INVALID)?;
+            }
+            if params.pBlockCounter.is_null() || params.pNonce.is_null() {
+                return Err(CKR_MECHANISM_PARAM_INVALID)?;
+            }
+            let mut iv =
+                bytes_to_vec(params.pBlockCounter, CHACHA20_COUNTER_SIZE);
+            iv.extend_from_slice(&bytes_to_vec(
+                params.pNonce,
+                CHACHA20_NONCE_SIZE,
+            ));
+            Ok(ChaChaParams {
+                iv: iv,
+                aad: Vec::new(),
+            })
+        }
+        CKM_CHACHA20_POLY1305 => {
+            let params =
+                mech.get_parameters::<CK_SALSA20_CHACHA20_POLY1305_PARAMS>()?;
+            if params.pNonce.is_null()
+                || usize::try_from(params.ulNonceLen)? != CHACHA20_NONCE_SIZE
+            {
+                return Err(CKR_MECHANISM_PARAM_INVALID)?;
+            }
+            if params.ulAADLen > 0 && params.pAAD.is_null() {
+                return Err(CKR_MECHANISM_PARAM_INVALID)?;
+            }
+            Ok(ChaChaParams {
+                iv: bytes_to_vec(params.pNonce, CHACHA20_NONCE_SIZE),
+                aad: bytes_to_vec(
+                    params.pAAD,
+                    usize::try_from(params.ulAADLen)?,
+                ),
+            })
+        }
+        _ => Err(CKR_MECHANISM_INVALID)?,
+    }
+}
+
+/// Maps a PKCS#11 mechanism type to the `ossl` crate's cipher selector.
+fn get_cipher(mech: CK_MECHANISM_TYPE) -> Result<EncAlg> {
+    match mech {
+        CKM_CHACHA20 => Ok(EncAlg::ChaCha20),
+        CKM_CHACHA20_POLY1305 => Ok(EncAlg::ChaCha20Poly1305),
+        _ => Err(CKR_MECHANISM_INVALID)?,
+    }
+}
+
+/// A ChaCha20 or ChaCha20-Poly1305 Encryption/Decryption Operation
+#[derive(Debug)]
+pub struct ChaChaOperation {
+    /// The specific mechanism being used (`CKM_CHACHA20` or
+    /// `CKM_CHACHA20_POLY1305`).
+    mech: CK_MECHANISM_TYPE,
+    /// The operation type flags (`CKF_ENCRYPT`, `CKF_MESSAGE_ENCRYPT`,
+    /// etc.), distinguishing classic from message-mode operations that
+    /// share this same struct.
+    op: CK_FLAGS,
+    /// The wrapped ChaCha20 key. Retained (unlike the classic-only path,
+    /// which can discard it once `ctx` is built) because message-mode
+    /// rebuilds `ctx` fresh for every message via
+    /// [ChaChaOperation::msg_encrypt_new]/[msg_decrypt_new], each with its
+    /// own nonce, while reusing the same key across the whole session.
+    key: OsslSecret,
+    /// Flag indicating if the operation has been finalized.
+    finalized: bool,
+    /// Flag indicating if the operation is in progress (update called).
+    in_use: bool,
+    /// The underlying ossl cipher context. `None` between
+    /// `msg_encrypt_init`/`msg_decrypt_init` and the first
+    /// `msg_encrypt_begin`/`msg_decrypt_begin` of a message-mode session.
+    ctx: Option<OsslCipher>,
+    /// Accumulates the tail of the ciphertext during multi-part
+    /// ChaCha20-Poly1305 decryption: the tag has a fixed length but its
+    /// position is only known once no more data follows, since it is
+    /// appended to the end of the ciphertext.
+    buffer: Vec<u8>,
+}
+
+impl Drop for ChaChaOperation {
+    fn drop(&mut self) {
+        zeromem(self.buffer.as_mut_slice());
+    }
+}
+
+impl ChaChaOperation {
+    /// Helper function to register the ChaCha20 mechanisms
+    pub fn register_mechanisms(mechs: &mut Mechanisms) {
+        mechs.add_mechanism(CKM_CHACHA20, &(*CHACHA20_MECHS)[0]);
+        mechs.add_mechanism(CKM_CHACHA20_POLY1305, &(*CHACHA20_MECHS)[1]);
+        mechs.add_mechanism(CKM_CHACHA20_KEY_GEN, &(*CHACHA20_MECHS)[2]);
+    }
+
+    /// Encryption/Decryption Initialization helper
+    fn cipher_initialize(
+        mech: CK_MECHANISM_TYPE,
+        params: &ChaChaParams,
+        key: &[u8],
+        enc: bool,
+    ) -> Result<OsslCipher> {
+        Ok(OsslCipher::new(
+            osslctx(),
+            get_cipher(mech)?,
+            enc,
+            OsslSecret::from_slice(key),
+            Some(params.iv.clone()),
+            match mech {
+                CKM_CHACHA20_POLY1305 => Some(AeadParams::new(
+                    if params.aad.len() > 0 {
+                        Some(params.aad.clone())
+                    } else {
+                        None
+                    },
+                    POLY1305_TAG_SIZE,
+                    0,
+                )),
+                _ => None,
+            },
+        )?)
+    }
+
+    /// Instantiates a new Encryption ChaCha20/ChaCha20-Poly1305 Operation
+    pub fn encrypt_new(
+        mech: &CK_MECHANISM,
+        key: &Object,
+    ) -> Result<ChaChaOperation> {
+        let params = init_params(mech)?;
+        let chachakey = object_to_raw_key(key)?;
+        let ctx =
+            Self::cipher_initialize(mech.mechanism, &params, &chachakey, true)?;
+        Ok(ChaChaOperation {
+            mech: mech.mechanism,
+            op: CKF_ENCRYPT,
+            key: chachakey,
+            finalized: false,
+            in_use: false,
+            ctx: Some(ctx),
+            buffer: Vec::new(),
+        })
+    }
+
+    /// Instantiates a new Decryption ChaCha20/ChaCha20-Poly1305 Operation
+    pub fn decrypt_new(
+        mech: &CK_MECHANISM,
+        key: &Object,
+    ) -> Result<ChaChaOperation> {
+        let params = init_params(mech)?;
+        let chachakey = object_to_raw_key(key)?;
+        let ctx = Self::cipher_initialize(
+            mech.mechanism,
+            &params,
+            &chachakey,
+            false,
+        )?;
+        Ok(ChaChaOperation {
+            mech: mech.mechanism,
+            op: CKF_DECRYPT,
+            key: chachakey,
+            finalized: false,
+            in_use: false,
+            ctx: Some(ctx),
+            buffer: Vec::new(),
+        })
+    }
+
+    /// Instantiates a new message-based Encryption Operation
+    /// (`C_MessageEncryptInit`). The cipher context itself is not created
+    /// until the first `msg_encrypt_begin`, since each message supplies
+    /// its own nonce.
+    pub fn msg_encrypt_init(
+        mech: &CK_MECHANISM,
+        key: &Object,
+    ) -> Result<ChaChaOperation> {
+        if mech.mechanism != CKM_CHACHA20_POLY1305 {
+            return Err(CKR_MECHANISM_INVALID)?;
+        }
+        Ok(ChaChaOperation {
+            mech: mech.mechanism,
+            op: CKF_MESSAGE_ENCRYPT,
+            key: object_to_raw_key(key)?,
+            finalized: false,
+            in_use: false,
+            ctx: None,
+            buffer: Vec::new(),
+        })
+    }
+
+    /// Instantiates a new message-based Decryption Operation
+    /// (`C_MessageDecryptInit`).
+    pub fn msg_decrypt_init(
+        mech: &CK_MECHANISM,
+        key: &Object,
+    ) -> Result<ChaChaOperation> {
+        if mech.mechanism != CKM_CHACHA20_POLY1305 {
+            return Err(CKR_MECHANISM_INVALID)?;
+        }
+        Ok(ChaChaOperation {
+            mech: mech.mechanism,
+            op: CKF_MESSAGE_DECRYPT,
+            key: object_to_raw_key(key)?,
+            finalized: false,
+            in_use: false,
+            ctx: None,
+            buffer: Vec::new(),
+        })
+    }
+
+    /// Parses `CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS`. Unlike
+    /// `CK_GCM_MESSAGE_PARAMS`/`CK_CCM_MESSAGE_PARAMS`, this struct has no
+    /// generator field -- the caller always supplies the nonce -- and
+    /// carries the tag out-of-band in `pTag` (never appended to the
+    /// ciphertext, unlike the classic, non-message path).
+    ///
+    /// Only the fields needed by the caller are read here: the nonce (used
+    /// by `msg_encrypt_new`/`msg_decrypt_new` to (re)initialize `ctx`) or
+    /// the tag pointer (used by `msg_encrypt_final`/`msg_decrypt_final`),
+    /// never both -- so this returns the whole parsed struct and leaves it
+    /// to the caller to use only the field(s) valid for that call. Per
+    /// PKCS#11 semantics the pointers inside are valid only for the
+    /// duration of the current call and must not be retained afterward.
+    fn parse_msg_params(
+        parameter: CK_VOID_PTR,
+        parameter_len: CK_ULONG,
+    ) -> Result<CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS> {
+        let params = unsafe {
+            cast_params::<CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS>(
+                parameter,
+                parameter_len,
+            )
+        }?;
+        if params.pNonce.is_null()
+            || usize::try_from(params.ulNonceLen)? != CHACHA20_NONCE_SIZE
+        {
+            return Err(CKR_MECHANISM_PARAM_INVALID)?;
+        }
+        if params.pTag.is_null() {
+            return Err(CKR_MECHANISM_PARAM_INVALID)?;
+        }
+        Ok(params)
+    }
+
+    /// Initializes a new message-based encryption, building `ctx` fresh
+    /// from this message's nonce and AAD.
+    fn msg_encrypt_new(
+        &mut self,
+        parameter: CK_VOID_PTR,
+        parameter_len: CK_ULONG,
+        aad: &[u8],
+    ) -> Result<()> {
+        if self.op != CKF_MESSAGE_ENCRYPT {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        if self.in_use {
+            return Err(CKR_OPERATION_ACTIVE)?;
+        }
+
+        let params = Self::parse_msg_params(parameter, parameter_len)?;
+        let chacha_params = ChaChaParams {
+            iv: bytes_to_vec(params.pNonce, CHACHA20_NONCE_SIZE),
+            aad: aad.to_vec(),
+        };
+
+        self.ctx = Some(Self::cipher_initialize(
+            self.mech,
+            &chacha_params,
+            &self.key,
+            true,
+        )?);
+        self.finalized = false;
+        self.in_use = true;
+        Ok(())
+    }
+
+    /// Initializes a new message-based decryption, building `ctx` fresh
+    /// from this message's nonce and AAD.
+    fn msg_decrypt_new(
+        &mut self,
+        parameter: CK_VOID_PTR,
+        parameter_len: CK_ULONG,
+        aad: &[u8],
+    ) -> Result<()> {
+        if self.op != CKF_MESSAGE_DECRYPT {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        if self.in_use {
+            return Err(CKR_OPERATION_ACTIVE)?;
+        }
+
+        let params = Self::parse_msg_params(parameter, parameter_len)?;
+        let chacha_params = ChaChaParams {
+            iv: bytes_to_vec(params.pNonce, CHACHA20_NONCE_SIZE),
+            aad: aad.to_vec(),
+        };
+
+        self.ctx = Some(Self::cipher_initialize(
+            self.mech,
+            &chacha_params,
+            &self.key,
+            false,
+        )?);
+        self.finalized = false;
+        self.in_use = true;
+        Ok(())
+    }
+
+    fn op_err(&mut self, err: CK_RV) -> error::Error {
+        self.finalized = true;
+        error::Error::ck_rv(err)
+    }
+}
+
+impl MechOperation for ChaChaOperation {
+    fn mechanism(&self) -> Result<CK_MECHANISM_TYPE> {
+        Ok(self.mech)
+    }
+
+    fn finalized(&self) -> bool {
+        self.finalized
+    }
+}
+
+impl Encryption for ChaChaOperation {
+    /// One shot encryption implementation
+    fn encrypt(&mut self, plain: &[u8], cipher: &mut [u8]) -> Result<usize> {
+        if self.finalized {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        let outl = self.encrypt_update(plain, cipher)?;
+        if outl > cipher.len() {
+            return Err(self.op_err(CKR_GENERAL_ERROR));
+        }
+        Ok(outl + self.encrypt_final(&mut cipher[outl..])?)
+    }
+
+    /// Calls the underlying OpenSSL function to encrypt the plaintext
+    /// buffer provided
+    fn encrypt_update(
+        &mut self,
+        plain: &[u8],
+        cipher: &mut [u8],
+    ) -> Result<usize> {
+        if self.finalized {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        self.in_use = true;
+
+        let outlen = self.encryption_len(plain.len(), false)?;
+        if cipher.len() < outlen {
+            /* This is the only, non-fatal error */
+            return Err(error::Error::buf_too_small(outlen));
+        }
+
+        let ctx = match &mut self.ctx {
+            Some(c) => c,
+            None => return Err(self.op_err(CKR_GENERAL_ERROR)),
+        };
+
+        if plain.len() == 0 {
+            return Ok(0);
+        }
+        ctx.update(plain, cipher)
+            .or_else(|_| Err(self.op_err(CKR_DEVICE_ERROR)))
+    }
+
+    /// Calls the underlying OpenSSL function to finalize the encryption
+    /// operation. For `CKM_CHACHA20_POLY1305` this returns the Poly1305
+    /// tag; plain `CKM_CHACHA20` has no finalization output.
+    fn encrypt_final(&mut self, cipher: &mut [u8]) -> Result<usize> {
+        if self.finalized {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        if !self.in_use {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+
+        let ctx = match &mut self.ctx {
+            Some(c) => c,
+            None => return Err(self.op_err(CKR_GENERAL_ERROR)),
+        };
+
+        let outlen = match self.mech {
+            CKM_CHACHA20_POLY1305 => {
+                if cipher.len() < POLY1305_TAG_SIZE {
+                    /* This is the only, non-fatal error */
+                    return Err(error::Error::buf_too_small(POLY1305_TAG_SIZE));
+                }
+                let outlen = ctx.finalize(cipher)?;
+                if outlen != 0 {
+                    self.finalized = true;
+                    return Err(CKR_DEVICE_ERROR)?;
+                }
+                ctx.get_tag(&mut cipher[..POLY1305_TAG_SIZE])?;
+                POLY1305_TAG_SIZE
+            }
+            CKM_CHACHA20 => 0,
+            _ => {
+                self.finalized = true;
+                return Err(CKR_GENERAL_ERROR)?;
+            }
+        };
+
+        self.finalized = true;
+        Ok(outlen)
+    }
+
+    /// Provides the expected output buffer size for the provided input
+    /// plaintext length.
+    fn encryption_len(&mut self, data_len: usize, _fin: bool) -> Result<usize> {
+        match self.mech {
+            CKM_CHACHA20 => Ok(data_len),
+            CKM_CHACHA20_POLY1305 => Ok(data_len + POLY1305_TAG_SIZE),
+            _ => Err(self.op_err(CKR_GENERAL_ERROR)),
+        }
+    }
+}
+
+impl Decryption for ChaChaOperation {
+    /// One shot decryption implementation
+    fn decrypt(&mut self, cipher: &[u8], plain: &mut [u8]) -> Result<usize> {
+        if self.finalized {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        let outl = self.decrypt_update(cipher, plain)?;
+        if outl > plain.len() {
+            return Err(self.op_err(CKR_GENERAL_ERROR));
+        }
+        Ok(outl + self.decrypt_final(&mut plain[outl..])?)
+    }
+
+    /// Calls the underlying OpenSSL function to decrypt the ciphertext
+    /// buffer provided. For `CKM_CHACHA20_POLY1305`, since the Poly1305
+    /// tag is appended at the end of the ciphertext and its position is
+    /// only known once no more data follows, the trailing
+    /// `POLY1305_TAG_SIZE` bytes seen so far are always held back in
+    /// `self.buffer` until a later call (or `decrypt_final`) proves they
+    /// were not the tag after all.
+    fn decrypt_update(
+        &mut self,
+        cipher: &[u8],
+        plain: &mut [u8],
+    ) -> Result<usize> {
+        if self.finalized {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        self.in_use = true;
+
+        let outlen = match self.mech {
+            CKM_CHACHA20 => cipher.len(),
+            CKM_CHACHA20_POLY1305 => {
+                let tlen = cipher.len() + self.buffer.len();
+                if tlen > POLY1305_TAG_SIZE {
+                    tlen - POLY1305_TAG_SIZE
+                } else {
+                    0
+                }
+            }
+            _ => return Err(self.op_err(CKR_GENERAL_ERROR)),
+        };
+        if plain.len() < outlen {
+            /* This is the only, non-fatal error */
+            return Err(error::Error::buf_too_small(outlen));
+        }
+
+        let ctx = match &mut self.ctx {
+            Some(c) => c,
+            None => return Err(self.op_err(CKR_GENERAL_ERROR)),
+        };
+
+        let mut plain_offset = 0;
+        let mut cipher_offset = 0;
+        let mut cipher_end = cipher.len();
+        match self.mech {
+            CKM_CHACHA20_POLY1305 => {
+                /* the tag is appended at the end of the ciphertext,
+                 * but we do not know how long the ciphertext is */
+                if self.buffer.len() > 0 {
+                    if cipher_end > POLY1305_TAG_SIZE {
+                        /* consume the saved buffer now,
+                         * so we avoid unnecessary data copy */
+                        plain_offset = ctx
+                            .update(self.buffer.as_slice(), plain)
+                            .or_else(|_| {
+                                self.finalized = true;
+                                Err(CKR_DEVICE_ERROR)
+                            })?;
+                        zeromem(self.buffer.as_mut_slice());
+                        self.buffer.clear();
+                        cipher_end -= POLY1305_TAG_SIZE;
+                        self.buffer.extend_from_slice(&cipher[cipher_end..]);
+                    } else {
+                        self.buffer.extend_from_slice(cipher);
+                        if self.buffer.len() > POLY1305_TAG_SIZE {
+                            let buflen = self.buffer.len() - POLY1305_TAG_SIZE;
+                            plain_offset = ctx
+                                .update(
+                                    &self.buffer.as_slice()[..buflen],
+                                    plain,
+                                )
+                                .or_else(|_| {
+                                    self.finalized = true;
+                                    Err(CKR_DEVICE_ERROR)
+                                })?;
+                            zeromem(&mut self.buffer.as_mut_slice()[..buflen]);
+                            let _ = self.buffer.drain(..buflen);
+                        }
+                    }
+                    /* The cipher buffer has been utilized */
+                    cipher_offset = cipher_end;
+                } else if cipher_end > POLY1305_TAG_SIZE {
+                    cipher_end -= POLY1305_TAG_SIZE;
+                    self.buffer.extend_from_slice(&cipher[cipher_end..]);
+                } else {
+                    self.buffer.extend_from_slice(cipher);
+                    /* The cipher buffer has been utilized */
+                    cipher_offset = cipher_end;
+                }
+            }
+            _ => (),
+        }
+
+        if cipher_end - cipher_offset > 0 {
+            let outlen = ctx
+                .update(
+                    &cipher[cipher_offset..cipher_end],
+                    &mut plain[plain_offset..],
+                )
+                .or_else(|_| {
+                    self.finalized = true;
+                    Err(CKR_DEVICE_ERROR)
+                })?;
+            plain_offset += outlen;
+        }
+
+        Ok(plain_offset)
+    }
+
+    /// Calls the underlying OpenSSL function to finalize the decryption
+    /// operation. For `CKM_CHACHA20_POLY1305` this verifies the buffered
+    /// Poly1305 tag and returns any trailing plaintext.
+    fn decrypt_final(&mut self, plain: &mut [u8]) -> Result<usize> {
+        if self.finalized {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        if !self.in_use {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+
+        let ctx = match &mut self.ctx {
+            Some(c) => c,
+            None => return Err(self.op_err(CKR_GENERAL_ERROR)),
+        };
+
+        self.finalized = true;
+
+        let outlen = 0;
+        match self.mech {
+            CKM_CHACHA20_POLY1305 => {
+                if self.buffer.len() != POLY1305_TAG_SIZE {
+                    return Err(CKR_ENCRYPTED_DATA_LEN_RANGE)?;
+                }
+                ctx.set_tag(self.buffer.as_slice())?;
+                match ctx.finalize(plain) {
+                    Ok(len) => {
+                        if len != 0 {
+                            return Err(CKR_DEVICE_ERROR)?;
+                        }
+                    }
+                    Err(_) => return Err(CKR_ENCRYPTED_DATA_INVALID)?,
+                }
+            }
+            CKM_CHACHA20 => (),
+            _ => return Err(CKR_GENERAL_ERROR)?,
+        }
+
+        Ok(outlen)
+    }
+
+    /// Provides the expected output buffer size for the provided input
+    /// ciphertext length.
+    fn decryption_len(&mut self, data_len: usize, fin: bool) -> Result<usize> {
+        let outlen = if fin {
+            match self.mech {
+                CKM_CHACHA20_POLY1305 => {
+                    if self.buffer.len() + data_len < POLY1305_TAG_SIZE {
+                        return Err(self.op_err(CKR_ENCRYPTED_DATA_LEN_RANGE));
+                    }
+                    self.buffer.len() + data_len - POLY1305_TAG_SIZE
+                }
+                CKM_CHACHA20 => data_len,
+                _ => return Err(self.op_err(CKR_GENERAL_ERROR)),
+            }
+        } else {
+            match self.mech {
+                CKM_CHACHA20_POLY1305 => {
+                    if self.buffer.len() + data_len < POLY1305_TAG_SIZE {
+                        0
+                    } else {
+                        self.buffer.len() + data_len
+                    }
+                }
+                CKM_CHACHA20 => data_len,
+                _ => return Err(self.op_err(CKR_GENERAL_ERROR)),
+            }
+        };
+        Ok(outlen)
+    }
+}
+
+impl MessageOperation for ChaChaOperation {
+    fn busy(&self) -> bool {
+        self.in_use
+    }
+    fn finalize(&mut self) -> Result<()> {
+        if self.in_use {
+            return Err(CKR_OPERATION_ACTIVE)?;
+        }
+        self.finalized = true;
+        Ok(())
+    }
+}
+
+impl MsgEncryption for ChaChaOperation {
+    /// One-shot message-based encryption implementation
+    fn msg_encrypt(
+        &mut self,
+        param: CK_VOID_PTR,
+        paramlen: CK_ULONG,
+        aad: &[u8],
+        plain: &[u8],
+        cipher: &mut [u8],
+    ) -> Result<usize> {
+        self.msg_encrypt_begin(param, paramlen, aad)?;
+        self.msg_encrypt_final(param, paramlen, plain, cipher)
+    }
+
+    /// Begins a new message-based encryption: parses this message's nonce
+    /// and AAD and (re)initializes `ctx`.
+    fn msg_encrypt_begin(
+        &mut self,
+        param: CK_VOID_PTR,
+        paramlen: CK_ULONG,
+        aad: &[u8],
+    ) -> Result<()> {
+        if self.finalized {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        self.msg_encrypt_new(param, paramlen, aad)
+    }
+
+    /// Feeds in the next plaintext chunk of the current message. The
+    /// Poly1305 tag is not part of this output -- it is written
+    /// separately, into `pTag`, by `msg_encrypt_final`.
+    fn msg_encrypt_next(
+        &mut self,
+        _param: CK_VOID_PTR,
+        _paramlen: CK_ULONG,
+        plain: &[u8],
+        cipher: &mut [u8],
+    ) -> Result<usize> {
+        if self.finalized {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        if !self.in_use {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        if cipher.len() < plain.len() {
+            /* This is the only non-fatal error */
+            return Err(error::Error::buf_too_small(plain.len()));
+        }
+
+        let ctx = match &mut self.ctx {
+            Some(c) => c,
+            None => return Err(self.op_err(CKR_GENERAL_ERROR)),
+        };
+
+        if plain.len() == 0 {
+            return Ok(0);
+        }
+        ctx.update(plain, cipher)
+            .or_else(|_| Err(self.op_err(CKR_DEVICE_ERROR)))
+    }
+
+    /// Feeds the final plaintext chunk, then writes the Poly1305 tag into
+    /// the current message's `pTag`.
+    fn msg_encrypt_final(
+        &mut self,
+        param: CK_VOID_PTR,
+        paramlen: CK_ULONG,
+        plain: &[u8],
+        cipher: &mut [u8],
+    ) -> Result<usize> {
+        if self.finalized {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        if !self.in_use {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+
+        let params = Self::parse_msg_params(param, paramlen)?;
+        let outlen = self.msg_encrypt_next(param, paramlen, plain, cipher)?;
+
+        let ctx = match &mut self.ctx {
+            Some(c) => c,
+            None => return Err(self.op_err(CKR_GENERAL_ERROR)),
+        };
+
+        if !ctx.finalize(cipher).is_ok_and(|len| len == 0) {
+            zeromem(cipher);
+            return Err(self.op_err(CKR_DEVICE_ERROR));
+        }
+
+        let tagbuf =
+            unsafe { bytes_to_slice_mut(params.pTag, POLY1305_TAG_SIZE) }?;
+        if ctx.get_tag(tagbuf).is_err() {
+            zeromem(cipher);
+            return Err(self.op_err(CKR_DEVICE_ERROR));
+        }
+
+        self.in_use = false;
+        Ok(outlen)
+    }
+
+    /// Provides the expected output buffer size. The Poly1305 tag is not
+    /// included -- it goes into `pTag`, not the cipher buffer.
+    fn msg_encryption_len(
+        &mut self,
+        data_len: usize,
+        _fin: bool,
+    ) -> Result<usize> {
+        if self.finalized {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        Ok(data_len)
+    }
+}
+
+impl MsgDecryption for ChaChaOperation {
+    /// One-shot message-based decryption implementation
+    fn msg_decrypt(
+        &mut self,
+        param: CK_VOID_PTR,
+        paramlen: CK_ULONG,
+        aad: &[u8],
+        cipher: &[u8],
+        plain: &mut [u8],
+    ) -> Result<usize> {
+        self.msg_decrypt_begin(param, paramlen, aad)?;
+        self.msg_decrypt_final(param, paramlen, cipher, plain)
+    }
+
+    /// Begins a new message-based decryption: parses this message's nonce
+    /// and AAD and (re)initializes `ctx`.
+    fn msg_decrypt_begin(
+        &mut self,
+        param: CK_VOID_PTR,
+        paramlen: CK_ULONG,
+        aad: &[u8],
+    ) -> Result<()> {
+        if self.finalized {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        self.msg_decrypt_new(param, paramlen, aad)
+    }
+
+    /// Feeds in the next ciphertext chunk of the current message. The
+    /// Poly1305 tag is not part of this input -- it is supplied separately,
+    /// via `pTag`, to `msg_decrypt_final`.
+    fn msg_decrypt_next(
+        &mut self,
+        _param: CK_VOID_PTR,
+        _paramlen: CK_ULONG,
+        cipher: &[u8],
+        plain: &mut [u8],
+    ) -> Result<usize> {
+        if self.finalized {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        if !self.in_use {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        if plain.len() < cipher.len() {
+            /* This is the only non-fatal error */
+            return Err(error::Error::buf_too_small(cipher.len()));
+        }
+
+        let ctx = match &mut self.ctx {
+            Some(c) => c,
+            None => return Err(self.op_err(CKR_GENERAL_ERROR)),
+        };
+
+        if cipher.len() == 0 {
+            return Ok(0);
+        }
+        ctx.update(cipher, plain)
+            .or_else(|_| Err(self.op_err(CKR_DEVICE_ERROR)))
+    }
+
+    /// Feeds the final ciphertext chunk, sets the Poly1305 tag from this
+    /// message's `pTag`, and verifies it.
+    fn msg_decrypt_final(
+        &mut self,
+        param: CK_VOID_PTR,
+        paramlen: CK_ULONG,
+        cipher: &[u8],
+        plain: &mut [u8],
+    ) -> Result<usize> {
+        if self.finalized {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        if !self.in_use {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+
+        let params = Self::parse_msg_params(param, paramlen)?;
+        let outlen = self.msg_decrypt_next(param, paramlen, cipher, plain)?;
+
+        let tag = unsafe { bytes_to_slice(params.pTag, POLY1305_TAG_SIZE) };
+
+        let ctx = match &mut self.ctx {
+            Some(c) => c,
+            None => return Err(self.op_err(CKR_GENERAL_ERROR)),
+        };
+
+        ctx.set_tag(tag).or_else(|_| {
+            self.finalized = true;
+            Err(CKR_DEVICE_ERROR)
+        })?;
+
+        match ctx.finalize(&mut plain[outlen..]) {
+            Ok(len) => {
+                if len != 0 {
+                    self.finalized = true;
+                    return Err(CKR_DEVICE_ERROR)?;
+                }
+            }
+            Err(_) => {
+                self.finalized = true;
+                return Err(CKR_ENCRYPTED_DATA_INVALID)?;
+            }
+        }
+
+        self.in_use = false;
+        Ok(outlen)
+    }
+
+    /// Provides the expected output buffer size. The Poly1305 tag is not
+    /// included -- it comes from `pTag`, not the cipher buffer.
+    fn msg_decryption_len(
+        &mut self,
+        data_len: usize,
+        _fin: bool,
+    ) -> Result<usize> {
+        if self.finalized {
+            return Err(CKR_OPERATION_NOT_INITIALIZED)?;
+        }
+        Ok(data_len)
+    }
+}

--- a/src/ossl/mod.rs
+++ b/src/ossl/mod.rs
@@ -2,6 +2,8 @@
 // See LICENSE.txt file for terms
 
 pub mod aes;
+#[cfg(feature = "chacha20")]
+pub mod chacha20;
 pub mod common;
 pub mod drbg;
 

--- a/src/tests/chacha20.rs
+++ b/src/tests/chacha20.rs
@@ -1,0 +1,606 @@
+// Copyright 2026 Alexandre Laroche
+// See LICENSE.txt file for terms
+
+use crate::tests::*;
+
+use serial_test::parallel;
+
+/// RFC 8439 §2.4.2 test vector: all-zero 256-bit key, all-zero 96-bit
+/// nonce, block counter 0 -- the first block of the ChaCha20 keystream,
+/// observed as ciphertext when XORed with an all-zero plaintext. Reused
+/// from ossl/src/tests/chacha20.rs, which already vets it against the raw
+/// OpenSSL cipher this mechanism is built on.
+#[test]
+#[parallel]
+fn test_chacha20_kat() {
+    let mut testtokn = TestToken::initialized("test_chacha20_kat", None);
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let key = vec![0u8; 32];
+    let block_counter = vec![0u8; 4];
+    let nonce = vec![0u8; 12];
+    let plaintext = vec![0u8; 32];
+    let expected_ciphertext = hex::decode(
+        "76b8e0ada0f13d90405d6ae55386bd28bdd219b8a08ded1aa836efcc8b770dc7",
+    )
+    .unwrap();
+
+    let handle = ret_or_panic!(import_object(
+        session,
+        CKO_SECRET_KEY,
+        &[(CKA_KEY_TYPE, CKK_CHACHA20)],
+        &[(CKA_VALUE, key.as_slice())],
+        &[(CKA_ENCRYPT, true), (CKA_DECRYPT, true)],
+    ));
+
+    let params = CK_CHACHA20_PARAMS {
+        pBlockCounter: block_counter.as_ptr() as *mut CK_BYTE,
+        blockCounterBits: 32,
+        pNonce: nonce.as_ptr() as *mut CK_BYTE,
+        ulNonceBits: 96,
+    };
+    let mechanism = CK_MECHANISM {
+        mechanism: CKM_CHACHA20,
+        pParameter: void_ptr!(&params),
+        ulParameterLen: sizeof!(CK_CHACHA20_PARAMS),
+    };
+
+    let ciphertext =
+        ret_or_panic!(encrypt(session, handle, &plaintext, &mechanism));
+    assert_eq!(ciphertext, expected_ciphertext);
+
+    let recovered =
+        ret_or_panic!(decrypt(session, handle, &ciphertext, &mechanism));
+    assert_eq!(recovered, plaintext);
+
+    testtokn.finalize();
+}
+
+/// Exercises `C_EncryptUpdate`/`C_EncryptFinal` with arbitrary chunk sizes
+/// against the same known-answer vector as [test_chacha20_kat], since
+/// ChaCha20 is a true stream cipher: any split must reassemble to the same
+/// output as a single-shot call.
+#[test]
+#[parallel]
+fn test_chacha20_multipart() {
+    let mut testtokn = TestToken::initialized("test_chacha20_multipart", None);
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let key = vec![0u8; 32];
+    let block_counter = vec![0u8; 4];
+    let nonce = vec![0u8; 12];
+    let plaintext = vec![0u8; 32];
+    let expected_ciphertext = hex::decode(
+        "76b8e0ada0f13d90405d6ae55386bd28bdd219b8a08ded1aa836efcc8b770dc7",
+    )
+    .unwrap();
+
+    let handle = ret_or_panic!(import_object(
+        session,
+        CKO_SECRET_KEY,
+        &[(CKA_KEY_TYPE, CKK_CHACHA20)],
+        &[(CKA_VALUE, key.as_slice())],
+        &[(CKA_ENCRYPT, true)],
+    ));
+
+    let params = CK_CHACHA20_PARAMS {
+        pBlockCounter: block_counter.as_ptr() as *mut CK_BYTE,
+        blockCounterBits: 32,
+        pNonce: nonce.as_ptr() as *mut CK_BYTE,
+        ulNonceBits: 96,
+    };
+    let mut mechanism = CK_MECHANISM {
+        mechanism: CKM_CHACHA20,
+        pParameter: void_ptr!(&params),
+        ulParameterLen: sizeof!(CK_CHACHA20_PARAMS),
+    };
+
+    let ret = fn_encrypt_init(session, &mut mechanism, handle);
+    assert_eq!(ret, CKR_OK);
+
+    let mut ciphertext =
+        ret_or_panic!(encrypt_update(session, &plaintext[..1]));
+    ciphertext.append(&mut ret_or_panic!(encrypt_update(
+        session,
+        &plaintext[1..17]
+    )));
+    ciphertext.append(&mut ret_or_panic!(encrypt_update(
+        session,
+        &plaintext[17..]
+    )));
+    ciphertext.append(&mut ret_or_panic!(encrypt_final(session)));
+
+    assert_eq!(ciphertext, expected_ciphertext);
+
+    testtokn.finalize();
+}
+
+/// RFC 8439 §2.8.2 test vector's key/nonce/AAD, reused from
+/// ossl/src/tests/chacha20.rs (test_chacha20_poly1305), which already vets
+/// the mechanism's full known-answer ciphertext/tag against the raw
+/// OpenSSL cipher this mechanism is built on. This test only checks the
+/// AEAD round-trip and tamper-rejection properties, so a plain ASCII
+/// plaintext is enough -- it does not need to match the RFC's own message
+/// byte-for-byte.
+#[test]
+#[parallel]
+fn test_chacha20_poly1305_kat() {
+    let mut testtokn =
+        TestToken::initialized("test_chacha20_poly1305_kat", None);
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let key = hex::decode(
+        "1c9240a5eb55d38af333888604f6b5f0473917c1402b80099dca5cbc207075c0",
+    )
+    .unwrap();
+    let nonce = hex::decode("000000000102030405060708").unwrap();
+    let aad = hex::decode("f33388860000000000004e91").unwrap();
+    let plaintext = b"ChaCha20-Poly1305 AEAD round trip".to_vec();
+
+    let handle = ret_or_panic!(import_object(
+        session,
+        CKO_SECRET_KEY,
+        &[(CKA_KEY_TYPE, CKK_CHACHA20)],
+        &[(CKA_VALUE, key.as_slice())],
+        &[(CKA_ENCRYPT, true), (CKA_DECRYPT, true)],
+    ));
+
+    let params = CK_SALSA20_CHACHA20_POLY1305_PARAMS {
+        pNonce: nonce.as_ptr() as *mut CK_BYTE,
+        ulNonceLen: nonce.len() as CK_ULONG,
+        pAAD: aad.as_ptr() as *mut CK_BYTE,
+        ulAADLen: aad.len() as CK_ULONG,
+    };
+    let mechanism = CK_MECHANISM {
+        mechanism: CKM_CHACHA20_POLY1305,
+        pParameter: void_ptr!(&params),
+        ulParameterLen: sizeof!(CK_SALSA20_CHACHA20_POLY1305_PARAMS),
+    };
+
+    let ciphertext =
+        ret_or_panic!(encrypt(session, handle, &plaintext, &mechanism));
+    assert_eq!(ciphertext.len(), plaintext.len() + 16);
+
+    let recovered =
+        ret_or_panic!(decrypt(session, handle, &ciphertext, &mechanism));
+    assert_eq!(recovered, plaintext);
+
+    /* A tampered tag must be rejected */
+    let mut tampered = ciphertext.clone();
+    let last = tampered.len() - 1;
+    tampered[last] ^= 0xff;
+    assert!(decrypt(session, handle, &tampered, &mechanism).is_err());
+
+    testtokn.finalize();
+}
+
+/// Exercises `C_EncryptUpdate`/`C_EncryptFinal` and
+/// `C_DecryptUpdate`/`C_DecryptFinal` for ChaCha20-Poly1305, specifically
+/// to cover the tag-tail buffering: the Poly1305 tag is appended to the
+/// end of the ciphertext, so a multi-part decrypt must hold back the last
+/// 16 bytes seen so far until `C_DecryptFinal` proves no more data follows.
+#[test]
+#[parallel]
+fn test_chacha20_poly1305_multipart() {
+    let mut testtokn =
+        TestToken::initialized("test_chacha20_poly1305_multipart", None);
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let key = vec![0x42u8; 32];
+    let nonce = vec![0x24u8; 12];
+    let aad = b"header".to_vec();
+    let plaintext = b"ChaCha20-Poly1305 multi-part round trip test data, \
+                       spanning more than one Poly1305/ChaCha20 block."
+        .to_vec();
+
+    let handle = ret_or_panic!(import_object(
+        session,
+        CKO_SECRET_KEY,
+        &[(CKA_KEY_TYPE, CKK_CHACHA20)],
+        &[(CKA_VALUE, key.as_slice())],
+        &[(CKA_ENCRYPT, true), (CKA_DECRYPT, true)],
+    ));
+
+    let params = CK_SALSA20_CHACHA20_POLY1305_PARAMS {
+        pNonce: nonce.as_ptr() as *mut CK_BYTE,
+        ulNonceLen: nonce.len() as CK_ULONG,
+        pAAD: aad.as_ptr() as *mut CK_BYTE,
+        ulAADLen: aad.len() as CK_ULONG,
+    };
+    let mut mechanism = CK_MECHANISM {
+        mechanism: CKM_CHACHA20_POLY1305,
+        pParameter: void_ptr!(&params),
+        ulParameterLen: sizeof!(CK_SALSA20_CHACHA20_POLY1305_PARAMS),
+    };
+
+    /* One-shot encrypt to get the reference ciphertext||tag */
+    let expected =
+        ret_or_panic!(encrypt(session, handle, &plaintext, &mechanism));
+
+    /* Multi-part encrypt in small, uneven chunks must match it */
+    let ret = fn_encrypt_init(session, &mut mechanism, handle);
+    assert_eq!(ret, CKR_OK);
+    let mut ciphertext = Vec::new();
+    for chunk in plaintext.chunks(7) {
+        ciphertext.append(&mut ret_or_panic!(encrypt_update(session, chunk)));
+    }
+    ciphertext.append(&mut ret_or_panic!(encrypt_final(session)));
+    assert_eq!(ciphertext, expected);
+
+    /* Multi-part decrypt in small, uneven chunks (including chunks smaller
+     * than the 16-byte tag) must recover the plaintext */
+    let ret = fn_decrypt_init(session, &mut mechanism, handle);
+    assert_eq!(ret, CKR_OK);
+    let mut recovered = Vec::new();
+    for chunk in ciphertext.chunks(5) {
+        recovered.append(&mut ret_or_panic!(decrypt_update(session, chunk)));
+    }
+    recovered.append(&mut ret_or_panic!(decrypt_final(session)));
+    assert_eq!(recovered, plaintext);
+
+    testtokn.finalize();
+}
+
+/// `CKM_CHACHA20_KEY_GEN` must always produce a 256-bit key.
+#[test]
+#[parallel]
+fn test_chacha20_key_gen() {
+    let mut testtokn = TestToken::initialized("test_chacha20_key_gen", None);
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let handle = ret_or_panic!(generate_key(
+        session,
+        CKM_CHACHA20_KEY_GEN,
+        std::ptr::null_mut(),
+        0,
+        &[(CKA_VALUE_LEN, 32)],
+        &[],
+        &[(CKA_TOKEN, false), (CKA_ENCRYPT, true), (CKA_DECRYPT, true)],
+    ));
+
+    /* A generated key must be usable, which -- since object_to_raw_key
+     * rejects anything but exactly 32 bytes -- proves it was sized
+     * correctly, without needing to read CKA_VALUE_LEN back directly. */
+    let block_counter = vec![0u8; 4];
+    let nonce = vec![0u8; 12];
+    let params = CK_CHACHA20_PARAMS {
+        pBlockCounter: block_counter.as_ptr() as *mut CK_BYTE,
+        blockCounterBits: 32,
+        pNonce: nonce.as_ptr() as *mut CK_BYTE,
+        ulNonceBits: 96,
+    };
+    let mechanism = CK_MECHANISM {
+        mechanism: CKM_CHACHA20,
+        pParameter: void_ptr!(&params),
+        ulParameterLen: sizeof!(CK_CHACHA20_PARAMS),
+    };
+    let plaintext = b"generated key round trip".to_vec();
+    let ciphertext =
+        ret_or_panic!(encrypt(session, handle, &plaintext, &mechanism));
+    let recovered =
+        ret_or_panic!(decrypt(session, handle, &ciphertext, &mechanism));
+    assert_eq!(recovered, plaintext);
+
+    testtokn.finalize();
+}
+
+/// The alternative, original (64-bit-nonce/64-bit-counter) `CK_CHACHA20_PARAMS`
+/// layout is not implemented (only the IETF/RFC 8439 layout is), and a
+/// wrong-size key must be rejected.
+#[test]
+#[parallel]
+fn test_chacha20_param_validation() {
+    let mut testtokn =
+        TestToken::initialized("test_chacha20_param_validation", None);
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let key = vec![0u8; 32];
+    let handle = ret_or_panic!(import_object(
+        session,
+        CKO_SECRET_KEY,
+        &[(CKA_KEY_TYPE, CKK_CHACHA20)],
+        &[(CKA_VALUE, key.as_slice())],
+        &[(CKA_ENCRYPT, true)],
+    ));
+
+    /* 64-bit counter / 64-bit nonce (the non-IETF layout) is rejected */
+    let block_counter = vec![0u8; 8];
+    let nonce = vec![0u8; 8];
+    let params = CK_CHACHA20_PARAMS {
+        pBlockCounter: block_counter.as_ptr() as *mut CK_BYTE,
+        blockCounterBits: 64,
+        pNonce: nonce.as_ptr() as *mut CK_BYTE,
+        ulNonceBits: 64,
+    };
+    let mut mechanism = CK_MECHANISM {
+        mechanism: CKM_CHACHA20,
+        pParameter: void_ptr!(&params),
+        ulParameterLen: sizeof!(CK_CHACHA20_PARAMS),
+    };
+    let ret = fn_encrypt_init(session, &mut mechanism, handle);
+    assert_eq!(ret, CKR_MECHANISM_PARAM_INVALID);
+
+    /* A wrong-size key is rejected at import time */
+    let short_key = vec![0u8; 16];
+    let ret = import_object(
+        session,
+        CKO_SECRET_KEY,
+        &[(CKA_KEY_TYPE, CKK_CHACHA20)],
+        &[(CKA_VALUE, short_key.as_slice())],
+        &[(CKA_ENCRYPT, true)],
+    );
+    assert!(ret.is_err());
+
+    testtokn.finalize();
+}
+
+/// Message-mode (`C_MessageEncryptInit`/`C_EncryptMessage`/
+/// `C_MessageEncryptFinal` and decrypt counterparts) one-shot round trip,
+/// including the defining feature of message mode: reusing one
+/// initialized session across several independently-nonced messages. Also
+/// checks that the Poly1305 tag lands in the separate `pTag` output, not
+/// appended to the ciphertext (unlike the classic, non-message path).
+#[test]
+#[parallel]
+fn test_chacha20_poly1305_message_mode() {
+    let mut testtokn =
+        TestToken::initialized("test_chacha20_poly1305_message_mode", None);
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let key = vec![0x11u8; 32];
+    let handle = ret_or_panic!(import_object(
+        session,
+        CKO_SECRET_KEY,
+        &[(CKA_KEY_TYPE, CKK_CHACHA20)],
+        &[(CKA_VALUE, key.as_slice())],
+        &[(CKA_ENCRYPT, true), (CKA_DECRYPT, true)],
+    ));
+
+    let mut mechanism = CK_MECHANISM {
+        mechanism: CKM_CHACHA20_POLY1305,
+        pParameter: std::ptr::null_mut(),
+        ulParameterLen: 0,
+    };
+
+    let ret = fn_message_encrypt_init(session, &mut mechanism, handle);
+    assert_eq!(ret, CKR_OK);
+
+    // Encrypt two independent messages under the same initialized
+    // session, each with its own nonce/AAD -- exactly what message mode
+    // exists to make efficient.
+    let messages: [(&[u8], &[u8], &[u8]); 2] = [
+        (
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01",
+            b"aad-one",
+            b"first message",
+        ),
+        (
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02",
+            b"aad-two",
+            b"second, different message",
+        ),
+    ];
+
+    let mut ciphertexts = Vec::new();
+    for (nonce, aad, plaintext) in &messages {
+        let mut tag = [0u8; 16];
+        let mut param = CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS {
+            pNonce: nonce.as_ptr() as *mut CK_BYTE,
+            ulNonceLen: nonce.len() as CK_ULONG,
+            pTag: tag.as_mut_ptr(),
+        };
+        let mut ciphertext = vec![0u8; plaintext.len()];
+        let mut ciphertext_len = ciphertext.len() as CK_ULONG;
+
+        let ret = fn_encrypt_message(
+            session,
+            void_ptr!(&mut param),
+            sizeof!(CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS),
+            aad.as_ptr() as CK_BYTE_PTR,
+            aad.len() as CK_ULONG,
+            plaintext.as_ptr() as *mut CK_BYTE,
+            plaintext.len() as CK_ULONG,
+            ciphertext.as_mut_ptr(),
+            &mut ciphertext_len,
+        );
+        assert_eq!(ret, CKR_OK);
+        assert_eq!(ciphertext_len as usize, plaintext.len());
+        ciphertexts.push((ciphertext, tag));
+    }
+
+    let ret = fn_message_encrypt_final(session);
+    assert_eq!(ret, CKR_OK);
+
+    // Decrypt both back, again reusing one initialized session.
+    let ret = fn_message_decrypt_init(session, &mut mechanism, handle);
+    assert_eq!(ret, CKR_OK);
+
+    for (i, (nonce, aad, plaintext)) in messages.iter().enumerate() {
+        let (ciphertext, mut tag) = ciphertexts[i].clone();
+        let mut param = CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS {
+            pNonce: nonce.as_ptr() as *mut CK_BYTE,
+            ulNonceLen: nonce.len() as CK_ULONG,
+            pTag: tag.as_mut_ptr(),
+        };
+        let mut recovered = vec![0u8; ciphertext.len()];
+        let mut recovered_len = recovered.len() as CK_ULONG;
+
+        let ret = fn_decrypt_message(
+            session,
+            void_ptr!(&mut param),
+            sizeof!(CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS),
+            aad.as_ptr() as CK_BYTE_PTR,
+            aad.len() as CK_ULONG,
+            ciphertext.as_ptr() as *mut CK_BYTE,
+            ciphertext.len() as CK_ULONG,
+            recovered.as_mut_ptr(),
+            &mut recovered_len,
+        );
+        assert_eq!(ret, CKR_OK);
+        assert_eq!(&recovered[..], *plaintext);
+    }
+
+    let ret = fn_message_decrypt_final(session);
+    assert_eq!(ret, CKR_OK);
+
+    testtokn.finalize();
+}
+
+/// Exercises `C_EncryptMessageBegin`/`C_EncryptMessageNext` and their
+/// decrypt counterparts for a single message split into several chunks.
+#[test]
+#[parallel]
+fn test_chacha20_poly1305_message_mode_multipart() {
+    let mut testtokn = TestToken::initialized(
+        "test_chacha20_poly1305_message_mode_multipart",
+        None,
+    );
+    let session = testtokn.get_session(true);
+    testtokn.login();
+
+    let key = vec![0x22u8; 32];
+    let nonce = vec![0x33u8; 12];
+    let aad = b"multipart-aad".to_vec();
+    let plaintext = b"this message is split across several \
+                       C_EncryptMessageNext/C_DecryptMessageNext calls"
+        .to_vec();
+
+    let handle = ret_or_panic!(import_object(
+        session,
+        CKO_SECRET_KEY,
+        &[(CKA_KEY_TYPE, CKK_CHACHA20)],
+        &[(CKA_VALUE, key.as_slice())],
+        &[(CKA_ENCRYPT, true), (CKA_DECRYPT, true)],
+    ));
+
+    let mut mechanism = CK_MECHANISM {
+        mechanism: CKM_CHACHA20_POLY1305,
+        pParameter: std::ptr::null_mut(),
+        ulParameterLen: 0,
+    };
+
+    let ret = fn_message_encrypt_init(session, &mut mechanism, handle);
+    assert_eq!(ret, CKR_OK);
+
+    let mut tag = [0u8; 16];
+    let mut param = CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS {
+        pNonce: nonce.as_ptr() as *mut CK_BYTE,
+        ulNonceLen: nonce.len() as CK_ULONG,
+        pTag: tag.as_mut_ptr(),
+    };
+
+    let ret = fn_encrypt_message_begin(
+        session,
+        void_ptr!(&mut param),
+        sizeof!(CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS),
+        aad.as_ptr() as CK_BYTE_PTR,
+        aad.len() as CK_ULONG,
+    );
+    assert_eq!(ret, CKR_OK);
+
+    let mut ciphertext = Vec::new();
+    for chunk in plaintext.chunks(9) {
+        let mut out = vec![0u8; chunk.len()];
+        let mut out_len = out.len() as CK_ULONG;
+        let ret = fn_encrypt_message_next(
+            session,
+            void_ptr!(&mut param),
+            sizeof!(CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS),
+            chunk.as_ptr() as *mut CK_BYTE,
+            chunk.len() as CK_ULONG,
+            out.as_mut_ptr(),
+            &mut out_len,
+            0,
+        );
+        assert_eq!(ret, CKR_OK);
+        ciphertext.extend_from_slice(&out[..out_len as usize]);
+    }
+    // Final, zero-length chunk with CKF_END_OF_MESSAGE finalizes and
+    // writes the tag into param.pTag. `fixed`-over-empty-span in the C#
+    // wrapper aside, this library itself still requires a real, non-null
+    // pointer even for zero-length data -- only a real pointer with
+    // pul_ciphertext_part_len set to 0 is a genuine, real call (a null
+    // ciphertext_part is instead treated as a length probe).
+    let mut empty_in: [u8; 0] = [];
+    let mut empty_out: [u8; 0] = [];
+    let mut out_len: CK_ULONG = 0;
+    let ret = fn_encrypt_message_next(
+        session,
+        void_ptr!(&mut param),
+        sizeof!(CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS),
+        empty_in.as_mut_ptr(),
+        0,
+        empty_out.as_mut_ptr(),
+        &mut out_len,
+        CKF_END_OF_MESSAGE,
+    );
+    assert_eq!(ret, CKR_OK);
+
+    let ret = fn_message_encrypt_final(session);
+    assert_eq!(ret, CKR_OK);
+    assert_eq!(ciphertext.len(), plaintext.len());
+
+    // Decrypt back, split into different-sized chunks.
+    let ret = fn_message_decrypt_init(session, &mut mechanism, handle);
+    assert_eq!(ret, CKR_OK);
+
+    let mut param = CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS {
+        pNonce: nonce.as_ptr() as *mut CK_BYTE,
+        ulNonceLen: nonce.len() as CK_ULONG,
+        pTag: tag.as_mut_ptr(),
+    };
+    let ret = fn_decrypt_message_begin(
+        session,
+        void_ptr!(&mut param),
+        sizeof!(CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS),
+        aad.as_ptr() as CK_BYTE_PTR,
+        aad.len() as CK_ULONG,
+    );
+    assert_eq!(ret, CKR_OK);
+
+    let mut recovered = Vec::new();
+    for chunk in ciphertext.chunks(13) {
+        let mut out = vec![0u8; chunk.len()];
+        let mut out_len = out.len() as CK_ULONG;
+        let ret = fn_decrypt_message_next(
+            session,
+            void_ptr!(&mut param),
+            sizeof!(CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS),
+            chunk.as_ptr() as *mut CK_BYTE,
+            chunk.len() as CK_ULONG,
+            out.as_mut_ptr(),
+            &mut out_len,
+            0,
+        );
+        assert_eq!(ret, CKR_OK);
+        recovered.extend_from_slice(&out[..out_len as usize]);
+    }
+    let mut empty_in: [u8; 0] = [];
+    let mut empty_out: [u8; 0] = [];
+    let mut out_len: CK_ULONG = 0;
+    let ret = fn_decrypt_message_next(
+        session,
+        void_ptr!(&mut param),
+        sizeof!(CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS),
+        empty_in.as_mut_ptr(),
+        0,
+        empty_out.as_mut_ptr(),
+        &mut out_len,
+        CKF_END_OF_MESSAGE,
+    );
+    assert_eq!(ret, CKR_OK);
+
+    let ret = fn_message_decrypt_final(session);
+    assert_eq!(ret, CKR_OK);
+
+    assert_eq!(recovered, plaintext);
+
+    testtokn.finalize();
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -342,6 +342,9 @@ mod mechs;
 #[cfg(feature = "aes")]
 mod aes;
 
+#[cfg(feature = "chacha20")]
+mod chacha20;
+
 #[cfg(feature = "rsa")]
 mod rsa;
 


### PR DESCRIPTION
## Summary

Adds the two PKCS#11 v3.0 ChaCha20 mechanisms, which previously had no implementation at all: `CKM_CHACHA20`/`CKM_CHACHA20_KEY_GEN`/`CKM_CHACHA20_POLY1305` only appeared in `pkcs11/mod.rs`'s `const_to_elem!` name-lookup table (used for trace/debug output, alongside plenty of other constants this project doesn't implement, e.g. the GOST mechanisms right next to them there) -- no mechanism registration, no dispatch, and no `CKK_CHACHA20` key-object factory existed.

## What already existed

The underlying crypto was already built and working. The shared `ossl` crate (a workspace member of `kryoptic-lib` itself, not just of `rustls/ossl`) has a complete `EncAlg::ChaCha20`/`EncAlg::ChaCha20Poly1305` cipher-context implementation in `ossl/src/cipher.rs`, including the AEAD setup path, with its own test coverage (`ossl/src/tests/chacha20.rs`). It was added for the `rustls/ossl` TLS provider, but has no dependency on TLS and is directly usable from `kryoptic-lib`.

## What this PR adds

- A new `chacha20` Cargo feature (added to `standard`), registered in `enabled.rs`.
- `src/chacha20.rs` -- a `CKK_CHACHA20` key factory (fixed 256-bit key, unlike AES's several selectable sizes) and mechanism registration.
- `src/ossl/chacha20.rs` -- the classic `Encryption`/`Decryption` operation (adapted from `AesOperation`'s CTR/GCM paths), **and** `MsgEncryption`/`MsgDecryption` message-mode support for `CKM_CHACHA20_POLY1305` (`C_MessageEncryptInit`/`C_EncryptMessage`/`C_EncryptMessageNext`/`C_MessageEncryptFinal` and decrypt counterparts).

Message-mode support turned out not to be optional: [pkcs11-provider](https://github.com/latchset/pkcs11-provider) -- the flagship downstream consumer this project's own CI tests against -- doesn't use the classic params path for `CKM_CHACHA20_POLY1305` at all. Its `src/cipher.c` is built entirely around `CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS`, the same message-mode API `CKM_AES_GCM`/`CKM_AES_CCM` already implement here. Testing an earlier, classic-only revision of this PR against pkcs11-provider's own CI confirmed it: the AEAD test failed with `EVP_Encrypt* failed!`, and the TLS test negotiated `ECDHE-ECDSA-CHACHA20-POLY1305` and then failed decryption with `bad record mac`. `CKM_CHACHA20_POLY1305` gets its own mechanism-registry entry with `CKF_MESSAGE_ENCRYPT`/`CKF_MESSAGE_DECRYPT`/`CKF_MULTI_MESSAGE` (mirroring how GCM/CCM get a separate, message-flagged entry from AES's other modes); plain `CKM_CHACHA20` stays classic-only, since message mode has no use case for a non-AEAD stream cipher.

## FIPS

Neither mechanism is added to the `fips` feature bundle -- ChaCha20 and ChaCha20-Poly1305 are not NIST/FIPS-approved algorithms (unlike AES-GCM/CCM). This follows the existing convention for `hotp` (also excluded from `fips` for the same kind of reason): the feature simply isn't listed as a `fips` dependency, no additional `#[cfg(not(feature = "fips"))]` guard needed on top of that, since a FIPS build doesn't combine extra, non-approved features on its own.

## Scope

- Only the IETF/RFC 8439 `CK_CHACHA20_PARAMS` layout (96-bit nonce, 32-bit block counter) is supported for plain `CKM_CHACHA20` -- the spec's alternative, original (64-bit-nonce/64-bit-counter) layout is rejected with `CKR_MECHANISM_PARAM_INVALID`, since OpenSSL's `"ChaCha20"` cipher only implements the IETF layout as a single fixed-width IV.
- Wrap/unwrap, key derivation, and MAC are **not** implemented for either mechanism in this change.

## Testing

`src/tests/chacha20.rs` reuses the RFC 8439 test vectors from `ossl/src/tests/chacha20.rs`, which already vets them against the raw OpenSSL cipher this mechanism is built on:
- ChaCha20 known-answer vector, both one-shot and split across arbitrary `C_EncryptUpdate` chunk sizes.
- ChaCha20-Poly1305 known-answer key/nonce/AAD: round-trip and tamper-rejection, classic and message-mode.
- Multi-part encrypt/decrypt tests for both the classic path (tag-tail buffering in small, uneven chunks) and message mode (`C_EncryptMessageBegin`/`C_EncryptMessageNext`).
- A message-mode test reusing one initialized session across two independently-nonced messages -- the reason message mode exists.
- Key generation and parameter/key-size validation.

Full local suite: 138 `kryoptic-lib` tests pass, 0 failures.

## Known CI failure: pkcs11-provider bug, not this PR's

The `pkcs11-provider` integration job's `aead` and `tls` tests still fail on this PR, but I've root-caused both to the exact same pre-existing bug in `pkcs11-provider` itself, reproduced locally with debug tracing on both sides:

- **`aead` test**: `C_MessageEncryptInit` fails with `CKR_KEY_TYPE_INCONSISTENT`. `pkcs11-provider`'s generic raw-key-import path for ciphers (`p11prov_cipher_legacy_init` in `src/cipher.c`, comment literally says *"importing the AES key"*) hardcodes `CKK_AES` for any cipher under test, including ChaCha20 -- a leftover from when AES was the only cipher family it exercised. Our `ChaChaOperation` correctly requires `CKA_KEY_TYPE == CKK_CHACHA20` per spec, so the mismatched key is rejected.
- **`tls` test**: same root cause, one level removed. The suite runs twice: once with only the server routing crypto through `pkcs11-provider` (that pass fully succeeds, including ChaCha20 -- verified byte-correct against OpenSSL's own default-provider crypto in both directions), and once with `-propquery ?provider=pkcs11` forcing *both* sides through it. Only in that second pass does `pkcs11-provider` also route the TLS traffic-key import through the same hardcoded-`CKK_AES` path used by the `aead` test, so `C_MessageDecryptInit` fails with `CKR_KEY_TYPE_INCONSISTENT` on the very first encrypted record -- surfacing as "bad record mac" rather than a clean init error, but confirmed via debug tracing to be the identical cause. AES suites pass under the same second pass because `CKK_AES` happens to be correct for them.

Loosening our key-type check to accept `CKK_AES` for `CKM_CHACHA20_POLY1305` would paper over this rather than fix it (real type confusion), so I left it as-is. This looks like something to fix on the `pkcs11-provider` side.

Fixes: https://github.com/latchset/kryoptic/issues/504

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
